### PR TITLE
Re-export Gravatar

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoBaseProfileViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoBaseProfileViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Gravatar
 import GravatarUI
 
 open class DemoBaseProfileViewController: UIViewController {

--- a/Demo/Demo/Gravatar-Demo/DemoProfileConfigurationViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoProfileConfigurationViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Gravatar
 import GravatarUI
 import SafariServices
 

--- a/Demo/Demo/Gravatar-Demo/DemoProfilePresentationStylesViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoProfilePresentationStylesViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Gravatar
 import GravatarUI
 
 @MainActor

--- a/Demo/Demo/Gravatar-Demo/DemoProfileViewsViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoProfileViewsViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Gravatar
 import GravatarUI
 import SafariServices
 

--- a/Demo/Demo/Gravatar-Demo/DemoUIImageViewExtensionViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoUIImageViewExtensionViewController.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import UIKit
-import Gravatar
 import GravatarUI
 
 class DemoUIImageViewExtensionViewController: UIViewController {

--- a/Sources/GravatarUI/Exports.swift
+++ b/Sources/GravatarUI/Exports.swift
@@ -1,0 +1,1 @@
+@_exported import Gravatar

--- a/Sources/GravatarUI/RenameMe.swift
+++ b/Sources/GravatarUI/RenameMe.swift
@@ -1,1 +1,0 @@
-import Foundation

--- a/Tests/GravatarUITests/AboutMeBuilderTests.swift
+++ b/Tests/GravatarUITests/AboutMeBuilderTests.swift
@@ -1,4 +1,3 @@
-import Gravatar
 import GravatarUI
 import SnapshotTesting
 import XCTest

--- a/Tests/GravatarUITests/DisplayNameBuilderTests.swift
+++ b/Tests/GravatarUITests/DisplayNameBuilderTests.swift
@@ -1,4 +1,3 @@
-import Gravatar
 import GravatarUI
 import SnapshotTesting
 import XCTest

--- a/Tests/GravatarUITests/GravatarWrapper+UIImageViewTests.swift
+++ b/Tests/GravatarUITests/GravatarWrapper+UIImageViewTests.swift
@@ -1,4 +1,3 @@
-import Gravatar
 import GravatarUI
 import XCTest
 

--- a/Tests/GravatarUITests/LargeProfileSummaryViewTests.swift
+++ b/Tests/GravatarUITests/LargeProfileSummaryViewTests.swift
@@ -1,4 +1,3 @@
-import Gravatar
 import GravatarUI
 import SnapshotTesting
 import XCTest

--- a/Tests/GravatarUITests/LargeProfileViewTests.swift
+++ b/Tests/GravatarUITests/LargeProfileViewTests.swift
@@ -1,4 +1,3 @@
-import Gravatar
 import GravatarUI
 import SnapshotTesting
 import XCTest

--- a/Tests/GravatarUITests/PersonalInfoBuilderTests.swift
+++ b/Tests/GravatarUITests/PersonalInfoBuilderTests.swift
@@ -1,4 +1,3 @@
-import Gravatar
 import GravatarUI
 import SnapshotTesting
 import XCTest

--- a/Tests/GravatarUITests/ProfileButtonsActionsTests.swift
+++ b/Tests/GravatarUITests/ProfileButtonsActionsTests.swift
@@ -1,4 +1,3 @@
-import Gravatar
 import GravatarUI
 import SnapshotTesting
 import XCTest

--- a/Tests/GravatarUITests/ProfileSummaryViewTests.swift
+++ b/Tests/GravatarUITests/ProfileSummaryViewTests.swift
@@ -1,4 +1,3 @@
-import Gravatar
 import GravatarUI
 import SnapshotTesting
 import XCTest

--- a/Tests/GravatarUITests/ProfileViewTests.swift
+++ b/Tests/GravatarUITests/ProfileViewTests.swift
@@ -1,4 +1,3 @@
-import Gravatar
 import GravatarUI
 import SnapshotTesting
 import XCTest

--- a/Tests/GravatarUITests/TestActivityIndicator.swift
+++ b/Tests/GravatarUITests/TestActivityIndicator.swift
@@ -1,4 +1,3 @@
-import Gravatar
 import GravatarUI
 import UIKit
 

--- a/Tests/GravatarUITests/TestImageFetcher.swift
+++ b/Tests/GravatarUITests/TestImageFetcher.swift
@@ -1,5 +1,3 @@
-import Foundation
-import Gravatar
 import GravatarUI
 import XCTest
 

--- a/Tests/GravatarUITests/TestImageProcessor.swift
+++ b/Tests/GravatarUITests/TestImageProcessor.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Gravatar
 import UIKit
 

--- a/Tests/GravatarUITests/TestPlaceholderDisplayers.swift
+++ b/Tests/GravatarUITests/TestPlaceholderDisplayers.swift
@@ -1,4 +1,3 @@
-import Gravatar
 @testable import GravatarUI
 import SnapshotTesting
 import XCTest


### PR DESCRIPTION
Closes #154 

### Description

Small PR which re-exports Gravatar package from GravatarUI.
Now by `import GravatarUI`, there's access to `Gravatar` package.

### Testing Steps

🍏 CI