### PR TITLE
Add "Client-Type" header for avatar upload request

### DIFF
--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -46,6 +46,6 @@ public struct AvatarService {
     /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
     @discardableResult
     public func upload(_ image: UIImage, email: Email, accessToken: String) async throws -> URLResponse {
-        try await imageUploader.uploadImage(image, email: email, accessToken: accessToken)
+        try await imageUploader.uploadImage(image, email: email, accessToken: accessToken, additionalHTTPHeaders: [(name: "Client-Type", value: "ios")])
     }
 }

--- a/Sources/Gravatar/Network/Services/ImageUploader.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploader.swift
@@ -1,5 +1,7 @@
 import UIKit
 
+typealias HTTPHeaderField = (name: String, value: String)
+
 /// Represents a type which can be used by Gravatar to upload an  image to Gravatar.
 protocol ImageUploader {
     /// Uploads an image to be used as the user's Gravatar profile image, and returns the `URLResponse` of the network tasks asynchronously. Throws
@@ -8,11 +10,13 @@ protocol ImageUploader {
     ///   - image: The image to be uploaded.
     ///   - email: The user email account.
     ///   - accessToken: The authentication token for the user.
+    ///   - additionalHTTPHeaders: Additional headers to add.
     /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
     @discardableResult
     func uploadImage(
         _ image: UIImage,
         email: Email,
-        accessToken: String
+        accessToken: String,
+        additionalHTTPHeaders: [HTTPHeaderField]?
     ) async throws -> URLResponse
 }

--- a/Tests/GravatarTests/AvatarServiceTests.swift
+++ b/Tests/GravatarTests/AvatarServiceTests.swift
@@ -35,6 +35,7 @@ final class AvatarServiceTests: XCTestCase {
         XCTAssertTrue(sessionMock.request?.value(forHTTPHeaderField: "Authorization")?.hasPrefix("Bearer ") ?? false)
         XCTAssertNotNil(sessionMock.request?.value(forHTTPHeaderField: "Content-Type"))
         XCTAssertTrue(sessionMock.request?.value(forHTTPHeaderField: "Content-Type")?.hasPrefix("multipart/form-data; boundary=Boundary") ?? false)
+        XCTAssertTrue(sessionMock.request?.value(forHTTPHeaderField: "Client-Type") == "ios")
     }
 
     func testUploadImageError() async throws {

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 module Gravatar
-    VERSION = '1.0.0'.freeze
+    VERSION = '1.0.1'.freeze
 end


### PR DESCRIPTION
Closes #170 

WordPressiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/22959

### Description

Adds a new header to avatar upload
> Client-Type:ios

Bumps up version as "1.0.1"

### Testing Steps

Follow instructions in https://github.com/wordpress-mobile/WordPress-iOS/pull/22959