### PR TITLE
Open `claimProfile(...)` from `ProfileViewConfiguration` as well

### DIFF
--- a/Sources/GravatarUI/ProfileFields/Model/ClaimProfileModel.swift
+++ b/Sources/GravatarUI/ProfileFields/Model/ClaimProfileModel.swift
@@ -53,24 +53,24 @@ extension ProfileViewClaimProfileConfigurable where Self: BaseProfileView {
 
 extension LargeProfileView: ProfileViewClaimProfileConfigurable {
     public static func claimProfileConfiguration(userName: String? = nil, palette: PaletteType = .system) -> ProfileViewConfiguration {
-        ProfileViewConfiguration.Templates.claimProfile(profileStyle: .large, userName: userName, palette: palette)
+        ProfileViewConfiguration.claimProfile(profileStyle: .large, userName: userName, palette: palette)
     }
 }
 
 extension ProfileView: ProfileViewClaimProfileConfigurable {
     public static func claimProfileConfiguration(userName: String? = nil, palette: PaletteType = .system) -> ProfileViewConfiguration {
-        ProfileViewConfiguration.Templates.claimProfile(profileStyle: .standard, userName: userName, palette: palette)
+        ProfileViewConfiguration.claimProfile(profileStyle: .standard, userName: userName, palette: palette)
     }
 }
 
 extension LargeProfileSummaryView: ProfileViewClaimProfileConfigurable {
     public static func claimProfileConfiguration(userName: String? = nil, palette: PaletteType = .system) -> ProfileViewConfiguration {
-        ProfileViewConfiguration.Templates.claimProfile(profileStyle: .largeSummary, userName: userName, palette: palette)
+        ProfileViewConfiguration.claimProfile(profileStyle: .largeSummary, userName: userName, palette: palette)
     }
 }
 
 extension ProfileSummaryView: ProfileViewClaimProfileConfigurable {
     public static func claimProfileConfiguration(userName: String? = nil, palette: PaletteType = .system) -> ProfileViewConfiguration {
-        ProfileViewConfiguration.Templates.claimProfile(profileStyle: .summary, userName: userName, palette: palette)
+        ProfileViewConfiguration.claimProfile(profileStyle: .summary, userName: userName, palette: palette)
     }
 }

--- a/Sources/GravatarUI/ProfileFields/Model/ClaimProfileModel.swift
+++ b/Sources/GravatarUI/ProfileFields/Model/ClaimProfileModel.swift
@@ -53,33 +53,24 @@ extension ProfileViewClaimProfileConfigurable where Self: BaseProfileView {
 
 extension LargeProfileView: ProfileViewClaimProfileConfigurable {
     public static func claimProfileConfiguration(userName: String? = nil, palette: PaletteType = .system) -> ProfileViewConfiguration {
-        ProfileViewConfiguration.large(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
+        ProfileViewConfiguration.Templates.claimProfile(profileStyle: .large, userName: userName, palette: palette)
     }
 }
 
 extension ProfileView: ProfileViewClaimProfileConfigurable {
     public static func claimProfileConfiguration(userName: String? = nil, palette: PaletteType = .system) -> ProfileViewConfiguration {
-        ProfileViewConfiguration.standard(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
+        ProfileViewConfiguration.Templates.claimProfile(profileStyle: .standard, userName: userName, palette: palette)
     }
 }
 
 extension LargeProfileSummaryView: ProfileViewClaimProfileConfigurable {
     public static func claimProfileConfiguration(userName: String? = nil, palette: PaletteType = .system) -> ProfileViewConfiguration {
-        ProfileViewConfiguration.largeSummary(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
+        ProfileViewConfiguration.Templates.claimProfile(profileStyle: .largeSummary, userName: userName, palette: palette)
     }
 }
 
 extension ProfileSummaryView: ProfileViewClaimProfileConfigurable {
     public static func claimProfileConfiguration(userName: String? = nil, palette: PaletteType = .system) -> ProfileViewConfiguration {
-        ProfileViewConfiguration.summary(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
-    }
-}
-
-extension ProfileViewConfiguration {
-    fileprivate func configureAsClaim() -> ProfileViewConfiguration {
-        var copy = self
-        copy.profileButtonStyle = .create
-        copy.avatarPlaceholder = UIImage(named: "empty-profile-avatar")
-        return copy
+        ProfileViewConfiguration.Templates.claimProfile(profileStyle: .summary, userName: userName, palette: palette)
     }
 }

--- a/Sources/GravatarUI/ProfileView/ProfileViewConfiguration.swift
+++ b/Sources/GravatarUI/ProfileView/ProfileViewConfiguration.swift
@@ -4,7 +4,7 @@ import UIKit
 public struct ProfileViewConfiguration: UIContentConfiguration {
     public var model: ProfileModel?
     public var summaryModel: ProfileSummaryModel?
-    let profileStyle: Style
+    public let profileStyle: Style
     var avatarID: AvatarIdentifier? {
         model?.avatarIdentifier ?? summaryModel?.avatarIdentifier
     }
@@ -84,7 +84,7 @@ extension ProfileViewConfiguration {
 
     /// List of some prefilled `ProfileViewConfiguration`s  that are designed for different purposes. For example, as a fallback for when the user doesn't have
     /// a Gravatar account.
-    enum Templates {
+    public enum Templates {
         /// Creates a `ProfileViewConfiguration` that is designed for emails without a Gravatar account. This configuration invites the user to claim their
         /// Gravatar profile.
         /// - Parameters:

--- a/Sources/GravatarUI/ProfileView/ProfileViewConfiguration.swift
+++ b/Sources/GravatarUI/ProfileView/ProfileViewConfiguration.swift
@@ -97,7 +97,7 @@ extension ProfileViewConfiguration {
             case .standard:
                 ProfileViewConfiguration.standard(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
             case .large:
-                ProfileViewConfiguration.largeSummary(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
+                ProfileViewConfiguration.large(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
             case .largeSummary:
                 ProfileViewConfiguration.largeSummary(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
             case .summary:

--- a/Sources/GravatarUI/ProfileView/ProfileViewConfiguration.swift
+++ b/Sources/GravatarUI/ProfileView/ProfileViewConfiguration.swift
@@ -82,27 +82,23 @@ extension ProfileViewConfiguration {
         self.init(model: model, palette: palette, profileStyle: .largeSummary)
     }
 
-    /// List of some prefilled `ProfileViewConfiguration`s  that are designed for different purposes. For example, as a fallback for when the user doesn't have
-    /// a Gravatar account.
-    public enum Templates {
-        /// Creates a `ProfileViewConfiguration` that is designed for emails without a Gravatar account. This configuration invites the user to claim their
-        /// Gravatar profile.
-        /// - Parameters:
-        ///   - style: Style of the profile view. See: ``ProfileViewConfiguration.Style``
-        ///   - userName: Optional. If not provided, a string that says "Your Name" will be shown.
-        ///   - palette: The ``PaletteType`` to use.
-        /// - Returns: A new `ProfileViewConfiguration`.
-        public static func claimProfile(profileStyle style: Style, userName: String? = nil, palette: PaletteType = .system) -> ProfileViewConfiguration {
-            switch style {
-            case .standard:
-                ProfileViewConfiguration.standard(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
-            case .large:
-                ProfileViewConfiguration.large(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
-            case .largeSummary:
-                ProfileViewConfiguration.largeSummary(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
-            case .summary:
-                ProfileViewConfiguration.summary(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
-            }
+    /// Creates a `ProfileViewConfiguration` that is designed for emails without a Gravatar account. This configuration invites the user to claim their
+    /// Gravatar profile.
+    /// - Parameters:
+    ///   - style: Style of the profile view. See: ``ProfileViewConfiguration.Style``
+    ///   - userName: Optional. If not provided, a string that says "Your Name" will be shown.
+    ///   - palette: The ``PaletteType`` to use.
+    /// - Returns: A new `ProfileViewConfiguration`.
+    public static func claimProfile(profileStyle style: Style, userName: String? = nil, palette: PaletteType = .system) -> ProfileViewConfiguration {
+        switch style {
+        case .standard:
+            ProfileViewConfiguration.standard(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
+        case .large:
+            ProfileViewConfiguration.large(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
+        case .largeSummary:
+            ProfileViewConfiguration.largeSummary(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
+        case .summary:
+            ProfileViewConfiguration.summary(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
         }
     }
 }

--- a/Sources/GravatarUI/ProfileView/ProfileViewConfiguration.swift
+++ b/Sources/GravatarUI/ProfileView/ProfileViewConfiguration.swift
@@ -81,4 +81,37 @@ extension ProfileViewConfiguration {
     public static func largeSummary(model: ProfileSummaryModel? = nil, palette: PaletteType = .system) -> ProfileViewConfiguration {
         self.init(model: model, palette: palette, profileStyle: .largeSummary)
     }
+
+    /// List of some prefilled `ProfileViewConfiguration`s  that are designed for different purposes. For example, as a fallback for when the user doesn't have
+    /// a Gravatar account.
+    enum Templates {
+        /// Creates a `ProfileViewConfiguration` that is designed for emails without a Gravatar account. This configuration invites the user to claim their
+        /// Gravatar profile.
+        /// - Parameters:
+        ///   - style: Style of the profile view. See: ``ProfileViewConfiguration.Style``
+        ///   - userName: Optional. If not provided, a string that says "Your Name" will be shown.
+        ///   - palette: The ``PaletteType`` to use.
+        /// - Returns: A new `ProfileViewConfiguration`.
+        public static func claimProfile(profileStyle style: Style, userName: String? = nil, palette: PaletteType = .system) -> ProfileViewConfiguration {
+            switch style {
+            case .standard:
+                ProfileViewConfiguration.standard(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
+            case .large:
+                ProfileViewConfiguration.largeSummary(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
+            case .largeSummary:
+                ProfileViewConfiguration.largeSummary(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
+            case .summary:
+                ProfileViewConfiguration.summary(model: ClaimProfileModel(userName: userName), palette: palette).configureAsClaim()
+            }
+        }
+    }
+}
+
+extension ProfileViewConfiguration {
+    private func configureAsClaim() -> ProfileViewConfiguration {
+        var copy = self
+        copy.profileButtonStyle = .create
+        copy.avatarPlaceholder = UIImage(named: "empty-profile-avatar")
+        return copy
+    }
 }


### PR DESCRIPTION
Closes # Continuation of the empty profile work.

### Description

I noticed that we didn't offer the `claimProfile(...)` config directly via `ProfileViewConfiguration`. In pocket-casts I use `ProfileViewConfiguration` so the code is unaware of the underlying view type. It would be good to offer this via `ProfileViewConfiguration` as well.

I am not sure if this is the best but I created a new `Templates` enum to separate these type of "prefilled" configurations from other static functions that create an empty profile. 

So the usage will look like this:

> ProfileViewConfiguration.Templates.claimProfile(profileStyle: .summary, ...)

Let me know what you think.

### Testing Steps

CI green.