### PR TITLE
Make canonical URL public

### DIFF
--- a/Sources/Gravatar/GravatarURL.swift
+++ b/Sources/Gravatar/GravatarURL.swift
@@ -9,7 +9,7 @@ public struct GravatarURL {
         static let imageSize = 80
     }
 
-    let canonicalURL: URL
+    public let canonicalURL: URL
 
     public func url(with options: GravatarImageDownloadOptions) -> URL {
         // TODO: Find a way to remove explicit unwrap.


### PR DESCRIPTION
Makes canonicalURL public because it's used from WP side. It's what they store in core data. 