### PR TITLE
First version of CONTRIBUTING.md and CODE-OF-CONDUCT.md

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,28 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by emailing a project maintainer via support@gravatar.com, with a subject that includes `Code of Conduct`. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# How to Contribute
+
+First off, thank you for contributing! We're excited to collaborate with you! 🎉
+
+The following is a set of guidelines for the many ways you can join our collective effort.
+
+Before anything else, please take a moment to read our [Code of Conduct](CODE-OF-CONDUCT.md). We expect all participants, from full-timers to occasional tinkerers, to uphold it.
+
+## Security
+
+If you happen to find a security vulnerability, we would appreciate you letting us know at https://hackerone.com/automattic and allowing us to respond before disclosing the issue publicly.
+
+## Reporting Bugs, Asking Questions, and Suggesting Features
+
+Have a suggestion or feedback? Please go to [Issues](https://github.com/Automattic/Gravatar-SDK-iOS/issues) and [open a new issue](https://github.com/Automattic/Gravatar-SDK-iOS/issues/new). Prefix the title with a category like _"Bug:"_, _"Question:"_, or _"Feature Request:"_. Screenshots help us resolve issues and answer questions faster, so thanks for including some if you can.
+
+Before you ask a question, it is best to search for existing [Issues](https://github.com/Automattic/Gravatar-SDK-iOS/issues) that might help you. In case you find a suitable issue, you can ask your question by adding a comment there.
+
+Similarly, before reporting a bug, check if there is not already a bug report existing for your case.
+
+## Submitting Code Changes
+
+If you're just getting started and want to familiarize yourself with the app’s code, we suggest looking at [these issues](https://github.com/Automattic/Gravatar-SDK-iOS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) with the **good first issue** label. But if you’d like to tackle something different, you're more than welcome to visit the [Issues](https://github.com/Automattic/Gravatar-SDK-iOS/issues) page and pick an item that interests you.
+
+We always try to avoid duplicating efforts.  If you decide to work on an issue, leave a comment to state your intent. If you choose to focus on a new feature, or the change you’re proposing is significant, we recommend waiting for a response before proceeding. The issue may no longer align with project goals.
+
+If the change is trivial, feel free to send a pull request without notifying us.
+
+### Pull Requests and Code Reviews
+
+All code contributions pass through pull requests. If you haven't created a pull request before, we recommend this free video series, [How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github). 
+
+The core team monitors and reviews all pull requests. Depending on the changes, we will either approve them or close them with an explanation. We might also work with you to improve a pull request before approval.
+
+Note: If you are part of the org, and have the necessary permissions for the repo, please add yourself to the PR as an `assignee`, and add the appropriate GitHub label(s) and Milestone.
+
+### PR merge policy
+
+* PRs require one reviewer to approve the PR before it can be merged to the base branch
+* We keep the PR git history when merging (merge via "merge commit")
+* The reviewer who approved the PR will merge it right after approval (without waiting for the PR author) if all checks are green.
+
+### Development Practices
+
+Have look at the [Coding Style](README.md#coding-style) guide to learn how to format your code so it passes the convention and quality checks like the rest of the project.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ pod 'Gravatar'
 
 Gravatar
 
+## Coding Style
+
+## Contributing
+
+Read our [Contributing Guide](CONTRIBUTING.md) to learn about reporting issues, contributing code, and more ways to contribute.
+
 ## License
 
 Gravatar-SDK-iOS is an open source project covered by the [Mozilla Public License Version 2.0](LICENSE.md).


### PR DESCRIPTION
As part of the public release, we need to add the first version of the documentation about how to contribute and the code of conduct.

We've discussed the content of these files on the Android PR: https://github.com/Automattic/Gravatar-SDK-Android/pull/62 

Links have been updated to point to the iOS repository.

cc: @etoledom @pinarol @andrewdmontgomery 