### PR TITLE
Fix concurrency warnings

### DIFF
--- a/Sources/Gravatar/Identifiers/Email.swift
+++ b/Sources/Gravatar/Identifiers/Email.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Represents a Gravatar account email address
-public struct Email: Equatable {
+public struct Email: Equatable, Sendable {
     let string: String
 
     var hashID: HashID {

--- a/Sources/Gravatar/Identifiers/HashID.swift
+++ b/Sources/Gravatar/Identifiers/HashID.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A type that provides a hash that represents a gravatar profile
-public struct HashID: Equatable {
+public struct HashID: Equatable, Sendable {
     let string: String
 
     /// Initializes a new `HashID` object, reprensenting the gravatar hash of the Gravatar email address

--- a/Sources/Gravatar/Identifiers/ProfileIdentifier.swift
+++ b/Sources/Gravatar/Identifiers/ProfileIdentifier.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// The `ProfileService` uses an `ProfileIdentifier` to specifiy which avatar to fetch.  The `ProfileService` allows specifying a profile
 /// by either its email address or the hashID
-public enum ProfileIdentifier: Equatable {
+public enum ProfileIdentifier: Equatable, Sendable {
     case email(Email)
     case hashID(HashID)
 }

--- a/Sources/Gravatar/Network/Errors.swift
+++ b/Sources/Gravatar/Network/Errors.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 
-public enum ResponseErrorReason {
+public enum ResponseErrorReason: Sendable {
     /// An error occurred in the system URL session.
     case URLSessionError(error: Error)
 
@@ -31,7 +31,7 @@ public enum ResponseErrorReason {
     }
 }
 
-public enum RequestErrorReason {
+public enum RequestErrorReason: Sendable {
     /// The URL could not be initialized.
     case urlInitializationFailed
 


### PR DESCRIPTION
Closes #159
Closes #160 

### Description

Conforming some types to Sendable will silence some of the warnings under strict concurrency.

### Testing Steps

🍏 CI