### PR TITLE
Rename defaultImage as defaultImageOption

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoAvatarDownloadViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoAvatarDownloadViewController.swift
@@ -51,7 +51,7 @@ class DemoAvatarDownloadViewController: UIViewController {
     private lazy var imageDefaultButton: UIButton = {
         let button = UIButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle("Default Image: (Backend driven)", for: .normal)
+        button.setTitle("Default Image Option: (Backend driven)", for: .normal)
         button.addTarget(self, action: #selector(selectImageDefault), for: .touchUpInside)
         return button
     }()
@@ -129,12 +129,12 @@ class DemoAvatarDownloadViewController: UIViewController {
     private var preferredDefaultImage: DefaultImageOption? = nil
 
     @objc private func selectImageDefault() {
-        let controller = UIAlertController(title: "Default Image", message: nil, preferredStyle: .actionSheet)
+        let controller = UIAlertController(title: "Default Image Option", message: nil, preferredStyle: .actionSheet)
 
         DefaultImageOption.allCases.forEach { option in
             controller.addAction(UIAlertAction(title: "\(option)", style: .default) { [weak self] action in
                 self?.preferredDefaultImage = option
-                self?.imageDefaultButton.setTitle("Default Image: \(option)", for: .normal)
+                self?.imageDefaultButton.setTitle("Default Image Option: \(option)", for: .normal)
             })
         }
 
@@ -150,7 +150,7 @@ class DemoAvatarDownloadViewController: UIViewController {
             rating: preferredRating,
             forceRefresh: igonreCacheSwitchWithLabel.isOn,
             forceDefaultImage: forceDefaultImageSwitchWithLabel.isOn,
-            defaultImage: preferredDefaultImage
+            defaultImageOption: preferredDefaultImage
         )
 
         avatarImageView.image = nil // Setting to nil to make the effect of `forceRefresh more visible

--- a/Demo/Demo/Gravatar-Demo/DemoUIImageViewExtensionViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoUIImageViewExtensionViewController.swift
@@ -141,7 +141,7 @@ class DemoUIImageViewExtensionViewController: UIViewController {
         let placeholderImage: UIImage? = showPlaceholderSwitchWithLabel.isOn ? UIImage(named: "placeholder") : nil
         avatarImageView.gravatar.setImage(email: emailInputField.text ?? "",
                                           placeholder: placeholderImage,
-                                          defaultImage: preferredDefaultImage,
+                                          defaultImageOption: preferredDefaultImage,
                                           options: options) { result in
             switch result {
             case .success(let result):

--- a/Sources/Gravatar/GravatarCompatibleUI/UIImageView+Gravatar.swift
+++ b/Sources/Gravatar/GravatarCompatibleUI/UIImageView+Gravatar.swift
@@ -147,7 +147,7 @@ extension GravatarWrapper where Component: UIImageView {
         placeholder: UIImage? = nil,
         rating: ImageRating? = nil,
         preferredSize: CGSize? = nil,
-        defaultImage: DefaultImageOption? = nil,
+        defaultImageOption: DefaultImageOption? = nil,
         options: [GravatarImageSettingOption]? = nil,
         completionHandler: GravatarImageSetCompletion? = nil
     ) -> CancellableDataTask? {
@@ -155,7 +155,7 @@ extension GravatarWrapper where Component: UIImageView {
         let downloadOptions = GravatarImageSettingOptions(options: options).deriveDownloadOptions(
             garavatarRating: rating,
             preferredSize: pointsSize,
-            defaultImage: defaultImage
+            defaultImageOption: defaultImageOption
         )
 
         let gravatarURL = GravatarURL.gravatarUrl(with: email, options: downloadOptions.imageQueryOptions)

--- a/Sources/Gravatar/Options/GravatarOptions.swift
+++ b/Sources/Gravatar/Options/GravatarOptions.swift
@@ -58,13 +58,13 @@ public struct GravatarImageSettingOptions {
     func deriveDownloadOptions(
         garavatarRating rating: ImageRating? = nil,
         preferredSize size: ImageSize? = nil,
-        defaultImage: DefaultImageOption? = nil
+        defaultImageOption: DefaultImageOption? = nil
     ) -> GravatarImageDownloadOptions {
         GravatarImageDownloadOptions(
             preferredSize: size,
             rating: rating,
             forceRefresh: forceRefresh,
-            defaultImage: defaultImage,
+            defaultImageOption: defaultImageOption,
             processingMethod: processingMethod
         )
     }
@@ -84,14 +84,14 @@ public struct GravatarImageDownloadOptions {
     ///   - gravatarRating: maximum rating for image (set to `nil` for default rating)
     ///   - forceRefresh: force the image to be downloaded, ignoring the cache
     ///   - forceDefaultImage: force the default image to be used (set to `nil` for default value)
-    ///   - defaultImage: configure the default image (set to `nil` to use the default default image)
+    ///   - defaultImageOption: configure the default image (set to `nil` to use the default default image)
     ///   - processor: processor for handling the downloaded `Data`
     public init(
         preferredSize: ImageSize? = nil,
         rating: ImageRating? = nil,
         forceRefresh: Bool = false,
         forceDefaultImage: Bool? = nil,
-        defaultImage: DefaultImageOption? = nil,
+        defaultImageOption: DefaultImageOption? = nil,
         processingMethod: ImageProcessingMethod = .common
     ) {
         self.forceRefresh = forceRefresh
@@ -101,7 +101,7 @@ public struct GravatarImageDownloadOptions {
         self.imageQueryOptions = ImageQueryOptions(
             preferredSize: preferredSize,
             rating: rating,
-            defaultImage: defaultImage,
+            defaultImageOption: defaultImageOption,
             forceDefaultImage: forceDefaultImage
         )
     }

--- a/Sources/Gravatar/Options/ImageQueryOptions.swift
+++ b/Sources/Gravatar/Options/ImageQueryOptions.swift
@@ -7,7 +7,7 @@ import UIKit
 public struct ImageQueryOptions {
     let rating: ImageRating?
     let forceDefaultImage: Bool?
-    let defaultImage: DefaultImageOption?
+    let defaultImageOption: DefaultImageOption?
     let preferredPixelSize: Int?
 
     /// Creating an instance of `ImageQueryOptions`.
@@ -17,20 +17,20 @@ public struct ImageQueryOptions {
     ///   - preferredSize: The preferred image size. Note that many users have lower resolution images, so requesting larger sizes may result in
     /// pixelation/low-quality images.
     ///   - gravatarRating: The lowest rating allowed to be displayed. If the requested email hash does not have an image meeting the requested rating level,
-    ///   - defaultImage: Choose what will happen if no Gravatar image is found. See ``DefaultImageOption`` for more info.
+    ///   - defaultImageOption: Choose what will happen if no Gravatar image is found. See ``DefaultImageOption`` for more info.
     /// then the default image is returned.
     ///   - forceDefaultImage: If set to `true`, the requested image will always be the default.
     public init(
         preferredSize: ImageSize? = nil,
         rating: ImageRating? = nil,
-        defaultImage: DefaultImageOption? = nil,
+        defaultImageOption: DefaultImageOption? = nil,
         forceDefaultImage: Bool? = nil
     ) {
         self.init(
             scaleFactor: UIScreen.main.scale,
             rating: rating,
             forceDefaultImage: forceDefaultImage,
-            defaultImage: defaultImage,
+            defaultImageOption: defaultImageOption,
             preferredSize: preferredSize
         )
     }
@@ -39,12 +39,12 @@ public struct ImageQueryOptions {
         scaleFactor: CGFloat,
         rating: ImageRating? = nil,
         forceDefaultImage: Bool? = nil,
-        defaultImage: DefaultImageOption? = nil,
+        defaultImageOption: DefaultImageOption? = nil,
         preferredSize: ImageSize? = nil
     ) {
         self.rating = rating
         self.forceDefaultImage = forceDefaultImage
-        self.defaultImage = defaultImage
+        self.defaultImageOption = defaultImageOption
         self.preferredPixelSize = preferredSize?.pixels(scaleFactor: scaleFactor)
     }
 }
@@ -53,7 +53,7 @@ public struct ImageQueryOptions {
 
 extension ImageQueryOptions {
     private enum QueryName: String, CaseIterable {
-        case defaultImage = "d"
+        case defaultImageOption = "d"
         case preferredPixelSize = "s"
         case rating = "r"
         case forceDefaultImage = "f"
@@ -65,8 +65,8 @@ extension ImageQueryOptions {
 
     private func queryItem(for queryName: QueryName) -> URLQueryItem? {
         let value: String? = switch queryName {
-        case .defaultImage:
-            self.defaultImage.queryValue
+        case .defaultImageOption:
+            self.defaultImageOption.queryValue
         case .forceDefaultImage:
             self.forceDefaultImage.queryValue
         case .rating:

--- a/Tests/GravatarTests/GravatarURLTests.swift
+++ b/Tests/GravatarTests/GravatarURLTests.swift
@@ -38,13 +38,13 @@ final class GravatarURLTests: XCTestCase {
     func testUrlWithDefaultImage() throws {
         let url = GravatarURL(verifiedGravatarURL)
         XCTAssertNotNil(url)
-        XCTAssertEqual(url?.url(with: ImageQueryOptions(defaultImage: .fileNotFound)).query, "d=404")
-        XCTAssertEqual(url?.url(with: ImageQueryOptions(defaultImage: .misteryPerson)).query, "d=mp")
-        XCTAssertEqual(url?.url(with: ImageQueryOptions(defaultImage: .monsterId)).query, "d=monsterid")
-        XCTAssertEqual(url?.url(with: ImageQueryOptions(defaultImage: .retro)).query, "d=retro")
-        XCTAssertEqual(url?.url(with: ImageQueryOptions(defaultImage: .roboHash)).query, "d=robohash")
-        XCTAssertEqual(url?.url(with: ImageQueryOptions(defaultImage: .transparentPNG)).query, "d=blank")
-        XCTAssertEqual(url?.url(with: ImageQueryOptions(defaultImage: .wavatar)).query, "d=wavatar")
+        XCTAssertEqual(url?.url(with: ImageQueryOptions(defaultImageOption: .fileNotFound)).query, "d=404")
+        XCTAssertEqual(url?.url(with: ImageQueryOptions(defaultImageOption: .misteryPerson)).query, "d=mp")
+        XCTAssertEqual(url?.url(with: ImageQueryOptions(defaultImageOption: .monsterId)).query, "d=monsterid")
+        XCTAssertEqual(url?.url(with: ImageQueryOptions(defaultImageOption: .retro)).query, "d=retro")
+        XCTAssertEqual(url?.url(with: ImageQueryOptions(defaultImageOption: .roboHash)).query, "d=robohash")
+        XCTAssertEqual(url?.url(with: ImageQueryOptions(defaultImageOption: .transparentPNG)).query, "d=blank")
+        XCTAssertEqual(url?.url(with: ImageQueryOptions(defaultImageOption: .wavatar)).query, "d=wavatar")
     }
 
     func testUrlWithForcedImageDefault() throws {
@@ -68,7 +68,7 @@ final class GravatarURLTests: XCTestCase {
             "https://gravatar.com/avatar/676212ff796c79a3c06261eb10e3f455aa93998ee6e45263da13679c74b1e674"
         )
 
-        let urlAddingDefaultImage = GravatarURL.gravatarUrl(with: exampleEmail, options: ImageQueryOptions(defaultImage: .identicon))
+        let urlAddingDefaultImage = GravatarURL.gravatarUrl(with: exampleEmail, options: ImageQueryOptions(defaultImageOption: .identicon))
         XCTAssertEqual(
             urlAddingDefaultImage?.absoluteString,
             "https://gravatar.com/avatar/676212ff796c79a3c06261eb10e3f455aa93998ee6e45263da13679c74b1e674?d=identicon"
@@ -95,7 +95,7 @@ final class GravatarURLTests: XCTestCase {
         let allOptions = ImageQueryOptions(
             preferredSize: .pixels(200),
             rating: .g,
-            defaultImage: .monsterId,
+            defaultImageOption: .monsterId,
             forceDefaultImage: true
         )
         let urlAddingAllOptions = GravatarURL.gravatarUrl(with: exampleEmail, options: allOptions)

--- a/Tests/GravatarTests/GravatarWrapper+UIImageViewTests.swift
+++ b/Tests/GravatarTests/GravatarWrapper+UIImageViewTests.swift
@@ -80,7 +80,7 @@ final class GravatarWrapper_UIImageViewTests: XCTestCase {
 
         imageView.gravatar.setImage(
             email: "hello@gmail.com",
-            defaultImage: .roboHash,
+            defaultImageOption: .roboHash,
             options: [.imageDownloader(imageDownloader)]
         )
 

--- a/Tests/GravatarTests/ImageServiceTests.swift
+++ b/Tests/GravatarTests/ImageServiceTests.swift
@@ -233,7 +233,7 @@ final class ImageServiceTests: XCTestCase {
         let response = HTTPURLResponse.successResponse(with: URL(string: urlWithQuery)!)
         let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
         let service = imageService(with: sessionMock)
-        let options = GravatarImageDownloadOptions(defaultImage: .misteryPerson)
+        let options = GravatarImageDownloadOptions(defaultImageOption: .misteryPerson)
 
         let imageResponse = try await service.fetchImage(with: TestData.email, options: options)
 


### PR DESCRIPTION
Closes #99 

`defaultImage` sounds like a `UIImage` type of parameter. I think it's better if we call this `defaultImageOption` since its type is actually `DefaultImageOption`. WDYT?

WordPressUI PR: https://github.com/wordpress-mobile/WordPressUI-iOS/pull/149