### PR TITLE
Fix docc deploy to GH pages

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -25,7 +25,7 @@ jobs:
       # Must be set to this for deploying to GitHub Pages
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -3,7 +3,7 @@ name: Deploy Gravatar DocC
 on:
   # Runs on pushes and PRs targeting the default branch
   push:
-    branches: [ "trunk", "etoledom/gh-docs" ]
+    branches: [ "trunk" ]
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -3,7 +3,7 @@ name: Deploy Gravatar DocC
 on:
   # Runs on pushes and PRs targeting the default branch
   push:
-    branches: [ "trunk" ]
+    branches: [ "trunk", "etoledom/gh-docs" ]
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
       - name: Switch Xcode 🔄
-        run: sudo xcode-select --switch /Applications/Xcode_15.0.app
+        run: sudo xcode-select --switch /Applications/Xcode_15.4.app
       - name: Build Gravatar DocC
         run: |
           xcodebuild docbuild -scheme Gravatar \

--- a/.spi.yml
+++ b/.spi.yml
@@ -6,6 +6,6 @@
 version: 1
 builder:
     configs:
-    - documentation_targets: [Gravatar, GravatarUI]
+    - documentation_targets: [Gravatar]
       platform: ios
       custom_documentation_parameters: [--include-extended-types]


### PR DESCRIPTION
### Description

Updating macos and xcode to use swift v5.10

**Note**: `"etoledom/gh-docs"` needs to be removed before merge

### Testing Steps
