### PR TITLE
Rename ImageRating to Rating

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoAvatarDownloadViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoAvatarDownloadViewController.swift
@@ -117,11 +117,11 @@ class DemoAvatarDownloadViewController: UIViewController {
         return Self.imageViewSize
     }
     
-    private var preferredRating: ImageRating? {
+    private var preferredRating: Rating? {
         if let ratingStr = gravatarRatingInputField.text,
            !ratingStr.isEmpty
         {
-            return ImageRating(rawValue: ratingStr)
+            return Rating(rawValue: ratingStr)
         }
         return nil
     }

--- a/Sources/Gravatar/GravatarCompatibleUI/UIImageView+Gravatar.swift
+++ b/Sources/Gravatar/GravatarCompatibleUI/UIImageView+Gravatar.swift
@@ -145,7 +145,7 @@ extension GravatarWrapper where Component: UIImageView {
     public func setImage(
         email: String,
         placeholder: UIImage? = nil,
-        rating: ImageRating? = nil,
+        rating: Rating? = nil,
         preferredSize: CGSize? = nil,
         defaultImageOption: DefaultImageOption? = nil,
         options: [ImageSettingOption]? = nil,

--- a/Sources/Gravatar/Options/GravatarOptions.swift
+++ b/Sources/Gravatar/Options/GravatarOptions.swift
@@ -56,7 +56,7 @@ public struct ImageSettingOptions {
     }
 
     func deriveDownloadOptions(
-        garavatarRating rating: ImageRating? = nil,
+        garavatarRating rating: Rating? = nil,
         preferredSize size: ImageSize? = nil,
         defaultImageOption: DefaultImageOption? = nil
     ) -> ImageDownloadOptions {
@@ -91,7 +91,7 @@ public struct ImageDownloadOptions {
     ///   - processingMethod: Method to use for processing the downloaded `Data`
     public init(
         preferredSize: ImageSize? = nil,
-        rating: ImageRating? = nil,
+        rating: Rating? = nil,
         forceRefresh: Bool = false,
         forceDefaultImage: Bool? = nil,
         defaultImageOption: DefaultImageOption? = nil,

--- a/Sources/Gravatar/Options/ImageQueryOptions.swift
+++ b/Sources/Gravatar/Options/ImageQueryOptions.swift
@@ -5,7 +5,7 @@ import UIKit
 /// For the options not specified, the backend defaults will be used.
 /// For more information, see the [Gravatar developer documentation](https://docs.gravatar.com/general/images/).
 public struct ImageQueryOptions {
-    let rating: ImageRating?
+    let rating: Rating?
     let forceDefaultImage: Bool?
     let defaultImageOption: DefaultImageOption?
     let preferredPixelSize: Int?
@@ -22,7 +22,7 @@ public struct ImageQueryOptions {
     ///   - forceDefaultImage: If set to `true`, the returned image will always be the default image, determined by the `defaultImageOption` parameter.
     public init(
         preferredSize: ImageSize? = nil,
-        rating: ImageRating? = nil,
+        rating: Rating? = nil,
         defaultImageOption: DefaultImageOption? = nil,
         forceDefaultImage: Bool? = nil
     ) {
@@ -37,7 +37,7 @@ public struct ImageQueryOptions {
 
     init(
         scaleFactor: CGFloat,
-        rating: ImageRating? = nil,
+        rating: Rating? = nil,
         forceDefaultImage: Bool? = nil,
         defaultImageOption: DefaultImageOption? = nil,
         preferredSize: ImageSize? = nil
@@ -91,7 +91,7 @@ extension DefaultImageOption? {
     }
 }
 
-extension ImageRating? {
+extension Rating? {
     fileprivate var queryValue: String? {
         guard let self else { return nil }
 

--- a/Sources/Gravatar/Options/Rating.swift
+++ b/Sources/Gravatar/Options/Rating.swift
@@ -1,16 +1,17 @@
 import Foundation
 
-/// Gravatar allows users to self-rate their images so that they can indicate if an image is appropriate for a certain audience. By default, only `G` rated
+/// Gravatar allows users to self-rate their images so that they can indicate if an image is appropriate for a certain audience. By default, only `general`
+/// rated
 /// images are displayed unless you indicate that you would like to see higher ratings.
 ///
 /// If the requested email hash does not have an image meeting the requested rating level, then the default image is returned (See: ``DefaultImageOption``)
-public enum ImageRating: String {
+public enum Rating: String {
     /// Suitable for display on all websites with any audience type.
-    case g
+    case general = "g"
     /// May contain rude gestures, provocatively dressed individuals, the lesser swear words, or mild violence.
-    case pg
+    case parentalGuidance = "pg"
     /// May contain such things as harsh profanity, intense violence, nudity, or hard drug use.
-    case r
+    case restricted = "r"
     /// May contain sexual imagery or extremely disturbing violence.
     case x
 }

--- a/Tests/GravatarTests/GravatarURLTests.swift
+++ b/Tests/GravatarTests/GravatarURLTests.swift
@@ -80,7 +80,7 @@ final class GravatarURLTests: XCTestCase {
             "https://gravatar.com/avatar/676212ff796c79a3c06261eb10e3f455aa93998ee6e45263da13679c74b1e674?s=24"
         )
 
-        let urlAddingRating = GravatarURL.gravatarUrl(with: exampleEmail, options: ImageQueryOptions(rating: .pg))
+        let urlAddingRating = GravatarURL.gravatarUrl(with: exampleEmail, options: ImageQueryOptions(rating: .parentalGuidance))
         XCTAssertEqual(
             urlAddingRating?.absoluteString,
             "https://gravatar.com/avatar/676212ff796c79a3c06261eb10e3f455aa93998ee6e45263da13679c74b1e674?r=pg"
@@ -94,7 +94,7 @@ final class GravatarURLTests: XCTestCase {
 
         let allOptions = ImageQueryOptions(
             preferredSize: .pixels(200),
-            rating: .g,
+            rating: .general,
             defaultImageOption: .monsterId,
             forceDefaultImage: true
         )


### PR DESCRIPTION
Closes #115 

### Description

Renaming `ImageRating` to `Rating`, plus some case names.

### Testing Steps

- Checkout https://github.com/wordpress-mobile/WordPressUI-iOS/pull/151
- Checkout https://github.com/wordpress-mobile/WordPress-iOS/pull/22856 (to avoid build errors)
- WPiOS should build
- CI on this PR should be 💚 