### PR TITLE
[Tooling] Update `a8c-ci-toolkit` plugin version to latest hotfix

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,4 +5,4 @@
 
 export IMAGE_ID=$(echo "xcode-$(cat .xcode-version)")
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.2.0"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.2.1"


### PR DESCRIPTION
### Description

This should fix the crash in `publish_pod` that happened [during this CI build](https://buildkite.com/automattic/gravatar-sdk-ios/builds/405#018ea897-18e0-4d2b-9ac3-418bc7831c71/255-2121). The crash should be fixed by [the 3.2.1 hotfix of the ci-toolkit plugin](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/tag/3.2.1).

See also @pinarol 's message in https://a8c.slack.com/archives/CC7L49W13/p1712226193319319?thread_ts=1712044283.064279&cid=CC7L49W13

### Testing Steps

This will require us to make a new version of the Gravatar pods to test the publish step in real world.