### PR TITLE
Removing `UIScreen.main` due to deprecation warning

### DIFF
--- a/Sources/Gravatar/Network/Services/ImageDownloadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageDownloadService.swift
@@ -39,7 +39,7 @@ public struct ImageDownloadService: ImageDownloader {
     public func fetchImage(
         with url: URL,
         forceRefresh: Bool = false,
-        processingMethod: ImageProcessingMethod = .common
+        processingMethod: ImageProcessingMethod = .common()
     ) async throws -> ImageDownloadResult {
         if !forceRefresh, let result = cachedImageResult(for: url) {
             return result

--- a/Sources/Gravatar/Options/AvatarQueryOptions.swift
+++ b/Sources/Gravatar/Options/AvatarQueryOptions.swift
@@ -27,7 +27,7 @@ public struct AvatarQueryOptions {
         forceDefaultAvatar: Bool? = nil
     ) {
         self.init(
-            scaleFactor: UIScreen.main.scale,
+            scaleFactor: UITraitCollection.current.displayScale,
             rating: rating,
             forceDefaultAvatar: forceDefaultAvatar,
             defaultAvatarOption: defaultAvatarOption,

--- a/Sources/Gravatar/Options/ImageDownloadOptions.swift
+++ b/Sources/Gravatar/Options/ImageDownloadOptions.swift
@@ -26,7 +26,7 @@ public struct ImageDownloadOptions {
         forceRefresh: Bool = false,
         forceDefaultAvatar: Bool? = nil,
         defaultAvatarOption: DefaultAvatarOption? = nil,
-        processingMethod: ImageProcessingMethod = .common
+        processingMethod: ImageProcessingMethod = .common()
     ) {
         self.forceRefresh = forceRefresh
         self.processingMethod = processingMethod

--- a/Sources/Gravatar/Options/ImageProcessorOption.swift
+++ b/Sources/Gravatar/Options/ImageProcessorOption.swift
@@ -11,20 +11,14 @@ public enum ImageProcessingMethod {
 
     /// A processing method which will directly transform the `Data` to an `UIImage` and return it.
     ///
-    /// This method uses UITraitCollection's displayScale to create a UIImage instance.
-    case common
-
-    /// A processing method which will directly transform the `Data` to a `UIImage` using the given scale factor.
-    /// - Parameter scaleFactor: The scale factor to use to create the `UIImage`.
-    case scaleFactor(_ scaleFactor: CGFloat)
+    /// - Parameter scaleFactor: The scale factor to use to create the `UIImage`. If nil,  UITraitCollection's displayScale is used.
+    case common(scaleFactor: CGFloat = UITraitCollection.current.displayScale)
 }
 
 extension ImageProcessingMethod {
     var processor: ImageProcessor {
         switch self {
-        case .common:
-            DefaultImageProcessor(scaleFactor: UITraitCollection.current.displayScale)
-        case .scaleFactor(let scaleFactor):
+        case .common(let scaleFactor):
             DefaultImageProcessor(scaleFactor: scaleFactor)
         case .custom(let processor):
             processor

--- a/Sources/Gravatar/Options/ImageProcessorOption.swift
+++ b/Sources/Gravatar/Options/ImageProcessorOption.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 /// Enum defining methods for processing and transforming the image data into a UIImage instance.
 ///
@@ -10,15 +11,21 @@ public enum ImageProcessingMethod {
 
     /// A processing method which will directly transform the `Data` to an `UIImage` and return it.
     ///
-    /// This method will use the appropiate scale factor for the device screen.
+    /// This method uses UITraitCollection's displayScale to create a UIImage instance.
     case common
+
+    /// A processing method which will directly transform the `Data` to a `UIImage` using the given scale factor.
+    /// - Parameter scaleFactor: The scale factor to use to create the `UIImage`.
+    case scaleFactor(_ scaleFactor: CGFloat)
 }
 
 extension ImageProcessingMethod {
     var processor: ImageProcessor {
         switch self {
         case .common:
-            DefaultImageProcessor.common
+            DefaultImageProcessor(scaleFactor: UITraitCollection.current.displayScale)
+        case .scaleFactor(let scaleFactor):
+            DefaultImageProcessor(scaleFactor: scaleFactor)
         case .custom(let processor):
             processor
         }

--- a/Sources/Gravatar/UIImage/Processor/DefaultImageProcessor.swift
+++ b/Sources/Gravatar/UIImage/Processor/DefaultImageProcessor.swift
@@ -1,9 +1,7 @@
 import UIKit
 
 /// The default processor. It applies the scale factor on the given image data and converts it into an image.
-struct DefaultImageProcessor: ImageProcessor {
-    public static let common = DefaultImageProcessor(scaleFactor: UIScreen.main.scale)
-
+struct DefaultImageProcessor: ImageProcessor, Sendable {
     public let scaleFactor: CGFloat
 
     public func process(_ data: Data) -> UIImage? {

--- a/Sources/GravatarUI/ImageDownloader+Extension.swift
+++ b/Sources/GravatarUI/ImageDownloader+Extension.swift
@@ -6,7 +6,7 @@ extension ImageDownloader {
     func fetchImage(
         with url: URL,
         forceRefresh: Bool = false,
-        processingMethod: ImageProcessingMethod = .common,
+        processingMethod: ImageProcessingMethod = .common(),
         completionHandler: ImageDownloadCompletion?
     ) -> CancellableDataTask? {
         Task {

--- a/Sources/GravatarUI/Options/ImageSettingOption.swift
+++ b/Sources/GravatarUI/Options/ImageSettingOption.swift
@@ -32,7 +32,7 @@ public struct ImageSettingOptions {
     var transition: ImageTransition = .none
     var removeCurrentImageWhileLoading = false
     var forceRefresh = false
-    var processingMethod: ImageProcessingMethod = .common
+    var processingMethod: ImageProcessingMethod = .common()
     var imageCache: ImageCaching = ImageCache.shared
     var imageDownloader: ImageDownloader? = nil
 


### PR DESCRIPTION
Closes #156 

### Description

`UIScreen.main` has a deprecation warning:

```swift
@available(iOS, introduced: 2.0, deprecated: 100000, message: "Use a UIScreen instance found through context instead: i.e, view.window.windowScene.screen")
open class var main: UIScreen { get }
```

The proposed method to access it `view.window.windowScene.screen` won't work for us since we don't have direct access to a view on this context.

An alternative method to get the screen scale is using `UITraitCollection`. It will have the correct `displayScale` as long as we are running in a UIKit app. (This is the method KingFisher uses).

I've also added an alternative `ImageProcessingMethod` for a custom scale factor, in case the user requested a custom image size independent of screen scale.

With this change, we don't have the build error when building with strict concurrency.

### Testing Steps

- Gravatar demo app: Try fetching image demo screen.
