### PR TITLE
Fix SwiftFormat Warnings

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,3 +1,5 @@
+--swiftversion 5.10
+
 ## File options
 
 --exclude .build,**/*.docc/**

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,3 +1,8 @@
+## Swift version
+
+# Some rules are applicable only to newer versions of Swift.
+# Any rules applicable to Swift versions that are newer than the version
+# specified here will be disabled.
 --swiftversion 5.10
 
 ## File options

--- a/Gravatar.podspec
+++ b/Gravatar.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   }
   s.documentation_url = 'https://automattic.github.io/Gravatar-SDK-iOS/'
     
-  s.swift_version     = Gravatar::SWIFT_VERSION
+  s.swift_versions    = Gravatar::SWIFT_VERSIONS
 
   ios_deployment_target = '15.0'
 

--- a/GravatarUI.podspec
+++ b/GravatarUI.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     }
     s.documentation_url = 'https://automattic.github.io/Gravatar-SDK-iOS/'
       
-    s.swift_version     = Gravatar::SWIFT_VERSION
+    s.swift_versions    = Gravatar::SWIFT_VERSIONS
     
     ios_deployment_target = '15.0'
     s.ios.deployment_target = ios_deployment_target

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 #   % make help
 
 # Cache
+# No spaces allowed
 SWIFTFORMAT_CACHE = ~/Library/Caches/com.charcoaldesign.swiftformat
 
 # The following values can be changed here, or passed on the command line.
@@ -52,13 +53,13 @@ bundle-install:
 swiftformat: # Automatically find and fixes lint issues
 	swift package plugin \
 		--allow-writing-to-package-directory \
-		--allow-writing-to-directory "$(SWIFTFORMAT_CACHE)" \
+		--allow-writing-to-directory $(SWIFTFORMAT_CACHE) \
 		swiftformat
 
 lint: # Use swiftformat to warn about format issues
 	swift package plugin \
 		--allow-writing-to-package-directory \
-		--allow-writing-to-directory "$(SWIFTFORMAT_CACHE)" \
+		--allow-writing-to-directory $(SWIFTFORMAT_CACHE) \
 		swiftformat \
 		--lint
 

--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,7 @@ let package = Package(
         .target(
             name: "GravatarUI",
             dependencies: ["Gravatar"],
+            resources: [.process("Resources")],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency")
             ]

--- a/version.rb
+++ b/version.rb
@@ -1,4 +1,6 @@
 module Gravatar
     VERSION = '2.0.2'.freeze
-    SWIFT_VERSION = '5.10'.freeze
+    SWIFT_VERSIONS = [
+        '5.10'
+    ].freeze
 end


### PR DESCRIPTION
Closes #306

### Description

This resolves a few warnings that are appearing in the output of running `swiftformat`  (see issue #306)

#### Where should we record the version?
SwiftFormat wants us to specify the version of Swift to use ([SwiftFormat docs](https://github.com/nicklockwood/SwiftFormat?tab=readme-ov-file#swift-version)).  It prefers to find that version in a `.swift-version` file.  But we removed it in #285 .  In this PR, I've moved that into the `.swiftformat` file.  But I worry about missing this configuration setting the next time we update the version of Swift.

Thoughts?  Perhaps this is a good reason to create documentation around the process of updating Xcode.  If we did that, keeping this setting in the `.swiftformat` file would be a safe choice.

### Testing Steps
- [ ] Run `make swiftformat` and observe that there are no warnings (see issue #306 for examples)
- [ ] Run `make lint` and observe that there are no warnings there either