### PR TITLE
Move pixels conversion into ImageSize extension

### DIFF
--- a/Sources/Gravatar/Options/ImageQueryOptions.swift
+++ b/Sources/Gravatar/Options/ImageQueryOptions.swift
@@ -45,15 +45,7 @@ public struct ImageQueryOptions {
         self.rating = rating
         self.forceDefaultImage = forceDefaultImage
         self.defaultImage = defaultImage
-
-        switch preferredSize {
-        case .pixels(let pixels):
-            preferredPixelSize = pixels
-        case .points(let points):
-            preferredPixelSize = Int(points * scaleFactor)
-        case .none:
-            preferredPixelSize = nil
-        }
+        self.preferredPixelSize = preferredSize?.pixels(scaleFactor: scaleFactor)
     }
 }
 

--- a/Sources/Gravatar/Options/ImageSize.swift
+++ b/Sources/Gravatar/Options/ImageSize.swift
@@ -13,3 +13,14 @@ public enum ImageSize {
     /// The returned image's size in pixels will be of the exact value passed here.
     case pixels(Int)
 }
+
+extension ImageSize {
+    func pixels(scaleFactor: CGFloat) -> Int {
+        switch self {
+        case .pixels(let pixels):
+            pixels
+        case .points(let points):
+            Int(points * scaleFactor)
+        }
+    }
+}


### PR DESCRIPTION
## What this does

This just encapsulates the `points --> pixels` conversion logic of an `ImageSize into an extension of the type.

## Testing

- [ ] CI should be clean