### PR TITLE
Remove test-spec from the podspecs

### DIFF
--- a/Gravatar.podspec
+++ b/Gravatar.podspec
@@ -21,19 +21,4 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = ios_deployment_target
 
   s.source_files = 'Sources/Gravatar/**/*.swift'
-
-  s.test_spec 'GravatarTests' do |swift_unit_tests|
-    swift_unit_tests.platforms = {
-        :ios => ios_deployment_target,
-    }
-    swift_unit_tests.source_files = [
-        'Tests/GravatarTests/**/*.swift'
-    ]
-    swift_unit_tests.resource_bundles = {
-        GravatarTestsResources: [
-            'Tests/GravatarTests/Resources/**/*'
-        ]
-    }
-    swift_unit_tests.requires_app_host = false
-  end
 end

--- a/GravatarUI.podspec
+++ b/GravatarUI.podspec
@@ -22,19 +22,4 @@ Pod::Spec.new do |s|
     s.source_files = 'Sources/GravatarUI/**/*.swift'
     s.dependency 'Gravatar', s.version.to_s
     s.ios.framework = 'UIKit'
-    
-    s.test_spec 'GravatarUITests' do |swift_unit_tests|
-      swift_unit_tests.platforms = {
-          :ios => ios_deployment_target,
-      }
-      swift_unit_tests.source_files = [
-          'Tests/GravatarUITests/**/*.swift'
-      ]
-      swift_unit_tests.resource_bundles = {
-          GravatarUITestsResources: [
-              'Tests/GravatarUITests/Resources/**/*'
-          ]
-      }
-      swift_unit_tests.requires_app_host = false
-    end
   end


### PR DESCRIPTION
Closes #

### Description

Our CI already uses spm configured test targets. Having the test-spec in the podspec is becoming limiting to us. 

For example: We want to add a common spm target to share code between Gravatar Tests and GravatarUI Tests. podspec doesn't let us have a local folder as a dependency. validate-podspecs CI job fails.

And it's also a pain every time we want to add a normal dependency to the test target.

### Testing Steps

CI green.