### PR TITLE
Refactor SHA256

### DIFF
--- a/Sources/Gravatar/Extensions/String+SHA256.swift
+++ b/Sources/Gravatar/Extensions/String+SHA256.swift
@@ -6,18 +6,11 @@
 //
 
 import CryptoKit
-
-enum StringError: Error {
-    case dataConvertionError
-}
+import Foundation
 
 extension String {
-    func sha256() throws -> String {
-        guard let data = self.data(using: .utf8) else {
-            throw StringError.dataConvertionError
-        }
-
-        let hashed = SHA256.hash(data: data)
+    func sha256() -> String {
+        let hashed = SHA256.hash(data: Data(self.utf8))
         let hashString = hashed.compactMap { String(format: "%02x", $0) }.joined()
         return hashString
     }

--- a/Sources/Gravatar/GravatarURL.swift
+++ b/Sources/Gravatar/GravatarURL.swift
@@ -61,10 +61,10 @@ public struct GravatarURL {
     /// This really ought to be in a different place, like Gravatar.swift, but there's
     /// lots of duplication around gravatars -nh
     private static func gravatarHash(of email: String) -> String {
-        return (try? email
+        return email
             .lowercased()
             .trimmingCharacters(in: .whitespaces)
-            .sha256()) ?? ""
+            .sha256()
     }
 }
 

--- a/Sources/Gravatar/Network/Services/ProfileService.swift
+++ b/Sources/Gravatar/Network/Services/ProfileService.swift
@@ -21,7 +21,7 @@ public struct ProfileService {
     }
 
     public func fetchProfile(for email: String) async throws -> GravatarProfile {
-        let path = try email.sha256() + ".json"
+        let path = email.sha256() + ".json"
         let result: FetchProfileResponse = try await client.fetchObject(from: path)
         let profile = result.entry[0]
         return GravatarProfile(with: profile)


### PR DESCRIPTION
## What this does

After trying everything I could to cause the `.data(using: .utf8)` to return `nil`, I went digging and discovered this:
https://forums.swift.org/t/can-encoding-string-to-data-with-utf8-fail/22437/4

It seems there are no longer any circumstances under which `nil` will be returned.  And even better, we can call `Data(self.utf8)` on the string to get a non-optional `Data`.

Closes #65 

## Testing

- [ ] CI should be green