### PR TITLE
ImageDownloader: Fix cancellation and some other problems

### DIFF
--- a/Sources/Gravatar/Cache/ImageCaching.swift
+++ b/Sources/Gravatar/Cache/ImageCaching.swift
@@ -9,7 +9,7 @@ public protocol ImageCaching: Sendable {
     /// - Parameters:
     ///   - image: The cache entry to set.
     ///   - key: The entry's key, used to be found via `.getEntry(key:)`.
-    func setEntry(_ entry: CacheEntry, for key: String) async
+    func setEntry(_ entry: CacheEntry?, for key: String) async
 
     /// Gets a `CacheEntry` from cache for the given key, or nil if none is found.
     ///
@@ -30,8 +30,12 @@ public struct ImageCache: ImageCaching {
 
     public init() {}
 
-    public func setEntry(_ entry: CacheEntry, for key: String) {
-        cache[key] = .init(entry)
+    public func setEntry(_ entry: CacheEntry?, for key: String) {
+        if let entry {
+            cache[key] = .init(entry)
+        } else {
+            cache[key] = nil
+        }
     }
 
     public func getEntry(with key: String) -> CacheEntry? {

--- a/Sources/Gravatar/Network/Services/ImageDownloadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageDownloadService.swift
@@ -4,7 +4,7 @@ import UIKit
 ///
 /// This is the default type which implements ``ImageDownloader``..
 /// Unless specified otherwise, `ImageDownloadService` will use a `URLSession` based `HTTPClient`, and a in-memory image cache.
-public struct ImageDownloadService: ImageDownloader {
+public struct ImageDownloadService: ImageDownloader, Sendable {
     private let client: HTTPClient
     let imageCache: ImageCaching
 
@@ -20,57 +20,60 @@ public struct ImageDownloadService: ImageDownloader {
         self.imageCache = cache ?? ImageCache()
     }
 
-    private func fetchImage(from url: URL, forceRefresh: Bool, processor: ImageProcessor) async throws -> ImageDownloadResult {
+    public func fetchImage(with url: URL, forceRefresh: Bool = false, processingMethod: ImageProcessingMethod = .common()) async throws -> ImageDownloadResult {
         let request = URLRequest.imageRequest(url: url, forceRefresh: forceRefresh)
 
-        let client = self.client
+        if !forceRefresh, let entry = await imageCache.getEntry(with: url.absoluteString) {
+            switch entry {
+            case .inProgress(let task):
+                let image = try await task.value
+                return ImageDownloadResult(image: image, sourceURL: url)
+            case .ready(let image):
+                return ImageDownloadResult(image: image, sourceURL: url)
+            }
+        }
         let task = Task<UIImage, Error> {
+            try await fetchAndProcessImage(request: request, processor: processingMethod.processor)
+        }
+        await imageCache.setEntry(.inProgress(task), for: url.absoluteString)
+        let image: UIImage
+        do {
+            image = try await task.value
+        } catch {
+            await imageCache.setEntry(nil, for: url.absoluteString)
+            throw error
+        }
+        await imageCache.setEntry(.ready(image), for: url.absoluteString)
+        return ImageDownloadResult(image: image, sourceURL: url)
+    }
+
+    private func fetchAndProcessImage(request: URLRequest, processor: ImageProcessor) async throws -> UIImage {
+        do {
             let (data, _) = try await client.fetchData(with: request)
             guard let image = processor.process(data) else {
                 throw ImageFetchingError.imageProcessorFailed
             }
             return image
-        }
-
-        await imageCache.setEntry(.inProgress(task), for: url.absoluteString)
-
-        let image = try await getImage(from: task)
-        await imageCache.setEntry(.ready(image), for: url.absoluteString)
-        return ImageDownloadResult(image: image, sourceURL: url)
-    }
-
-    public func fetchImage(
-        with url: URL,
-        forceRefresh: Bool = false,
-        processingMethod: ImageProcessingMethod = .common()
-    ) async throws -> ImageDownloadResult {
-        if !forceRefresh, let image = try await cachedImage(for: url) {
-            return ImageDownloadResult(image: image, sourceURL: url)
-        }
-        return try await fetchImage(from: url, forceRefresh: forceRefresh, processor: processingMethod.processor)
-    }
-
-    private func cachedImage(for url: URL) async throws -> UIImage? {
-        guard let entry = await imageCache.getEntry(with: url.absoluteString) else {
-            return nil
-        }
-
-        switch entry {
-        case .inProgress(let task):
-            return try await getImage(from: task)
-        case .ready(let image):
-            return image
-        }
-    }
-
-    private func getImage(from task: Task<UIImage, Error>) async throws -> UIImage {
-        do {
-            let image = try await task.value
-            return image
         } catch let error as HTTPClientError {
             throw ImageFetchingError.responseError(reason: error.map())
+        } catch let error as ImageFetchingError {
+            throw error
         } catch {
             throw ImageFetchingError.responseError(reason: .unexpected(error))
+        }
+    }
+
+    public func cancelTask(for url: URL) async {
+        if let entry = await imageCache.getEntry(with: url.absoluteString) {
+            switch entry {
+            case .inProgress(let task):
+                if !task.isCancelled {
+                    task.cancel()
+                    await imageCache.setEntry(nil, for: url.absoluteString)
+                }
+            default:
+                break
+            }
         }
     }
 }

--- a/Sources/Gravatar/Network/Services/ImageDownloadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageDownloadService.swift
@@ -69,7 +69,6 @@ public struct ImageDownloadService: ImageDownloader, Sendable {
             case .inProgress(let task):
                 if !task.isCancelled {
                     task.cancel()
-                    await imageCache.setEntry(nil, for: url.absoluteString)
                 }
             default:
                 break

--- a/Sources/Gravatar/Network/Services/ImageDownloader.swift
+++ b/Sources/Gravatar/Network/Services/ImageDownloader.swift
@@ -16,4 +16,8 @@ public protocol ImageDownloader {
         forceRefresh: Bool,
         processingMethod: ImageProcessingMethod
     ) async throws -> ImageDownloadResult
+
+    /// Cancels the download task for the given `URL`.
+    /// - Parameter url: `URL` of the download task.
+    func cancelTask(for url: URL) async
 }

--- a/Sources/Gravatar/Options/ImageProcessorOption.swift
+++ b/Sources/Gravatar/Options/ImageProcessorOption.swift
@@ -4,7 +4,7 @@ import UIKit
 /// Enum defining methods for processing and transforming the image data into a UIImage instance.
 ///
 /// Each case represents a specific processing or transformation method that will be applied to the image data.
-public enum ImageProcessingMethod {
+public enum ImageProcessingMethod: Sendable {
     /// Apply a custom processor to the image data.
     /// - Parameter processor: An instance of a type conforming to `ImageProcessor`.
     case custom(processor: ImageProcessor)

--- a/Tests/GravatarTests/ImageDownloadServiceTests.swift
+++ b/Tests/GravatarTests/ImageDownloadServiceTests.swift
@@ -14,6 +14,82 @@ final class ImageDownloadServiceTests: XCTestCase {
         XCTAssertNotNil(imageResponse.image)
     }
 
+    func testFetchImageCancel() async throws {
+        let imageURL = try XCTUnwrap(URL(string: "https://gravatar.com/avatar/HASH"))
+        let response = HTTPURLResponse.successResponse(with: imageURL)
+        let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
+        await sessionMock.update(isCancellable: true)
+        let service = imageDownloadService(with: sessionMock)
+
+        let task1 = Task {
+            do {
+                let _ = try await service.fetchImage(with: imageURL)
+                XCTFail()
+            } catch ImageFetchingError.responseError(reason: .URLSessionError(error: let error)) {
+                XCTAssertNotNil(error as? CancellationError)
+            } catch {
+                XCTFail()
+            }
+        }
+
+        let task2 = Task {
+            try await Task.sleep(nanoseconds: UInt64(0.05 * 1_000_000_000))
+            await service.cancelTask(for: imageURL)
+        }
+
+        await task1.value
+        try await task2.value
+    }
+
+    func testCallAfterAFailedCallWorksFine() async throws {
+        let imageURL = try XCTUnwrap(URL(string: "https://gravatar.com/avatar/HASH"))
+        let response = HTTPURLResponse.successResponse(with: imageURL)
+        let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
+        await sessionMock.update(isCancellable: true)
+        let service = imageDownloadService(with: sessionMock)
+
+        let task1 = Task {
+            do {
+                let _ = try await service.fetchImage(with: imageURL)
+                XCTFail()
+            } catch ImageFetchingError.responseError(reason: .URLSessionError(error: let error)) {
+                XCTAssertNotNil(error as? CancellationError)
+            } catch {
+                XCTFail()
+            }
+        }
+
+        let task2 = Task {
+            try await Task.sleep(nanoseconds: UInt64(0.1 * 1_000_000_000))
+            await service.cancelTask(for: imageURL)
+        }
+
+        await task1.value
+        try await task2.value
+
+        // The task is cancelled, now we retry and it should succeed.
+        await sessionMock.update(isCancellable: false)
+        let result = try await service.fetchImage(with: imageURL)
+        XCTAssertNotNil(result.image)
+    }
+
+    func testImageProcessingError() async throws {
+        let imageURL = try XCTUnwrap(URL(string: "https://gravatar.com/avatar/HASH"))
+        let response = HTTPURLResponse.successResponse(with: imageURL)
+        let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
+        let cache = TestImageCache()
+        let service = imageDownloadService(with: sessionMock, cache: cache)
+
+        do {
+            _ = try await service.fetchImage(with: imageURL, processingMethod: .custom(processor: FailingImageProcessor()))
+            XCTFail()
+        } catch ImageFetchingError.imageProcessorFailed {
+            // success
+        } catch {
+            XCTFail()
+        }
+    }
+
     func testFetchCatchedImageWithURL() async throws {
         let imageURL = "https://gravatar.com/avatar/HASH"
         let response = HTTPURLResponse.successResponse(with: URL(string: imageURL)!)

--- a/Tests/GravatarTests/TestImageCache.swift
+++ b/Tests/GravatarTests/TestImageCache.swift
@@ -8,7 +8,11 @@ actor TestImageCache: ImageCaching {
     private(set) var setImageCallsCount = 0
     private(set) var setTaskCallsCount = 0
 
-    func setEntry(_ entry: Gravatar.CacheEntry, for key: String) async {
+    func setEntry(_ entry: Gravatar.CacheEntry?, for key: String) async {
+        guard let entry else {
+            dict[key] = nil
+            return
+        }
         switch entry {
         case .inProgress:
             setTaskCallsCount += 1

--- a/Tests/GravatarTests/TestImageProcessor.swift
+++ b/Tests/GravatarTests/TestImageProcessor.swift
@@ -13,3 +13,9 @@ final class TestImageProcessor: ImageProcessor {
         return image
     }
 }
+
+final class FailingImageProcessor: ImageProcessor {
+    func process(_: Data) -> UIImage? {
+        nil
+    }
+}

--- a/Tests/GravatarTests/URLSessionMock.swift
+++ b/Tests/GravatarTests/URLSessionMock.swift
@@ -12,6 +12,7 @@ actor URLSessionMock: URLSessionProtocol {
     let returnData: Data
     let response: HTTPURLResponse
     let error: NSError?
+    var isCancellable: Bool = false
     private(set) var callsCount = 0
     private(set) var request: URLRequest? = nil
     private(set) var uploadData: Data? = nil
@@ -29,6 +30,12 @@ actor URLSessionMock: URLSessionProtocol {
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         callsCount += 1
         self.request = request
+        if isCancellable {
+            for _ in 0 ... 100 {
+                try await Task.sleep(nanoseconds: UInt64(0.05 * 1_000_000_000))
+                try Task.checkCancellation()
+            }
+        }
         if let error {
             throw error
         }
@@ -46,5 +53,9 @@ actor URLSessionMock: URLSessionProtocol {
 
     func update(request: URLRequest) async {
         self.request = request
+    }
+
+    func update(isCancellable: Bool) async {
+        self.isCancellable = isCancellable
     }
 }

--- a/Tests/GravatarUITests/TestImageCache.swift
+++ b/Tests/GravatarUITests/TestImageCache.swift
@@ -8,7 +8,11 @@ actor TestImageCache: ImageCaching {
     private(set) var setImageCallsCount = 0
     private(set) var setTaskCallsCount = 0
 
-    func setEntry(_ entry: Gravatar.CacheEntry, for key: String) async {
+    func setEntry(_ entry: Gravatar.CacheEntry?, for key: String) async {
+        guard let entry else {
+            dict[key] = nil
+            return
+        }
         switch entry {
         case .inProgress:
             setTaskCallsCount += 1

--- a/Tests/GravatarUITests/TestImageFetcher.swift
+++ b/Tests/GravatarUITests/TestImageFetcher.swift
@@ -25,4 +25,6 @@ class TestImageFetcher: ImageDownloader {
         }
         return try await task.value
     }
+
+    func cancelTask(for url: URL) async {}
 }

--- a/Tests/GravatarUITests/URLSessionMock.swift
+++ b/Tests/GravatarUITests/URLSessionMock.swift
@@ -12,6 +12,7 @@ actor URLSessionMock: URLSessionProtocol {
     let returnData: Data
     let response: HTTPURLResponse
     let error: NSError?
+    var isCancellable: Bool = false
     private(set) var callsCount = 0
     private(set) var request: URLRequest? = nil
     private(set) var uploadData: Data? = nil
@@ -29,6 +30,12 @@ actor URLSessionMock: URLSessionProtocol {
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         callsCount += 1
         self.request = request
+        if isCancellable {
+            for _ in 0 ... 100 {
+                try await Task.sleep(nanoseconds: UInt64(0.05 * 1_000_000_000))
+                try Task.checkCancellation()
+            }
+        }
         if let error {
             throw error
         }
@@ -46,5 +53,9 @@ actor URLSessionMock: URLSessionProtocol {
 
     func update(request: URLRequest) async {
         self.request = request
+    }
+
+    func update(isCancellable: Bool) async {
+        self.isCancellable = isCancellable
     }
 }


### PR DESCRIPTION
Closes #

### Description
 
AFAIU image download cancelling mechanism was broken by https://github.com/Automattic/Gravatar-SDK-iOS/pull/232.

Problem 1:

Cancelling an outer Task doesn't automatically cancel the Tasks created internally. We need to hold those tasks and cancel. Luckily we already hold those tasks in the cache now.

Problem 2:

If a download task fails for some reason it is stuck in the cache as "inProgress", and consequent calls with the same url never succeeds. We should remove the cache entry if the network call is not a success.

Problem 3.

The "imageProcessorFailed" error was not thrown as is but wrapped into .unexpected.

### Testing Steps

Demo app > UIImageView extension
Cancelling an ongoing task should work.
Retrying the cancelled download should also work("Ignore Cache" option needs to be unchecked to test this otherwise there's no bug).
