### PR TITLE
Rename `GravatarImageProcessor` to `ImageProcessor`

### DIFF
--- a/Sources/Gravatar/Network/Services/ImageService.swift
+++ b/Sources/Gravatar/Network/Services/ImageService.swift
@@ -31,7 +31,7 @@ public struct ImageService: ImageServing {
     public func fetchImage(
         with url: URL,
         forceRefresh: Bool = false,
-        processor: GravatarImageProcessor = DefaultImageProcessor.common,
+        processor: ImageProcessor = DefaultImageProcessor.common,
         completionHandler: ImageDownloadCompletion?
     ) -> CancellableDataTask? {
         Task {
@@ -64,7 +64,7 @@ public struct ImageService: ImageServing {
     public func fetchImage(
         with url: URL,
         forceRefresh: Bool = false,
-        processor: GravatarImageProcessor = DefaultImageProcessor.common
+        processor: ImageProcessor = DefaultImageProcessor.common
     ) async throws -> GravatarImageDownloadResult {
         if !forceRefresh, let result = cachedImageResult(for: url) {
             return result
@@ -72,7 +72,7 @@ public struct ImageService: ImageServing {
         return try await fetchImage(from: url, imageProcressor: processor)
     }
 
-    private func fetchImage(from url: URL, imageProcressor: GravatarImageProcessor) async throws -> GravatarImageDownloadResult {
+    private func fetchImage(from url: URL, imageProcressor: ImageProcessor) async throws -> GravatarImageDownloadResult {
         let request = URLRequest.imageRequest(url: url)
         let (data, response) = try await client.fetchData(with: request)
 

--- a/Sources/Gravatar/Network/Services/ImageServing.swift
+++ b/Sources/Gravatar/Network/Services/ImageServing.swift
@@ -12,7 +12,7 @@ public protocol ImageServing {
     func fetchImage(
         with url: URL,
         forceRefresh: Bool,
-        processor: GravatarImageProcessor,
+        processor: ImageProcessor,
         completionHandler: ImageDownloadCompletion?
     ) -> CancellableDataTask?
 
@@ -24,6 +24,6 @@ public protocol ImageServing {
     func fetchImage(
         with url: URL,
         forceRefresh: Bool,
-        processor: GravatarImageProcessor
+        processor: ImageProcessor
     ) async throws -> GravatarImageDownloadResult
 }

--- a/Sources/Gravatar/Options/GravatarOptions.swift
+++ b/Sources/Gravatar/Options/GravatarOptions.swift
@@ -14,7 +14,7 @@ public enum GravatarImageSettingOption {
     
     // Processor to run on the the downloaded data while converting it into an image.
     // If not set `DefaultImageProcessor.common` will be used.
-    case processor(GravatarImageProcessor)
+    case processor(ImageProcessor)
     
     // By setting this you can pass a cache of your preference to save the downloaded image. Default: GravatarImageCache.shared
     case imageCache(GravatarImageCaching)
@@ -28,7 +28,7 @@ public struct GravatarImageSettingOptions {
     var transition: GravatarImageTransition = .none
     var removeCurrentImageWhileLoading = false
     var forceRefresh = false
-    var processor: GravatarImageProcessor = DefaultImageProcessor.common
+    var processor: ImageProcessor = DefaultImageProcessor.common
     var imageCache: GravatarImageCaching = GravatarImageCache.shared
     var imageDownloader: ImageServing? = nil
 
@@ -68,7 +68,7 @@ public struct GravatarImageDownloadOptions {
     let forceRefresh: Bool
     let forceDefaultImage: Bool
     let defaultImage: DefaultImageOption?
-    let processor: GravatarImageProcessor
+    let processor: ImageProcessor
     let preferredPixelSize: Int?
 
     private let preferredSize: ImageSize?
@@ -80,7 +80,7 @@ public struct GravatarImageDownloadOptions {
         forceRefresh: Bool = false,
         forceDefaultImage: Bool = false,
         defaultImage: DefaultImageOption? = nil,
-        processor: GravatarImageProcessor = DefaultImageProcessor.common
+        processor: ImageProcessor = DefaultImageProcessor.common
     ) {
         self.init(
             scaleFactor: UIScreen.main.scale,
@@ -100,7 +100,7 @@ public struct GravatarImageDownloadOptions {
         forceRefresh: Bool = false,
         forceDefaultImage: Bool = false,
         defaultImage: DefaultImageOption? = nil,
-        processor: GravatarImageProcessor = DefaultImageProcessor.common
+        processor: ImageProcessor = DefaultImageProcessor.common
     ) {
         self.gravatarRating = gravatarRating
         self.forceRefresh = forceRefresh
@@ -127,7 +127,7 @@ public struct GravatarImageDownloadOptions {
         forceRefresh: Bool? = nil,
         forceDefaultImage: Bool? = nil,
         defaultImage: DefaultImageOption? = nil,
-        processor: GravatarImageProcessor? = nil
+        processor: ImageProcessor? = nil
     ) -> Self {
         GravatarImageDownloadOptions(
             scaleFactor: scaleFactor ?? self.scaleFactor,

--- a/Sources/Gravatar/UIImage/Processor/DefaultImageProcessor.swift
+++ b/Sources/Gravatar/UIImage/Processor/DefaultImageProcessor.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// The default processor. It applies the scale factor on the given image data and converts it into an image.
-public struct DefaultImageProcessor: GravatarImageProcessor {
+public struct DefaultImageProcessor: ImageProcessor {
     
     public static let common = DefaultImageProcessor(scaleFactor: UIScreen.main.scale)
 

--- a/Sources/Gravatar/UIImage/Processor/ImageProcessor.swift
+++ b/Sources/Gravatar/UIImage/Processor/ImageProcessor.swift
@@ -2,6 +2,6 @@ import Foundation
 import UIKit
 
 /// Processor to apply to the downloaded image data. 
-public protocol GravatarImageProcessor {
+public protocol ImageProcessor {
     func process(_ data: Data) -> UIImage?
 }

--- a/Tests/GravatarTests/GravatarOptionsTests.swift
+++ b/Tests/GravatarTests/GravatarOptionsTests.swift
@@ -39,7 +39,7 @@ final class GravatarOptionsTests: XCTestCase {
     }
 }
 
-class TestImageProcessor: GravatarImageProcessor {
+class TestImageProcessor: ImageProcessor {
     var processedData = false
     func process(_ data: Data) -> UIImage? {
         processedData = true

--- a/Tests/GravatarTests/TestImageRetriever.swift
+++ b/Tests/GravatarTests/TestImageRetriever.swift
@@ -16,7 +16,7 @@ class TestImageRetriever: ImageServing {
         self.result = result
     }
     
-    func fetchImage(with url: URL, forceRefresh: Bool, processor: Gravatar.GravatarImageProcessor, completionHandler: Gravatar.ImageDownloadCompletion?) -> Gravatar.CancellableDataTask? {
+    func fetchImage(with url: URL, forceRefresh: Bool, processor: Gravatar.ImageProcessor, completionHandler: Gravatar.ImageDownloadCompletion?) -> Gravatar.CancellableDataTask? {
         completionQueue.append((url.absoluteString, completionHandler))
         taskIdentifier += 1
         return TestDataTask(taskIdentifier: taskIdentifier)
@@ -28,7 +28,7 @@ class TestImageRetriever: ImageServing {
         return TestDataTask(taskIdentifier: taskIdentifier)
     }
 
-    func fetchImage(with url: URL, forceRefresh: Bool, processor: Gravatar.GravatarImageProcessor) async throws -> Gravatar.GravatarImageDownloadResult {
+    func fetchImage(with url: URL, forceRefresh: Bool, processor: Gravatar.ImageProcessor) async throws -> Gravatar.GravatarImageDownloadResult {
         fatalError("Not Implemented")
     }
 


### PR DESCRIPTION
## What this does

This just removes `Gravatar` from `GravatarImageProcessor:
- `GravatarImageProcessor ` --> `ImageProcessor `

Closes #51 

## Testing

- [ ] CI should be green
- [ ] Demo app smoke testing