### PR TITLE
Remove TestHelpers dependency from GravatarUI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
         ),
         .target(
             name: "GravatarUI",
-            dependencies: ["Gravatar", "TestHelpers"],
+            dependencies: ["Gravatar"],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency")
             ]

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 module Gravatar
-    VERSION = '2.0.1'.freeze
+    VERSION = '2.0.2'.freeze
 end


### PR DESCRIPTION
### Description

Copying https://github.com/Automattic/Gravatar-SDK-iOS/pull/298 to target release branch.

### Testing Steps

CI green.