### PR TITLE
Profile service parity with Android

### DIFF
--- a/Sources/Gravatar/Network/Services/Aliases.swift
+++ b/Sources/Gravatar/Network/Services/Aliases.swift
@@ -1,6 +1,0 @@
-/// A String representing an email.
-public typealias Email = String
-/// A String representing the hash of an email.
-public typealias Hash = String
-/// A String representing a user name.
-public typealias UserName = String

--- a/Sources/Gravatar/Network/Services/Aliases.swift
+++ b/Sources/Gravatar/Network/Services/Aliases.swift
@@ -1,0 +1,6 @@
+/// A String representing an email.
+public typealias Email = String
+/// A String representing the hash of an email.
+public typealias Hash = String
+/// A String representing a user name.
+public typealias UserName = String

--- a/Sources/Gravatar/Network/Services/ProfileFetching.swift
+++ b/Sources/Gravatar/Network/Services/ProfileFetching.swift
@@ -2,16 +2,16 @@ protocol ProfileFetching {
     /// Fetches a Gravatar user's profile information, and delivers the user profile asynchronously.
     /// - Parameter email: The user account email.
     /// - Returns: An asynchronously-delivered user profile.
-    func fetch(withEmail email: Email) async throws -> UserProfile
+    func fetch(withEmail email: String) async throws -> UserProfile
 
     /// Fetches a Gravatar user's profile information, and delivers the user profile asynchronously.
     /// - Parameter hash: The user's email sha256 hash which corresponds to their account. For more info, check [the gravatar
     /// documentation](https://docs.gravatar.com/general/hash/).
     /// - Returns: An asynchronously-delivered user profile.
-    func fetch(withHash hash: Hash) async throws -> UserProfile
+    func fetch(withHash hash: String) async throws -> UserProfile
 
     /// Fetches a Gravatar user's profile information, and delivers the user profile asynchronously.
     /// - Parameter userName: The user's account user name.
     /// - Returns: An asynchronously-delivered user profile.
-    func fetch(withUserName userName: UserName) async throws -> UserProfile
+    func fetch(withUserName userName: String) async throws -> UserProfile
 }

--- a/Sources/Gravatar/Network/Services/ProfileFetching.swift
+++ b/Sources/Gravatar/Network/Services/ProfileFetching.swift
@@ -1,0 +1,17 @@
+protocol ProfileFetching {
+    /// Fetches a Gravatar user's profile information, and delivers the user profile asynchronously.
+    /// - Parameter email: The user account email.
+    /// - Returns: An asynchronously-delivered user profile.
+    func fetch(withEmail email: Email) async throws -> UserProfile
+
+    /// Fetches a Gravatar user's profile information, and delivers the user profile asynchronously.
+    /// - Parameter hash: The user's email sha256 hash which corresponds to their account. For more info, check [the gravatar
+    /// documentation](https://docs.gravatar.com/general/hash/).
+    /// - Returns: An asynchronously-delivered user profile.
+    func fetch(withHash hash: Hash) async throws -> UserProfile
+
+    /// Fetches a Gravatar user's profile information, and delivers the user profile asynchronously.
+    /// - Parameter userName: The user's account user name.
+    /// - Returns: An asynchronously-delivered user profile.
+    func fetch(withUserName userName: UserName) async throws -> UserProfile
+}

--- a/Sources/Gravatar/Network/Services/ProfileService.swift
+++ b/Sources/Gravatar/Network/Services/ProfileService.swift
@@ -19,7 +19,6 @@ public struct ProfileService: ProfileFetching {
         self.client = client ?? URLSessionHTTPClient()
     }
 
-    @available(*, deprecated, renamed: "fetch(withEmail:)")
     /// Fetches a Gravatar user's profile information.
     /// - Parameters:
     ///   - email: The user account email.
@@ -37,15 +36,15 @@ public struct ProfileService: ProfileFetching {
         }
     }
 
-    public func fetch(withEmail email: Email) async throws -> UserProfile {
+    public func fetch(withEmail email: String) async throws -> UserProfile {
         try await fetch(withPath: email.sha256())
     }
 
-    public func fetch(withHash hash: Hash) async throws -> UserProfile {
+    public func fetch(withHash hash: String) async throws -> UserProfile {
         try await fetch(withPath: hash)
     }
 
-    public func fetch(withUserName userName: UserName) async throws -> UserProfile {
+    public func fetch(withUserName userName: String) async throws -> UserProfile {
         try await fetch(withPath: userName)
     }
 }

--- a/Sources/Gravatar/Network/Services/ProfileService.swift
+++ b/Sources/Gravatar/Network/Services/ProfileService.swift
@@ -8,7 +8,7 @@ public enum GravatarProfileFetchResult {
 }
 
 /// A service to perform Profile related tasks.
-public struct ProfileService {
+public struct ProfileService: ProfileFetching {
     private let client: HTTPClient
 
     /// Creates a new `ProfileService`.
@@ -19,6 +19,7 @@ public struct ProfileService {
         self.client = client ?? URLSessionHTTPClient()
     }
 
+    @available(*, deprecated, renamed: "fetch(withEmail:)")
     /// Fetches a Gravatar user's profile information.
     /// - Parameters:
     ///   - email: The user account email.
@@ -26,7 +27,7 @@ public struct ProfileService {
     public func fetchProfile(with email: String, onCompletion: @escaping ((_ result: GravatarProfileFetchResult) -> Void)) {
         Task {
             do {
-                let profile = try await fetchProfile(for: email)
+                let profile = try await fetch(withEmail: email)
                 onCompletion(.success(profile))
             } catch let error as ProfileServiceError {
                 onCompletion(.failure(error))
@@ -36,12 +37,16 @@ public struct ProfileService {
         }
     }
 
-    /// Fetches a Gravatar user's profile information, and delivers the user profile asynchronously.
-    /// - Parameter email: The user account email.
-    /// - Returns: An asynchronously-delivered user profile.
-    public func fetchProfile(for email: String) async throws -> UserProfile {
-        let url = try url(from: email.sha256() + ".json")
-        return try await fetchProfile(with: URLRequest(url: url))
+    public func fetch(withEmail email: Email) async throws -> UserProfile {
+        try await fetch(withPath: email.sha256())
+    }
+
+    public func fetch(withHash hash: Hash) async throws -> UserProfile {
+        try await fetch(withPath: hash)
+    }
+
+    public func fetch(withUserName userName: UserName) async throws -> UserProfile {
+        try await fetch(withPath: userName)
     }
 }
 
@@ -59,7 +64,12 @@ extension ProfileService {
         return url
     }
 
-    private func fetchProfile(with request: URLRequest) async throws -> UserProfile {
+    private func fetch(withPath path: String) async throws -> UserProfile {
+        let url = try url(from: path + ".json")
+        return try await fetch(with: URLRequest(url: url))
+    }
+
+    private func fetch(with request: URLRequest) async throws -> UserProfile {
         do {
             let (data, response) = try await client.fetchData(with: request)
             let fetchProfileResult = map(data, response)

--- a/Tests/GravatarTests/ProfileServiceTests.swift
+++ b/Tests/GravatarTests/ProfileServiceTests.swift
@@ -6,7 +6,7 @@ final class ProfileServiceTests: XCTestCase {
         let session = URLSessionMock(returnData: jsonData, response: .successResponse())
         let client = URLSessionHTTPClient(urlSession: session)
         let service = ProfileService(client: client)
-        let profile = try await service.fetchProfile(for: "some@email.com")
+        let profile = try await service.fetch(withEmail: "some@email.com")
 
         XCTAssertEqual(profile.displayName, "Beau Lebens")
     }
@@ -17,7 +17,7 @@ final class ProfileServiceTests: XCTestCase {
         let service = ProfileService(client: client)
 
         do {
-            _ = try await service.fetchProfile(for: "some@email.com")
+            _ = try await service.fetch(withEmail: "some@email.com")
         } catch ProfileServiceError.responseError(reason: let reason) {
             XCTAssertEqual(reason.httpStatusCode, 404)
         } catch {
@@ -31,7 +31,7 @@ final class ProfileServiceTests: XCTestCase {
         let service = ProfileService(client: client)
 
         do {
-            _ = try await service.fetchProfile(for: "some@email.com")
+            _ = try await service.fetch(withEmail: "some@email.com")
         } catch let error as ProfileServiceError {
             XCTAssertEqual(error.debugDescription, ProfileServiceError.noProfileInResponse.debugDescription)
         } catch {
@@ -83,7 +83,7 @@ final class ProfileServiceTests: XCTestCase {
         let session = URLSessionMock(returnData: jsonData, response: .successResponse())
         let client = URLSessionHTTPClient(urlSession: session)
         let service = ProfileService(client: client)
-        let profile = try await service.fetchProfile(for: "some@email.com")
+        let profile = try await service.fetch(withEmail: "some@email.com")
 
         XCTAssertEqual(profile.displayName, "Beau Lebens")
         XCTAssertNotNil(profile.lastProfileEdit)
@@ -93,7 +93,7 @@ final class ProfileServiceTests: XCTestCase {
         let session = URLSessionMock(returnData: jsonData, response: .successResponse())
         let client = URLSessionHTTPClient(urlSession: session)
         let service = ProfileService(client: client)
-        let profile = try await service.fetchProfile(for: "some@email.com")
+        let profile = try await service.fetch(withEmail: "some@email.com")
 
         XCTAssertEqual(profile.urls.first?.linkSlug, "some_slug")
         XCTAssertNotNil(profile.lastProfileEdit)
@@ -105,11 +105,41 @@ final class ProfileServiceTests: XCTestCase {
         let service = ProfileService(client: client)
 
         do {
-            let profile = try await service.fetchProfile(for: "some@email.com")
+            let profile = try await service.fetch(withEmail: "some@email.com")
             XCTAssertEqual(profile.displayName, "doxomi4985")
         } catch {
             XCTFail(error.localizedDescription)
         }
+    }
+
+    func testFetchWithEmail() async throws {
+        let session = URLSessionMock(returnData: jsonData, response: .successResponse())
+        let client = HTTPClientMock(session: session)
+        let service = ProfileService(client: client)
+        _ = try await service.fetch(withEmail: "some@email.com")
+
+        XCTAssertEqual(
+            session.request?.url?.absoluteString,
+            "https://gravatar.com/676212ff796c79a3c06261eb10e3f455aa93998ee6e45263da13679c74b1e674.json"
+        )
+    }
+
+    func testFetchWithHash() async throws {
+        let session = URLSessionMock(returnData: jsonData, response: .successResponse())
+        let client = HTTPClientMock(session: session)
+        let service = ProfileService(client: client)
+        _ = try await service.fetch(withHash: "HASH")
+
+        XCTAssertEqual(session.request?.url?.absoluteString, "https://gravatar.com/HASH.json")
+    }
+
+    func testFetchWithUserName() async throws {
+        let session = URLSessionMock(returnData: jsonData, response: .successResponse())
+        let client = HTTPClientMock(session: session)
+        let service = ProfileService(client: client)
+        _ = try await service.fetch(withUserName: "user")
+
+        XCTAssertEqual(session.request?.url?.absoluteString, "https://gravatar.com/user.json")
     }
 }
 

--- a/Tests/GravatarTests/UserProfileTests.swift
+++ b/Tests/GravatarTests/UserProfileTests.swift
@@ -102,7 +102,7 @@ extension UserProfileTests {
         let client = HTTPClientMock(session: urlSession)
         let profileService = ProfileService(client: client)
 
-        return try await profileService.fetchProfile(for: "test@example.com")
+        return try await profileService.fetch(withEmail: "test@example.com")
     }
 
     private func json(for profile: Profile) throws -> Data {
@@ -218,7 +218,7 @@ extension UserProfileTests {
 
 // MARK: - HTTPClient
 
-private struct HTTPClientMock: HTTPClient {
+struct HTTPClientMock: HTTPClient {
     private let session: URLSessionMock
 
     init(session: URLSessionMock) {
@@ -226,7 +226,8 @@ private struct HTTPClientMock: HTTPClient {
     }
 
     func fetchData(with request: URLRequest) async throws -> (Data, HTTPURLResponse) {
-        (session.returnData, session.response)
+        session.request = request
+        return (session.returnData, session.response)
     }
 
     func uploadData(with request: URLRequest, data: Data) async throws -> HTTPURLResponse {


### PR DESCRIPTION
Closes #112 

### Description

This PR changes the public API of `ProfileService` to be in parity with Android SDK.

I have added a new `protocol ProfileFetching`, which I hace kept internal since it doesn't have any practicality for users.
I have tested that the documentation declared in the protocol is shown on the docs of `ProfileService` even if the protocol is not public 👍 

![CleanShot 2024-03-18 at 21 11 36@2x](https://github.com/Automattic/Gravatar-SDK-iOS/assets/9772967/1fcbeae3-5540-4a2b-a774-8bb34d814fa8)

### To discus:

#### String aliases

I have created the String aliases for `Email`, `Hash`, and `Username`.  The method signature though must have a different label, since the parameter is still basically a `String` and the compiler can't differentiate from them.

I did a fast test declaring these as `struct`s, conforming to `ExpressibleByStringLiteral`. It works well when the parameter given is a string literal, but not when it's a variable (it would look like: `fetch(with: Email(stringLiteral: emailVariable))` which lacks practicality).

And having Email, Hash, and UserName structs conforming to `ExpressibleByStringLiteral` will rise the same ambiguity issue, so at the end this approach is not practical.

At the end, we are not gaining anything more than a bit more explicit method signature, but I'm leaving them as we agreed already to have them, and I don't see any harm on it.

#### Deprecating `completionHandler`.

This is not a necessity, but I'd argue that we either give all methods a `completionBlock` counterpart, or we don't provide any.

WPiOS uses the completion block method, and that's why I've added a deprecation warning instead of removing it directly, but we would need to eventually change it for the concurrency counterpart.

I advocate to not support completion blocks, except when it's more necessary like in View classes.

### Testing Steps

- CI should be 🍏 
