### PR TITLE
Remove TestHelpers dependency from GravatarUI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
         ),
         .target(
             name: "GravatarUI",
-            dependencies: ["Gravatar", "TestHelpers"],
+            dependencies: ["Gravatar"],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency")
             ]


### PR DESCRIPTION
This PR removes `TestHelpers` dependency from `GravatarUI` that was breaking release builds because of the following `@testable` import:

```
@testable import Gravatar

extension ImageDownloadService {
    static func mock(with session: URLSessionProtocol, cache: ImageCaching? = nil) -> ImageDownloadService {
        let client = URLSessionHTTPClient(urlSession: session)
        let service = ImageDownloadService(client: client, cache: cache)
        return service
    }
}
```

Error:

```
<head></head>
❌ /opt/ci/builds/builder/automattic/wordpress-ios/DerivedData/SourcePackages/checkouts/Gravatar-SDK-iOS/Sources/TestHelpers/ImageDownloadService+Extension.swift:1:18: module 'Gravatar' was not compiled for testing
--
  | @testable import Gravatar
```

**Note**: required for WP-iOS migration to SPM 🙇 
