### PR TITLE
Fix errors on xcode_16 with swift 6

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoFetchProfileViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoFetchProfileViewController.swift
@@ -64,7 +64,9 @@ class DemoFetchProfileViewController: UIViewController {
         title = "Fetch Profile"
         view.backgroundColor = .white
 
-        [segmentedControl, emailField, fetchProfileButton, activityIndicator, profileTextView].forEach(rootStackView.addArrangedSubview)
+        for view in [segmentedControl, emailField, fetchProfileButton, activityIndicator, profileTextView] {
+            rootStackView.addArrangedSubview(view)
+        }
         view.addSubview(rootStackView)
 
         NSLayoutConstraint.activate([

--- a/Demo/Demo/Gravatar-Demo/DemoProfilePresentationStylesViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoProfilePresentationStylesViewController.swift
@@ -22,7 +22,9 @@ class DemoProfilePresentationStylesViewController: DemoBaseProfileViewController
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Profile View Controller"
-        [emailField, profileStylesButton, paletteButton, customizeAvatarSwitchWithLabel, showBottomSheetButton].forEach(rootStackView.addArrangedSubview)
+        for view in [emailField, profileStylesButton, paletteButton, customizeAvatarSwitchWithLabel, showBottomSheetButton] {
+            rootStackView.addArrangedSubview(view)
+        }
         rootStackView.alignment = .center
     }
     

--- a/Demo/Demo/Gravatar-Demo/DemoProfileViewsViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoProfileViewsViewController.swift
@@ -63,7 +63,9 @@ class DemoProfileViewsViewController: DemoBaseProfileViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Fetch Profile"
-        [emailField, paletteButton, fetchProfileButton, activityIndictorSwitchWithLabel, largeProfileView, largeProfileSummaryView, profileView, profileSummaryView].forEach(rootStackView.addArrangedSubview)
+        for view in [emailField, paletteButton, fetchProfileButton, activityIndictorSwitchWithLabel, largeProfileView, largeProfileSummaryView, profileView, profileSummaryView] {
+            rootStackView.addArrangedSubview(view)
+        }
     }
     
     @objc func toggleLoadingState() {

--- a/Demo/Demo/Gravatar-Demo/DemoUploadImageViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoUploadImageViewController.swift
@@ -73,7 +73,9 @@ class DemoUploadImageViewController: UIViewController {
         title = "Upload Image"
         view.backgroundColor = .white
 
-        [emailField, tokenField, selectImageButton, avatarImageView, uploadImageButton, activityIndicator, resultLabel].forEach(rootStackView.addArrangedSubview)
+        for view in [emailField, tokenField, selectImageButton, avatarImageView, uploadImageButton, activityIndicator, resultLabel] {
+            rootStackView.addArrangedSubview(view)
+        }
         view.addSubview(rootStackView)
 
         NSLayoutConstraint.activate([

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -4,7 +4,7 @@ import UIKit
 /// A service to perform uploading and downloading of avatars.
 ///
 /// An avatar is a profile image of a Gravatar user. See [the avatar docs](https://support.gravatar.com/profiles/avatars/) for more info.
-public struct AvatarService {
+public struct AvatarService: Sendable {
     private let imageDownloader: ImageDownloader
     private let imageUploader: ImageUploader
 

--- a/Sources/Gravatar/Network/Services/ImageUploader.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploader.swift
@@ -3,7 +3,7 @@ import UIKit
 typealias HTTPHeaderField = (name: String, value: String)
 
 /// Represents a type which can be used by Gravatar to upload an  image to Gravatar.
-protocol ImageUploader {
+protocol ImageUploader: Sendable {
     /// Uploads an image to be used as the user's Gravatar profile image, and returns the `URLResponse` of the network tasks asynchronously. Throws
     /// `ImageUploadError`.
     /// - Parameters:

--- a/Sources/GravatarUI/ProfileView/BaseProfileView.swift
+++ b/Sources/GravatarUI/ProfileView/BaseProfileView.swift
@@ -487,6 +487,7 @@ open class BaseProfileView: UIView, UIContentView {
 }
 
 /// Methods for managing actions on the profile view.
+@MainActor
 public protocol ProfileViewDelegate: NSObjectProtocol {
     /// Tells the delegate that the profile action button of the view has been tapped.
     ///

--- a/Tests/GravatarUITests/ProfileButtonsActionsTests.swift
+++ b/Tests/GravatarUITests/ProfileButtonsActionsTests.swift
@@ -3,10 +3,10 @@ import SnapshotTesting
 import XCTest
 
 final class ProfileViewActionsTests: XCTestCase {
-    var delegate = TestProfileViewDelegate()
+    var delegate: TestProfileViewDelegate!
 
     override func setUp() async throws {
-        delegate = TestProfileViewDelegate()
+        delegate = await TestProfileViewDelegate()
     }
 
     @MainActor
@@ -93,7 +93,7 @@ final class ProfileViewActionsTests: XCTestCase {
     }
 }
 
-class TestProfileViewDelegate: NSObject, ProfileViewDelegate {
+class TestProfileViewDelegate: NSObject, ProfileViewDelegate, Sendable {
     var profileButtonActions: [(style: ProfileButtonStyle, url: URL?)] = []
     var accountButtonActions: [AccountModel] = []
 


### PR DESCRIPTION
Closes #

### Description

This PR fixes some errors on Xcode 16, when it's set to build Swift 6.

### Testing Steps

- Using Xcode 16 beta 2
- Open the demo project
- Set `// swift-tools-version: 6.0` on `Package.swift`
- Set `Swift Language Version: Swift 6` On the demo project's Build Settings.
- Build
- Check that there are no warnings or errors.
