### PR TITLE
[DO NOT MERGE] Add SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,8 @@
+only_rules: # Rules to run
+  - force_unwrapping
+
+included:
+  - Sources
+
+# If true, SwiftLint will treat all warnings as errors.
+strict: true

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,93 @@
 {
   "pins" : [
     {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "7892a123f7e8d0fe62f9f03728b17bbd4f94df5c",
+        "version" : "1.8.1"
+      }
+    },
+    {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "b6dc09ee51dfb0c66e042d2328c017483a1a5d56",
+        "version" : "0.34.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+        "version" : "1.2.3"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
+      }
+    },
+    {
       "identity" : "swiftformat",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
         "revision" : "fef156a6135e584985ed26713dd2e9ee41f952cb",
         "version" : "0.53.0"
+      }
+    },
+    {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint",
+      "state" : {
+        "revision" : "f17a4f9dfb6a6afb0408426354e4180daaf49cee",
+        "version" : "0.54.0"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
+        "version" : "7.0.2"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "8a835d918245ca22f36663dd3862138805d7f707",
+        "version" : "5.1.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Gravatar",
     platforms: [
-        .iOS(.v15),
+        .iOS(.v15)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
@@ -20,13 +20,15 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.53.0")
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.53.0"),
+        .package(url: "https://github.com/realm/SwiftLint", exact: "0.54.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "Gravatar"
+            name: "Gravatar",
+            plugins: [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]
         ),
         .testTarget(
             name: "GravatarTests",
@@ -35,7 +37,8 @@ let package = Package(
         ),
         .target(
             name: "GravatarUI",
-            dependencies: ["Gravatar"]
+            dependencies: ["Gravatar"],
+            plugins: [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]
         ),
         .testTarget(
             name: "GravatarUITests",

--- a/Sources/Gravatar/Network/Services/ImageUploadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploadService.swift
@@ -75,7 +75,7 @@ extension Data {
 
 extension URLRequest {
     fileprivate static func imageUploadRequest(with boundary: String) -> URLRequest {
-        let url = URL(string: "https://api.gravatar.com/v1/upload-image")!
+        let url = URL(string: "https://api.gravatar.com/v1/upload-image")! // swiftlint:disable:this force_unwrapping
         var request = URLRequest(url: url)
         request.addValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.httpMethod = "POST"


### PR DESCRIPTION
Closes #

### Description

This adds `SwiftLint` as a Build Tool plugin, and a basic configuration that enables only one rule: `force_unwrapping`.

### There's a problem
This doesn't currently play nicely with our implementation of SwiftFormat in our package.

SwiftFormat is giving some grief about SwiftLint.  SwiftLint technically supports macOS 12.  Our Package only specifies iOS .v15.  For some reason, SwiftFormat (which apparently looks at the Package.swift file) is throwing an error about this:
the library 'Gravatar' requires macos 10.13, but depends on the product 'SwiftLintPlugin' which requires macos 12.0; consider changing the library 'Gravatar' to require macos 12.0 or later, or the product 'SwiftLintPlugin' to require macos 10.13 or earlier.

I suspect this is because macOS 10.13 is the "default" when we don't specify in the Package.swift.
So when the plugin is added to our targets (so that it is run at build time for those targets), it's working ok because our Macs are running a newer OS than the plugin needs.  But SwiftFormat is detecting the theoretical difference.

We could mitigate this by updating our Package.swift:

```swift
    platforms: [
        .iOS(.v15),
        .macOS(.v12)
    ],
```

But we don't support macOS.  So I don't love this.

### SwiftLint vs SwiftFormat

SwiftFormat's ability to automatically make code changes is nice.  SwiftLint does have some limited capabilities for auto-correction.  But we can't use them yet.

The problem is with their SPM support.  At the moment, they only support a Build Tools version of the plugin.  These run on every build (which is very useful, and allows for in-line warnings and errors).  But Build Tool plugins cannot make changes to code.  They are read-only by design.

That's why SwiftFormat is a Command Line plugin (and requires manually running).

However, it looks like SwiftLint will be releasing a version of SwiftLint with support for both types of plugins: Build Tools and Command Line.

Ideally we would configure both:
- Build Tool Plugin: runs on every build, reports warnings and errors in-line
- Command Line Plugin: called manually by dev to autocorrect issues that can be corrected

### Waiting for the next major version of SwiftLint

Given the challenges above, I think it makes sense to strongly consider using either `SwiftLint` or `SwiftFormat` rather than both.

### Testing Steps

Try adding a force unwrapped variable somewhere, then try building.  You should see an build error.  Then try adding a comment to disable swiftlint on that line.  See the example in this PR.