### PR TITLE
Use `UIImage(localName:)` to check if the account icon exists.

### DIFF
--- a/Sources/GravatarUI/ProfileView/BaseProfileView.swift
+++ b/Sources/GravatarUI/ProfileView/BaseProfileView.swift
@@ -297,7 +297,7 @@ open class BaseProfileView: UIView, UIContentView {
     }
 
     func createAccountIconView(model: AccountModel) -> UIView {
-        let button: UIControl = if UIImage(named: model.shortname) != nil {
+        let button: UIControl = if UIImage(localName: model.shortname) != nil {
             createAccountButton(model: model)
         } else if let iconURL = model.iconURL { // If we have the iconURL try downloading the icon
             createRemoteSVGButton(url: iconURL)


### PR DESCRIPTION
Closes #

### Description

I noticed we have an unintended bug in account icons. It fallbacks to the webview unnecessarily. This should fix it.

### Testing Steps

In any demo screen with a profile card, the account icon should not be shown in the webview.