### PR TITLE
Update ProfileServiceError & Cleanup ProfileService

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoProfileConfigurationViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoProfileConfigurationViewController.swift
@@ -77,7 +77,7 @@ class DemoProfileConfigurationViewController: UITableViewController {
             models[email] = .standard(model: profile)
             snapshot.reloadItems([email])
             await dataSource.apply(snapshot)
-        } catch ProfileServiceError.responseError(let reason) where reason.httpStatusCode == 404 {
+        } catch APIError.responseError(let reason) where reason.httpStatusCode == 404 {
             models[email] = ProfileView.claimProfileConfiguration()
             snapshot.reloadItems([email])
             await dataSource.apply(snapshot)

--- a/Demo/Demo/Gravatar-Demo/DemoProfileViewsViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoProfileViewsViewController.swift
@@ -102,7 +102,7 @@ class DemoProfileViewsViewController: DemoBaseProfileViewController {
                 profileSummaryView.update(with: profile)
                 profileSummaryView.profileButtonStyle = .view
                 profileSummaryView.loadAvatar(with: profile.avatarIdentifier, options: [.transition(.fade(0.2))])
-            } catch ProfileServiceError.responseError(reason: let reason) where reason.httpStatusCode == 404 {
+            } catch APIError.responseError(reason: let reason) where reason.httpStatusCode == 404 {
                 largeProfileView.updateWithClaimProfilePrompt()
                 largeProfileSummaryView.updateWithClaimProfilePrompt()
                 profileView.updateWithClaimProfilePrompt()

--- a/Sources/Gravatar/Network/Data+Extension.swift
+++ b/Sources/Gravatar/Network/Data+Extension.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension Data {
+    func decode<T: Decodable>(dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .iso8601) throws -> T {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = dateDecodingStrategy
+        let result = try decoder.decode(T.self, from: self)
+        return result
+    }
+}

--- a/Sources/Gravatar/Network/Error+Extension.swift
+++ b/Sources/Gravatar/Network/Error+Extension.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension Error {
+    func apiError() -> APIError {
+        switch self {
+        case let error as HTTPClientError:
+            APIError.responseError(reason: error.map())
+        case let error as DecodingError:
+            APIError.decodingError(error)
+        case let error:
+            APIError.responseError(reason: .unexpected(error))
+        }
+    }
+}

--- a/Sources/Gravatar/Network/Errors.swift
+++ b/Sources/Gravatar/Network/Errors.swift
@@ -11,7 +11,7 @@ public enum ResponseErrorReason: Sendable {
     /// The response is not a `HTTPURLResponse`.
     case invalidURLResponse(response: URLResponse)
 
-    /// An unexpected error has ocurred.
+    /// An unexpected error has occurred.
     case unexpected(Error)
 
     // `true` if self is a `.invalidHTTPStatusCode`.
@@ -76,21 +76,22 @@ public enum ImageUploadError: Error {
     case responseError(reason: ResponseErrorReason)
 }
 
-public enum ProfileServiceError: Error {
+public enum APIError: Error {
     case requestError(reason: RequestErrorReason)
     case responseError(reason: ResponseErrorReason)
-    case noProfileInResponse
+    /// Error occurred while decoding the response.
+    case decodingError(DecodingError)
 }
 
-extension ProfileServiceError: CustomDebugStringConvertible {
+extension APIError: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
         case .responseError(let reason):
             "A response error has occoured with reason: \(reason)"
         case .requestError(let reason):
             "Something went wrong when creating the request. Reason: \(reason)."
-        case .noProfileInResponse:
-            "No profile information was found in the response."
+        case .decodingError(let error):
+            "Something went while decoding the response. Underlying error: \(error)"
         }
     }
 }

--- a/Sources/Gravatar/Network/Errors.swift
+++ b/Sources/Gravatar/Network/Errors.swift
@@ -91,7 +91,7 @@ extension APIError: CustomDebugStringConvertible {
         case .requestError(let reason):
             "Something went wrong when creating the request. Reason: \(reason)."
         case .decodingError(let error):
-            "Something went while decoding the response. Underlying error: \(error)"
+            "Something went wrong while decoding the response. Underlying error: \(error)"
         }
     }
 }

--- a/Sources/Gravatar/Network/Services/ProfileService.swift
+++ b/Sources/Gravatar/Network/Services/ProfileService.swift
@@ -2,11 +2,6 @@ import Foundation
 
 private let baseURL = URL(string: "https://api.gravatar.com/v3/profiles/")!
 
-public enum GravatarProfileFetchResult: Sendable {
-    case success(Profile)
-    case failure(ProfileServiceError)
-}
-
 /// A service to perform Profile related tasks.
 ///
 /// By default, the ``Profile`` instance returned by ``fetch(with:)`` will contain only a subset of the abailable information.
@@ -23,23 +18,6 @@ public struct ProfileService: ProfileFetching, Sendable {
         self.client = client ?? URLSessionHTTPClient()
     }
 
-    /// Fetches a Gravatar user's profile information.
-    /// - Parameters:
-    ///   - profileID: A `ProfileIdentifier` for the Gravatar profile
-    ///   - onCompletion: The completion handler to call when the fetch request is complete.
-    public func fetchProfile(with profileID: ProfileIdentifier, onCompletion: @Sendable @escaping (_ result: GravatarProfileFetchResult) -> Void) {
-        Task {
-            do {
-                let profile = try await fetch(with: profileID)
-                onCompletion(.success(profile))
-            } catch let error as ProfileServiceError {
-                onCompletion(.failure(error))
-            } catch {
-                onCompletion(.failure(.responseError(reason: .unexpected(error))))
-            }
-        }
-    }
-
     public func fetch(with profileID: ProfileIdentifier) async throws -> Profile {
         let url = baseURL.appending(pathComponent: profileID.id)
         let request = await URLRequest(url: url).authorized()
@@ -50,33 +28,11 @@ public struct ProfileService: ProfileFetching, Sendable {
 extension ProfileService {
     private func fetch(with request: URLRequest) async throws -> Profile {
         do {
-            let (data, response) = try await client.fetchData(with: request)
-            let profileResult: Result<Profile, ProfileServiceError> = map(data, response)
-            switch profileResult {
-            case .success(let success):
-                return success
-            case .failure(let failure):
-                throw failure
-            }
-        } catch let error as HTTPClientError {
-            throw ProfileServiceError.responseError(reason: error.map())
-        }
-    }
-
-    private func map(_ data: Data, _: HTTPURLResponse) -> Result<Profile, ProfileServiceError> {
-        do {
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            let profile = try decoder.decode(Profile.self, from: data)
-            return .success(profile)
-        } catch let error as HTTPClientError {
-            return .failure(.responseError(reason: error.map()))
-        } catch let error as ProfileServiceError {
-            return .failure(error)
-        } catch _ as DecodingError {
-            return .failure(.noProfileInResponse)
+            let (data, _) = try await client.fetchData(with: request)
+            let profileResult: Profile = try data.decode()
+            return profileResult
         } catch {
-            return .failure(.responseError(reason: .unexpected(error)))
+            throw error.apiError()
         }
     }
 }

--- a/Sources/GravatarUI/ProfileViewController/ProfileViewController.swift
+++ b/Sources/GravatarUI/ProfileViewController/ProfileViewController.swift
@@ -14,7 +14,7 @@ public class ProfileViewController: UIViewController {
 
     private var cancellables = Set<AnyCancellable>()
     private var profileIdentifier: ProfileIdentifier?
-    public var profileFetchingErrorHandler: ((ProfileServiceError) -> Void)?
+    public var profileFetchingErrorHandler: ((APIError) -> Void)?
 
     public let scrollView: UIScrollView = .init()
 

--- a/Sources/GravatarUI/ProfileViewController/ProfileViewModel.swift
+++ b/Sources/GravatarUI/ProfileViewController/ProfileViewModel.swift
@@ -4,7 +4,7 @@ import Gravatar
 @MainActor
 public class ProfileViewModel {
     @Published public private(set) var isLoading: Bool = false
-    @Published public private(set) var profileFetchingResult: Result<Profile, ProfileServiceError>?
+    @Published public private(set) var profileFetchingResult: Result<Profile, APIError>?
     private let profileService: ProfileService
 
     public init(profileService: ProfileService = ProfileService()) {
@@ -18,7 +18,7 @@ public class ProfileViewModel {
         do {
             isLoading = true
             profileFetchingResult = try await .success(profileService.fetch(with: profileIdentifier))
-        } catch let error as ProfileServiceError {
+        } catch let error as APIError {
             profileFetchingResult = .failure(error)
         } catch {
             profileFetchingResult = .failure(.responseError(reason: .unexpected(error)))

--- a/Tests/GravatarTests/AvatarServiceTests.swift
+++ b/Tests/GravatarTests/AvatarServiceTests.swift
@@ -51,7 +51,7 @@ final class AvatarServiceTests: XCTestCase {
             try await service.upload(ImageHelper.testImage, email: Email("some@email.com"), accessToken: "AccessToken")
             XCTFail("This should throw an error")
         } catch ImageUploadError.responseError(reason: let reason) where reason.httpStatusCode == responseCode {
-            // Expected error has ocurred.
+            // Expected error has occurred.
         } catch {
             XCTFail("This should have thrown an invalidHTTPStatusCode with:\(responseCode)")
         }

--- a/Tests/GravatarUITests/ProfileViewModelTests.swift
+++ b/Tests/GravatarUITests/ProfileViewModelTests.swift
@@ -38,7 +38,7 @@ final class ProfileViewModelTests: XCTestCase {
     @MainActor
     func testProfileFetchingResultUpdatesOnSuccess() async throws {
         let viewModel = ProfileViewModel(profileService: successfulService())
-        var states: [Result<Profile, ProfileServiceError>?] = []
+        var states: [Result<Profile, APIError>?] = []
         viewModel.$profileFetchingResult.sink { result in
             states.append(result)
         }.store(in: &cancellables)
@@ -51,7 +51,7 @@ final class ProfileViewModelTests: XCTestCase {
     @MainActor
     func testProfileFetchingResultUpdatesOnFailure() async throws {
         let viewModel = ProfileViewModel(profileService: failingService())
-        var states: [Result<Profile, ProfileServiceError>?] = []
+        var states: [Result<Profile, APIError>?] = []
         viewModel.$profileFetchingResult.sink { result in
             states.append(result)
         }.store(in: &cancellables)


### PR DESCRIPTION
Closes #266 

### Description

Updates these things in ProfileService:

- Updated ProfileServiceError to APIError, since it applies to all potential REST calls not just to the ProfileService. 
- Replaced "noProfileInResponse" with "decodingError".
- Removed some unnecessary and buggy result mapping code from ProfileService.
- Removed the compilation handler method in the ProfileService. Just for sake of less code.
- Added some unit tests for error cases.

### Testing Steps

Demo app > Fetch Profile
