### PR TITLE
Fix "'isGravatarDynamicFontSizeEnabled' is not concurrency-safe" warning

### DIFF
--- a/Sources/GravatarUI/DesignSystem/UIFont+DesignSystem.swift
+++ b/Sources/GravatarUI/DesignSystem/UIFont+DesignSystem.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 
+@MainActor
 extension UIFont {
     /// Whether to adjust the font size according to the system's font size settings. Default: `true`.
     public static var isGravatarDynamicFontSizeEnabled: Bool = true
@@ -8,6 +9,7 @@ extension UIFont {
     // Point values noted here comes from the "Large (Default)" column of the
     // Specification: https://developer.apple.com/design/human-interface-guidelines/typography#Specifications
     // Note: These are dynamic sized fonts so the real size will vary.
+    @MainActor
     enum DS {
         static var largeTitle: UIFont { DynamicFontHelper.font(forTextStyle: .largeTitle, weight: .bold) } // 34pt
         static var title1: UIFont { DynamicFontHelper.font(forTextStyle: .title1, weight: .bold) } // 28pt
@@ -15,12 +17,14 @@ extension UIFont {
         static var title3: UIFont { DynamicFontHelper.font(forTextStyle: .title3, weight: .semibold) } // 20pt
         static var headline: UIFont { DynamicFontHelper.font(forTextStyle: .headline, weight: .bold) } // 17pt
 
+        @MainActor
         enum Body {
             static var large: UIFont { DynamicFontHelper.font(forTextStyle: .body, weight: .regular) } // 17pt
             static var medium: UIFont { DynamicFontHelper.font(forTextStyle: .callout, weight: .regular) } // 16pt
             static var small: UIFont { DynamicFontHelper.font(forTextStyle: .subheadline, weight: .regular) } // 15pt
             static var xSmall: UIFont { DynamicFontHelper.font(forTextStyle: .footnote, weight: .regular) } // 13pt
 
+            @MainActor
             enum Emphasized {
                 static var large: UIFont { DynamicFontHelper.font(forTextStyle: .body, weight: .semibold) } // 17pt
                 static var medium: UIFont { DynamicFontHelper.font(forTextStyle: .callout, weight: .semibold) } // 16pt
@@ -34,6 +38,7 @@ extension UIFont {
 }
 
 private enum DynamicFontHelper {
+    @MainActor
     static func font(forTextStyle style: UIFont.TextStyle, weight: UIFont.Weight) -> UIFont {
         var fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
         let traits = [UIFontDescriptor.TraitKey.weight: weight]


### PR DESCRIPTION
Closes part of #136 

### Description

Fixes this warning:

<img width="1295" alt="Screenshot 2024-06-04 at 13 14 28" src="https://github.com/Automattic/Gravatar-SDK-iOS/assets/5032900/99b19f85-0025-4e97-aa8a-b7bd7e215880">

### Testing Steps

CI green.