### PR TITLE
Break up GravatarURL

### DIFF
--- a/Sources/Gravatar/GravatarURL.swift
+++ b/Sources/Gravatar/GravatarURL.swift
@@ -18,7 +18,7 @@ public struct GravatarURL {
         guard let url = canonicalURL.addQueryItems(from: options) else {
             fatalError("Internal error: invalid url with query items")
         }
-        
+
         return url
     }
 
@@ -109,11 +109,11 @@ extension URL {
             return nil
         }
         components.queryItems = options.queryItems()
-        
+
         if components.queryItems?.isEmpty == true {
             components.queryItems = nil
         }
-        
+
         return components.url
     }
 }
@@ -125,59 +125,57 @@ private enum ImageDownloadOptionQueryName: String, CaseIterable {
     case forceDefaultImage = "f"
 }
 
-private extension GravatarImageDownloadOptions {
-    func queryItems() -> [URLQueryItem] {
-        return ImageDownloadOptionQueryName.allCases
+extension GravatarImageDownloadOptions {
+    fileprivate func queryItems() -> [URLQueryItem] {
+        ImageDownloadOptionQueryName.allCases
             .map { self.queryItem(for: $0) }
             .filter { $0.value != nil }
     }
-    
-    func queryItem(for queryName: ImageDownloadOptionQueryName) -> URLQueryItem {
-        let value: String?
-        
-        switch queryName {
+
+    private func queryItem(for queryName: ImageDownloadOptionQueryName) -> URLQueryItem {
+        let value: String? = switch queryName {
         case .defaultImage:
-            value = self.defaultImage.queryValue()
+            self.defaultImage.queryValue()
         case .forceDefaultImage:
-            value = self.forceDefaultImage.queryValue()
+            self.forceDefaultImage.queryValue()
         case .gravatarRating:
-            value = self.gravatarRating.queryValue()
+            self.gravatarRating.queryValue()
         case .preferredPixelSize:
-            value = self.preferredPixelSize.queryValue()
+            self.preferredPixelSize.queryValue()
         }
-        
+
         return URLQueryItem(name: queryName.rawValue, value: value)
     }
 }
 
-private extension DefaultImageOption? {
-    func queryValue() -> String? {
-        guard let self = self else { return nil }
-        
+extension DefaultImageOption? {
+    fileprivate func queryValue() -> String? {
+        guard let self else { return nil }
+
         return self.rawValue
     }
 }
 
-private extension GravatarRating? {
-    func queryValue() -> String? {
-        guard let self = self else { return nil }
-        
+extension GravatarRating? {
+    fileprivate func queryValue() -> String? {
+        guard let self else { return nil }
+
         return self.stringValue()
     }
 }
 
-private extension Int? {
-    func queryValue() -> String? {
-        guard let self = self else { return nil }
-        
+extension Int? {
+    fileprivate func queryValue() -> String? {
+        guard let self else { return nil }
+
         return String(self)
     }
 }
 
-private extension Bool? {
-    func queryValue() -> String? {
-        guard let self = self else { return nil }
-        
+extension Bool? {
+    fileprivate func queryValue() -> String? {
+        guard let self else { return nil }
+
         switch self {
         case true:
             return "y"

--- a/Sources/Gravatar/Options/GravatarOptions.swift
+++ b/Sources/Gravatar/Options/GravatarOptions.swift
@@ -76,7 +76,7 @@ public struct GravatarImageDownloadOptions {
 
     private let preferredSize: ImageSize?
     private let scaleFactor: CGFloat
-    
+
     /// GravatarImageDownloadOptions initializer
     /// - Parameters:
     ///   - preferredSize: preferred image size (set to `nil` for default size)

--- a/Tests/GravatarTests/GravatarURLTests.swift
+++ b/Tests/GravatarTests/GravatarURLTests.swift
@@ -63,7 +63,7 @@ final class GravatarURLTests: XCTestCase {
         XCTAssertEqual(url?.url(with: options).query, nil)
         XCTAssertEqual(url?.url(with: options.updating(forceDefaultImage: true)).query, "f=y")
     }
-    
+
     func testUrlWithForceImageDefaultFalse() {
         let url = GravatarURL(verifiedGravatarURL)
         XCTAssertNotNil(url)


### PR DESCRIPTION
## What this does

I broke up the logic in the `addQueryItems(:)` function so that the business logic is contained within `GravatarImageDownloadOptions`.

@etoledom I also took a look at removing the explicit unwrap.  Your logic seems very good to me.  This is never going to be nil.  Since that's the case, I think we need to crash if we're wrong.  For now, I changed this to a `fatalError()` with a message.  But eventually I'd imagine we'd want better logging.

## Testing

- [ ] CI should be green