### PR TITLE
Create a SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Before anything else, please take a moment to read our [Code of Conduct](CODE-OF
 
 ## Security
 
-If you happen to find a security vulnerability, we would appreciate you letting us know at https://hackerone.com/automattic and allowing us to respond before disclosing the issue publicly.
+We take security bugs seriously.  Please see our [Security](SECURITY.md) documentation for details.
 
 ## Reporting Bugs, Asking Questions, and Suggesting Features
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,5 @@
 # Security Policy
 
-## Supported Versions
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.1.0   | :x:                |
-
 ## Reporting a Vulnerability
 
 The Gravatar team takes security bugs in Gravatar seriously. We appreciate your efforts to responsibly disclose your findings.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+The Gravatar team takes security bugs in Gravatar seriously. We appreciate your efforts to responsibly disclose your findings.
+
+To report a security issue, please use [HackerOne](https://hackerone.com/automattic).
+
+Report security bugs in third-party modules to the person or team maintaining the module.


### PR DESCRIPTION
Closes #108 

### Description
This adds a SECURITY.md file, and updates the README.md to point to it.

What do we think?  I took this content from GitHub's suggested content:
![image](https://github.com/Automattic/Gravatar-SDK-iOS/assets/1108984/76a3edfa-2fe6-4050-8984-1de47337f435)

Keeping a list of "supported versions" seems ambitious.  Maybe more than we need to commit to at this point.  But I thought I'd show it anyway.

### Testing Steps
No testing is required.