### PR TITLE
Fix: UILabel placeholder animations doesn't work in ProfileViewController

### DIFF
--- a/Sources/GravatarUI/ProfileView/ActivityIndicator/ProfileActivityIndicator.swift
+++ b/Sources/GravatarUI/ProfileView/ActivityIndicator/ProfileActivityIndicator.swift
@@ -20,7 +20,7 @@ class ProfilePlaceholderActivityIndicator: ProfileActivityIndicator {
         guard placeholderDisplayer.isShowing else { return }
         shouldStopAnimating = false
         self.placeholderDisplayer.elements?.forEach { element in
-            element.prepareForAnimation()
+            element.animationWillBegin()
         }
         doLoadingAnimation(index: 0, animatingColors: baseView.placeholderColors.loadingAnimationColors)
     }
@@ -31,6 +31,7 @@ class ProfilePlaceholderActivityIndicator: ProfileActivityIndicator {
             animator?.stopAnimation(true)
         }
         self.placeholderDisplayer.elements?.forEach { element in
+            element.animationDidEnd()
             if placeholderDisplayer.isShowing {
                 element.refreshColor()
             } else {

--- a/Sources/GravatarUI/ProfileView/BaseProfileView.swift
+++ b/Sources/GravatarUI/ProfileView/BaseProfileView.swift
@@ -297,7 +297,7 @@ open class BaseProfileView: UIView, UIContentView {
     }
 
     func createAccountIconView(model: AccountModel) -> UIView {
-        let button: UIControl = if UIImage(named: model.shortname) != nil {
+        let button: UIControl = if UIImage(localName: model.shortname) != nil {
             createAccountButton(model: model)
         } else if let iconURL = model.iconURL { // If we have the iconURL try downloading the icon
             createRemoteSVGButton(url: iconURL)

--- a/Sources/GravatarUI/ProfileView/Placeholder/PlaceholderDisplayers/AccountButtonsPlaceholderDisplayer.swift
+++ b/Sources/GravatarUI/ProfileView/Placeholder/PlaceholderDisplayers/AccountButtonsPlaceholderDisplayer.swift
@@ -63,5 +63,6 @@ class AccountButtonsPlaceholderDisplayer: PlaceholderDisplaying {
         }
     }
 
-    func prepareForAnimation() {}
+    func animationWillBegin() {}
+    func animationDidEnd() {}
 }

--- a/Sources/GravatarUI/ProfileView/Placeholder/PlaceholderDisplayers/BackgroundColorPlaceholderDisplayer.swift
+++ b/Sources/GravatarUI/ProfileView/Placeholder/PlaceholderDisplayers/BackgroundColorPlaceholderDisplayer.swift
@@ -41,5 +41,6 @@ class BackgroundColorPlaceholderDisplayer<T: UIView>: PlaceholderDisplaying {
         baseView.layer.backgroundColor = newColor?.cgColor
     }
 
-    func prepareForAnimation() {}
+    func animationWillBegin() {}
+    func animationDidEnd() {}
 }

--- a/Sources/GravatarUI/ProfileView/Placeholder/PlaceholderDisplayers/LabelPlaceholderDisplayer.swift
+++ b/Sources/GravatarUI/ProfileView/Placeholder/PlaceholderDisplayers/LabelPlaceholderDisplayer.swift
@@ -3,8 +3,23 @@ import UIKit
 /// A ``PlaceholderDisplaying`` implementation for a UILabel.
 @MainActor
 class LabelPlaceholderDisplayer: RectangularPlaceholderDisplayer<UILabel> {
-    override func prepareForAnimation() {
+    var isAnimating: Bool = false
+
+    override func animationDidEnd() {
+        isAnimating = false
+    }
+
+    override func animationWillBegin() {
         // If UILabel's backgroundColor is set, the animation won't be visible. So we need to clear it. This is only needed for UILabel so far.
         set(viewColor: .clear)
+        isAnimating = true
+    }
+
+    override func set(viewColor newColor: UIColor?) {
+        if !isAnimating {
+            // If UILabel's backgroundColor is set, the animation won't be visible.
+            // So prevent setting it if there's an animation in progress.
+            super.set(viewColor: newColor)
+        }
     }
 }

--- a/Sources/GravatarUI/ProfileView/Placeholder/PlaceholderDisplaying.swift
+++ b/Sources/GravatarUI/ProfileView/Placeholder/PlaceholderDisplaying.swift
@@ -16,8 +16,10 @@ public protocol PlaceholderDisplaying {
     func set(layerColor newColor: UIColor?)
     /// Sets the `backgroundColor` of the underlying view element.
     func set(viewColor newColor: UIColor?)
-    /// Prepares for color animations.
-    func prepareForAnimation()
+    /// Informs the element before the animations begin.
+    func animationWillBegin()
+    /// Informs the element after the  animations end.
+    func animationDidEnd()
     /// Refreshes the color.  `backgroundColor` is set to `placeholderColor` and`layer.backgroundColor` to nil.
     func refreshColor()
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/Gravatar-SDK-iOS/issues/240

### Description

This happens when animations begin and then for some valid reason we re-display the placeholders(which basically means we update the colors and etc.). 

UILabel is different in the sense that its `backgroundColor` is not animatable. So for UILabel we shouldn't let backgroundColor to be updated while an animation is in progress. 

### Testing Steps

Preferably use a network conditioner and lower your network speed

Open the Demo app > Profile View Controller > Enter an invalid email and show the bottom sheet

Observe: UILabels animate.
