### PR TITLE
Create "Generate Secrets.swift" Build Phase script

### DIFF
--- a/.buildkite/commands/build-demos.sh
+++ b/.buildkite/commands/build-demos.sh
@@ -3,9 +3,6 @@
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
-echo "--- Generate Secrets.swift source file"
-make secrets
-
 echo "--- 🛠 Building Demo (Swift)"
 bundle exec fastlane build_demo scheme:Gravatar-Demo
 

--- a/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
@@ -281,7 +281,6 @@
 /* Begin PBXShellScriptBuildPhase section */
 		49920BD82C3D93E6009E8DCF /* Generate Secrets.swift */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 495775F02B5B34980082812A /* Build configuration list for PBXNativeTarget "Gravatar-Demo" */;
 			buildPhases = (
+				49920BD82C3D93E6009E8DCF /* Generate Secrets.swift */,
 				495775DB2B5B34970082812A /* Sources */,
 				495775DC2B5B34970082812A /* Frameworks */,
 				495775DD2B5B34970082812A /* Resources */,
@@ -276,6 +277,29 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		49920BD82C3D93E6009E8DCF /* Generate Secrets.swift */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/../Makefile",
+			);
+			name = "Generate Secrets.swift";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/Demo/Gravatar-Demo/Secrets.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cd \"${SRCROOT}/../\"\nmake secrets\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		495775DB2B5B34970082812A /* Sources */ = {

--- a/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
@@ -281,13 +281,13 @@
 /* Begin PBXShellScriptBuildPhase section */
 		49920BD82C3D93E6009E8DCF /* Generate Secrets.swift */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/../Makefile",
 			);
 			name = "Generate Secrets.swift";
 			outputFileListPaths = (
@@ -297,7 +297,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"${SRCROOT}/../\"\nmake secrets\n";
+			shellScript = "SECRETS_PATH=\"${SRCROOT}/Demo/Gravatar-Demo/Secrets.swift\"\n\nif [ ! -f \"${SECRETS_PATH}\" ]; then\n    echo \"let apiKey: String? = nil\" > \"${SECRETS_PATH}\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ OPENAPI_GENERATOR_CLONE_DIR ?= $(CURRENT_MAKEFILE_DIR)/openapi-generator
 OPENAPI_YAML_PATH ?= $(CURRENT_MAKEFILE_DIR)/openapi/spec.yaml
 MODEL_TEMPLATE_PATH ?= $(CURRENT_MAKEFILE_DIR)/openapi
 OUTPUT_DIRECTORY ?= $(CURRENT_MAKEFILE_DIR)/Sources/Gravatar/OpenApi/Generated
-SECRETS_PATH=$(CURRENT_MAKEFILE_DIR)/Demo/Demo/Gravatar-Demo/Secrets.swift
 
 # Derived values (don't change these).
 CURRENT_MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
@@ -29,16 +28,16 @@ help:  # Display this help.
 	@-+echo
 	@-+grep -Eh "^[a-z-]+:.*#" $(CURRENT_MAKEFILE_PATH) | sed -E 's/^(.*:)(.*#+)(.*)/  \1 @@@ \3 /' | column -t -s "@@@"
 
-dev: secrets # Open the package in xcode
+dev: # Open the package in xcode
 	xed .
 
-dev-demo: secrets # Open an xcode project with the package and a demo project
+dev-demo: # Open an xcode project with the package and a demo project
 	xed Demo/
 
 test: bundle-install
 	bundle exec fastlane test
 
-build-demo: secrets build-demo-swift build-demo-swiftui
+build-demo: build-demo-swift build-demo-swiftui
 
 build-demo-swift: bundle-install
 	bundle exec fastlane build_demo scheme:Gravatar-Demo
@@ -77,12 +76,6 @@ update-example-snapshots:
 	# Append @2x to the file name.
 	cd ./Sources/GravatarUI/GravatarUI.docc/Resources/ProfileExamples && \
 	for filePath in *; do name=$${filePath%.*}; mv $$filePath $${name//-dark/~dark}@2x$${filePath#$$name}; done
-
-secrets: # Creates the Secrets file in the Demo app.
-	if [ ! -f $(SECRETS_PATH) ]; then \
-		touch $(SECRETS_PATH); \
-		echo "let apiKey: String? = nil" > $(SECRETS_PATH); \
-	fi
 
 install-and-generate: $(OPENAPI_GENERATOR_CLONE_DIR) # Clones and setup the openapi-generator.
 	"$(OPENAPI_GENERATOR_CLONE_DIR)"/run-in-docker.sh mvn package


### PR DESCRIPTION
Closes #

### Description

Create a Build Phase script that allows Xcode to generate the `Secrets.swift` file if it isn't present.  If the file is already present, no changes should be made to it.

### Testing Steps

#### Removeo the Secrets file and regenerate
- Delete any existing `Secrets.swift` file, then use Xcode to build the Demo app.
  - [ ] Observe that the `Secrets.swift` file is recreated
  - [ ] Look in the build log and confirm that "Run custom shell script 'Generate Secrets.swift' is present under `Build target Gravatar-Demo`

#### Modify the Secrets.swift file and verify changes are not overwritten
1. Leave the existing `Secrets.swift` in place
2. Build the Gravatar-Demo app
3. Use Xcode to build the Demo app.
  - [ ] Verify that the changes you made to the Secrets.swift file were not overwritten

#### Build and test via command line
- Delete the `Secrets.swift` file and run `make test`.
  - [ ] Observe that the `Secrets.swift` file is recreated
  - [ ] Observe that the Gravatar-Demo app builds and that all tests run and pass

#### Build and test via Xcode
- Delete the `Secrets.swift` file and run unit tests from within Xcode`.
  - [ ] Observe that the `Secrets.swift` file is recreated
  - [ ] Observe that the Gravatar-Demo app builds and that all tests run and pass