### PR TITLE
Remove the task from the cache when cancelled

### DIFF
--- a/Sources/Gravatar/Network/Services/ImageDownloadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageDownloadService.swift
@@ -79,6 +79,7 @@ public struct ImageDownloadService: ImageDownloader, Sendable {
             case .inProgress(let task):
                 if !task.isCancelled {
                     task.cancel()
+                    await imageCache.setEntry(nil, for: url.absoluteString)
                 }
             default:
                 break

--- a/Tests/GravatarTests/ImageDownloadServiceTests.swift
+++ b/Tests/GravatarTests/ImageDownloadServiceTests.swift
@@ -20,7 +20,8 @@ final class ImageDownloadServiceTests: XCTestCase {
         let response = HTTPURLResponse.successResponse(with: imageURL)
         let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
         await sessionMock.update(isCancellable: true)
-        let service = imageDownloadService(with: sessionMock)
+        let cache = TestImageCache()
+        let service = imageDownloadService(with: sessionMock, cache: cache)
 
         let task1 = Task {
             do {
@@ -28,6 +29,8 @@ final class ImageDownloadServiceTests: XCTestCase {
                 XCTFail()
             } catch ImageFetchingError.responseError(reason: .URLSessionError(error: let error)) {
                 XCTAssertNotNil(error as? CancellationError)
+                let entry = await cache.getEntry(with: imageURL.absoluteString)
+                XCTAssertNil(entry)
             } catch {
                 XCTFail()
             }


### PR DESCRIPTION
Closes #

### Description

I bumped into a bug while testing the WP side. There, the existing download is [cancelled](https://github.com/wordpress-mobile/WordPress-iOS/blob/fb271448cf9231aaae2cbc8862f92e3e8ddde3c8/WordPress/Classes/ViewRelated/Gravatar/UIImageView%2BGravatar.swift#L61) before each download attempt. Even though it's not necessary to do that it should work fine(especially after the CacheEntry.inProgress option no one needs to worry about multiple requests for the same URL but that's a separate topic). 

Anyway, I come across with a screen where the avatar remained empty and all download attempts resulted in "cancelled". I think it can be because we don't remove the task from the cache when cancelling it, so next time we try to download the same image it tries to await a cancelled task, which then results in a cancelled error to be thrown. But it is not easy to reproduce and I was able to repro the issue only in post revisions page. (somehow that page attempts to download the image multiple times even if there's only 1 cell, I guess the tableview is reloaded multiple times).

### Testing Steps

Let's first try to reproduce the issue:

Checkout this PR https://github.com/wordpress-mobile/WordPress-iOS/pull/23320
Login to Jetpack app
Go to Posts > Open one of your posts
Use the ... on the top to open the menu
Tap on the Revisions item
(If you don't see Revisions there it means you didn't edit the file yet. In that case edit and publish the post. Then check again.)

<img src="https://github.com/Automattic/Gravatar-SDK-iOS/assets/5032900/ab862a14-afce-44b7-be50-667163b7613a" width=300/> 

The avatar remains empty. (I am not sure how consistent you can repro the issue though. I suspect that it's a race condition)

Now point Gravatar SDK to the latest commit from this PR and test it again. The avatar should load fine.
