### PR TITLE
Recognize base host "gravatar.com" as gravatar URL

### DIFF
--- a/Sources/Gravatar/GravatarURL.swift
+++ b/Sources/Gravatar/GravatarURL.swift
@@ -18,19 +18,15 @@ public struct GravatarURL {
     }
 
     public static func isGravatarURL(_ url: URL) -> Bool {
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+        guard 
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            let host = components.host
+        else {
             return false
         }
 
-        guard let host = components.host, host.hasSuffix(".gravatar.com") else {
-                return false
-        }
-
-        guard url.path.hasPrefix("/avatar/") else {
-                return false
-        }
-
-        return true
+        return (host.hasSuffix(".gravatar.com") || host == "gravatar.com")
+            && components.path.hasPrefix("/avatar/")
     }
 
     /// Returns the Gravatar URL, for a given email, with the specified size + rating.

--- a/Tests/Gravatar/GravatarURLTests.swift
+++ b/Tests/Gravatar/GravatarURLTests.swift
@@ -9,15 +9,15 @@ import XCTest
 @testable import Gravatar
 
 final class GravatarURLTests: XCTestCase {
-
-    // TODO: This should work without `www.`, but currently the tests would break.
     let verifiedGravatarURL = URL(string: "https://0.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50")!
+    let verifiedGravatarURL2 = URL(string: "https://gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50")!
 
     let exampleEmail = "some@email.com"
     let exampleEmailSHA = "676212ff796c79a3c06261eb10e3f455aa93998ee6e45263da13679c74b1e674"
 
     func testIsGravatarUrl() throws {
         XCTAssertTrue(GravatarURL.isGravatarURL(verifiedGravatarURL))
+        XCTAssertTrue(GravatarURL.isGravatarURL(verifiedGravatarURL2))
         XCTAssertFalse(GravatarURL.isGravatarURL(URL(string: "https://wordpress.com/")!))
     }
 


### PR DESCRIPTION
This PR fixes an issue where urls like `https://gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50` were no recognized as a Gravatar URL.

cc @pinarol 
