### PR TITLE
[Concurrency] - Make GravatarProfileFetchResult sendable

### DIFF
--- a/Sources/Gravatar/Network/Services/ProfileService.swift
+++ b/Sources/Gravatar/Network/Services/ProfileService.swift
@@ -2,13 +2,13 @@ import Foundation
 
 private let baseURL = "https://gravatar.com/"
 
-public enum GravatarProfileFetchResult {
+public enum GravatarProfileFetchResult: Sendable {
     case success(UserProfile)
     case failure(ProfileServiceError)
 }
 
 /// A service to perform Profile related tasks.
-public struct ProfileService: ProfileFetching {
+public struct ProfileService: ProfileFetching, Sendable {
     private let client: HTTPClient
 
     /// Creates a new `ProfileService`.
@@ -23,7 +23,7 @@ public struct ProfileService: ProfileFetching {
     /// - Parameters:
     ///   - profileID: A `ProfileIdentifier` for the Gravatar profile
     ///   - onCompletion: The completion handler to call when the fetch request is complete.
-    public func fetchProfile(with profileID: ProfileIdentifier, onCompletion: @escaping ((_ result: GravatarProfileFetchResult) -> Void)) {
+    public func fetchProfile(with profileID: ProfileIdentifier, onCompletion: @Sendable @escaping (_ result: GravatarProfileFetchResult) -> Void) {
         Task {
             do {
                 let profile = try await fetch(with: profileID)

--- a/Sources/Gravatar/Network/UserProfile.swift
+++ b/Sources/Gravatar/Network/UserProfile.swift
@@ -4,7 +4,7 @@ struct Root: Decodable {
     let entry: [UserProfile]
 }
 
-public struct UserProfile: Decodable {
+public struct UserProfile: Decodable, Sendable {
     public let hash: String
     public let requestHash: String
     public let preferredUsername: String
@@ -56,13 +56,13 @@ extension UserProfile {
 }
 
 extension UserProfile {
-    public struct Name: Decodable {
+    public struct Name: Decodable, Sendable {
         public let givenName: String?
         public let familyName: String?
         public let formatted: String?
     }
 
-    public struct Email: Decodable {
+    public struct Email: Decodable, Sendable {
         public let value: String
         public let isPrimary: Bool
 
@@ -86,7 +86,7 @@ extension UserProfile {
         }
     }
 
-    public struct Account: Decodable {
+    public struct Account: Decodable, Sendable {
         public let domain: String
         public let display: String
         public let username: String
@@ -136,7 +136,7 @@ extension UserProfile {
         }
     }
 
-    public struct LinkURL: Decodable {
+    public struct LinkURL: Decodable, Sendable {
         public let title: String
         public let linkSlug: String?
         public let value: String
@@ -146,7 +146,7 @@ extension UserProfile {
         }
     }
 
-    public struct Photo: Decodable {
+    public struct Photo: Decodable, Sendable {
         public let type: String?
         public let value: String
 


### PR DESCRIPTION
Closes part of https://github.com/Automattic/Gravatar-SDK-iOS/issues/130 

### Description

Fixes this warning that appears when strict concurrency is enabled.

<img width="1213" alt="Screenshot 2024-05-16 at 15 53 55" src="https://github.com/Automattic/Gravatar-SDK-iOS/assets/5032900/d7a48aa8-22ef-4489-b4f6-afb22d4fd6a4">


### Testing Steps

CI green.