### PR TITLE
Refactor Demo project to embed the package instead of using it as a local package

### DIFF
--- a/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4948C4EC2B61C41100AC4875 /* Gravatar in Frameworks */ = {isa = PBXBuildFile; productRef = 4948C4EB2B61C41100AC4875 /* Gravatar */; };
+		4948C4EE2B61C41800AC4875 /* Gravatar in Frameworks */ = {isa = PBXBuildFile; productRef = 4948C4ED2B61C41800AC4875 /* Gravatar */; };
 		495775E22B5B34970082812A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495775E12B5B34970082812A /* AppDelegate.swift */; };
 		495775E42B5B34970082812A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495775E32B5B34970082812A /* SceneDelegate.swift */; };
 		495775E62B5B34970082812A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495775E52B5B34970082812A /* ViewController.swift */; };
@@ -20,6 +22,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4948C4E92B61C3FD00AC4875 /* Gravatar-SDK-iOS */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "Gravatar-SDK-iOS"; path = ..; sourceTree = "<group>"; };
 		495775DF2B5B34970082812A /* Gravatar-Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Gravatar-Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		495775E12B5B34970082812A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		495775E32B5B34970082812A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -40,6 +43,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4948C4EC2B61C41100AC4875 /* Gravatar in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -47,12 +51,20 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4948C4EE2B61C41800AC4875 /* Gravatar in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4948C4EA2B61C41100AC4875 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		495775DA2B5B34220082812A /* Gravatar-SwiftUI-Demo */ = {
 			isa = PBXGroup;
 			children = (
@@ -82,7 +94,9 @@
 			isa = PBXGroup;
 			children = (
 				49C5D60C2B5B33E20067C2A8 /* Demo */,
+				4948C4E92B61C3FD00AC4875 /* Gravatar-SDK-iOS */,
 				49C5D60B2B5B33E20067C2A8 /* Products */,
+				4948C4EA2B61C41100AC4875 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -129,6 +143,7 @@
 			);
 			name = "Gravatar-Demo";
 			packageProductDependencies = (
+				4948C4EB2B61C41100AC4875 /* Gravatar */,
 			);
 			productName = "Gravatar-Demo";
 			productReference = 495775DF2B5B34970082812A /* Gravatar-Demo.app */;
@@ -148,6 +163,7 @@
 			);
 			name = "Gravatar-SwiftUI-Demo";
 			packageProductDependencies = (
+				4948C4ED2B61C41800AC4875 /* Gravatar */,
 			);
 			productName = Demo;
 			productReference = 49C5D60A2B5B33E20067C2A8 /* Gravatar-SwiftUI-Demo.app */;
@@ -516,6 +532,17 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		4948C4EB2B61C41100AC4875 /* Gravatar */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Gravatar;
+		};
+		4948C4ED2B61C41800AC4875 /* Gravatar */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Gravatar;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 49C5D6022B5B33E20067C2A8 /* Project object */;
 }

--- a/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -13,8 +13,6 @@
 		495775E92B5B34970082812A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 495775E72B5B34970082812A /* Main.storyboard */; };
 		495775EB2B5B34980082812A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 495775EA2B5B34980082812A /* Assets.xcassets */; };
 		495775EE2B5B34980082812A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 495775EC2B5B34980082812A /* LaunchScreen.storyboard */; };
-		495775F52B5B35460082812A /* Gravatar in Frameworks */ = {isa = PBXBuildFile; productRef = 495775F42B5B35460082812A /* Gravatar */; };
-		495775F72B5B35540082812A /* Gravatar in Frameworks */ = {isa = PBXBuildFile; productRef = 495775F62B5B35540082812A /* Gravatar */; };
 		49C5D60E2B5B33E20067C2A8 /* DemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C5D60D2B5B33E20067C2A8 /* DemoApp.swift */; };
 		49C5D6102B5B33E20067C2A8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C5D60F2B5B33E20067C2A8 /* ContentView.swift */; };
 		49C5D6122B5B33E20067C2A8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 49C5D6112B5B33E20067C2A8 /* Assets.xcassets */; };
@@ -42,7 +40,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				495775F52B5B35460082812A /* Gravatar in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -50,7 +47,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				495775F72B5B35540082812A /* Gravatar in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -133,7 +129,6 @@
 			);
 			name = "Gravatar-Demo";
 			packageProductDependencies = (
-				495775F42B5B35460082812A /* Gravatar */,
 			);
 			productName = "Gravatar-Demo";
 			productReference = 495775DF2B5B34970082812A /* Gravatar-Demo.app */;
@@ -153,7 +148,6 @@
 			);
 			name = "Gravatar-SwiftUI-Demo";
 			packageProductDependencies = (
-				495775F62B5B35540082812A /* Gravatar */,
 			);
 			productName = Demo;
 			productReference = 49C5D60A2B5B33E20067C2A8 /* Gravatar-SwiftUI-Demo.app */;
@@ -187,7 +181,6 @@
 			);
 			mainGroup = 49C5D6012B5B33E20067C2A8;
 			packageReferences = (
-				495775F32B5B35460082812A /* XCLocalSwiftPackageReference ".." */,
 			);
 			productRefGroup = 49C5D60B2B5B33E20067C2A8 /* Products */;
 			projectDirPath = "";
@@ -523,24 +516,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCLocalSwiftPackageReference section */
-		495775F32B5B35460082812A /* XCLocalSwiftPackageReference ".." */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ..;
-		};
-/* End XCLocalSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		495775F42B5B35460082812A /* Gravatar */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Gravatar;
-		};
-		495775F62B5B35540082812A /* Gravatar */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Gravatar;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 49C5D6022B5B33E20067C2A8 /* Project object */;
 }


### PR DESCRIPTION
## What this does

Attempting to make this project dependent on a local package presents some problems:
- New source files in the package aren't available without closing/opening the project
- Source files in the package cannot be deleted from within the project

This may be because Local Packages are meant to override existing Package dependencies, instead of existing as first-class citizens.

We are exploring Apple's recommended approach, which is to add the package as a regular dependency, and then add the local package (which would override the dependency for local development).  We've run into errors.

So while we explore that, this PR makes an adjustment that should work:
- Removes the local package
- Adds the package to the project
- Adds the "product" of the package (the Gravatar library) to each of the targets (which embeds it in the target and links it)

## Testing

- [ ] Open the Demo project, add a new source file (and a new type) to the Package `Sources > Gravatar`, and confirm that you can reference that new type from the Demo app
- [ ] Confirm that you can build you changes
- [ ] Confirm that you can delete files from the Package in Xcode