### PR TITLE
Add `@discardableResult` to `setImage(with source: URL?, ...)`

### DIFF
--- a/Sources/GravatarUI/GravatarCompatibleUI/UIImageView+Gravatar.swift
+++ b/Sources/GravatarUI/GravatarCompatibleUI/UIImageView+Gravatar.swift
@@ -164,6 +164,7 @@ extension GravatarWrapper where Component: UIImageView {
     ///   - placeholder: A placeholder to show while downloading the image.
     ///   - options: A set of options to define image setting behaviour. See ``ImageSettingOption`` for more info.
     /// - Returns: The ``ImageDownloadResult``.
+    @discardableResult
     public func setImage(
         with source: URL?,
         placeholder: UIImage? = nil,

--- a/Sources/GravatarUI/ProfileView/Avatar/DefaultAvatarProvider.swift
+++ b/Sources/GravatarUI/ProfileView/Avatar/DefaultAvatarProvider.swift
@@ -105,7 +105,7 @@ class DefaultAvatarProvider: AvatarProviding {
     }
 
     func setImage(with source: URL?, placeholder: UIImage?, options: [ImageSettingOption]?) async throws {
-        let _ = try await avatarImageView.gravatar.setImage(with: source, placeholder: placeholder, options: options)
+        try await avatarImageView.gravatar.setImage(with: source, placeholder: placeholder, options: options)
     }
 
     func setImage(_ image: UIImage?) {

--- a/Tests/GravatarUITests/GravatarWrapper+UIImageViewTests.swift
+++ b/Tests/GravatarUITests/GravatarWrapper+UIImageViewTests.swift
@@ -74,7 +74,7 @@ final class GravatarWrapper_UIImageViewTests: XCTestCase {
         let imageView = UIImageView(frame: frame)
         let imageRetriever = TestImageFetcher(result: .fail)
         do {
-            let _ = try await imageView.gravatar.setImage(
+            try await imageView.gravatar.setImage(
                 with: nil,
                 placeholder: ImageHelper.placeholderImage,
                 options: [.imageDownloader(imageRetriever)]
@@ -168,7 +168,7 @@ final class GravatarWrapper_UIImageViewTests: XCTestCase {
 
         let task1 = Task {
             do {
-                let _ = try await imageView.gravatar.setImage(
+                try await imageView.gravatar.setImage(
                     with: URL(string: "https://first.com"),
                     options: [.imageDownloader(imageDownloader)]
                 )


### PR DESCRIPTION
Closes #

### Description

Let's add `@discardableResult` here too since the result is in fact discardable. The other public method ( `setImage(
        avatarID:...)`) already has it.

### Testing Steps

CI green.