### PR TITLE
Adding interests to Profile

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoFetchProfileViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoFetchProfileViewController.swift
@@ -119,6 +119,7 @@ Thumbnail URL: \(profile.avatarUrl)
 Wallets: \(String(describing: profile.payments?.cryptoWallets))
 Last edit: \(String(describing: profile.lastProfileEdit))
 Registration date: \(String(describing: profile.registrationDate))
+Interests: \(String(describing: profile.interests))
 """
     }
 

--- a/Sources/Gravatar/OpenApi/Generated/GalleryImage.swift
+++ b/Sources/Gravatar/OpenApi/Generated/GalleryImage.swift
@@ -5,13 +5,17 @@ import Foundation
 public struct GalleryImage: Codable, Hashable, Sendable {
     /// The URL to the image.
     public private(set) var url: String
+    /// The image alt text.
+    public private(set) var altText: String?
 
-    public init(url: String) {
+    public init(url: String, altText: String? = nil) {
         self.url = url
+        self.altText = altText
     }
 
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case url
+        case altText = "alt_text"
     }
 
     // Encodable protocol methods
@@ -19,5 +23,6 @@ public struct GalleryImage: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(url, forKey: .url)
+        try container.encodeIfPresent(altText, forKey: .altText)
     }
 }

--- a/Sources/Gravatar/OpenApi/Generated/Interest.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Interest.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// An interest the user has added to their profile.
+///
+public struct Interest: Codable, Hashable, Sendable {
+    /// The unique identifier for the interest.
+    public private(set) var id: Int
+    /// The name of the interest.
+    public private(set) var name: String
+
+    public init(id: Int, name: String) {
+        self.id = id
+        self.name = name
+    }
+
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+    }
+}

--- a/Sources/Gravatar/OpenApi/Generated/Profile.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Profile.swift
@@ -29,6 +29,8 @@ public struct Profile: Codable, Hashable, Sendable {
     public private(set) var pronouns: String
     /// A list of links the user has added to their profile. This is only provided in authenticated API requests.
     public private(set) var links: [Link]?
+    /// A list of interests the user has added to their profile. This is only provided in authenticated API requests.
+    public private(set) var interests: [Interest]?
     public private(set) var payments: ProfilePayments?
     public private(set) var contactInfo: ProfileContactInfo?
     /// Additional images a user has uploaded. This is only provided in authenticated API requests.
@@ -55,6 +57,7 @@ public struct Profile: Codable, Hashable, Sendable {
         pronunciation: String,
         pronouns: String,
         links: [Link]? = nil,
+        interests: [Interest]? = nil,
         payments: ProfilePayments? = nil,
         contactInfo: ProfileContactInfo? = nil,
         gallery: [GalleryImage]? = nil,
@@ -75,6 +78,7 @@ public struct Profile: Codable, Hashable, Sendable {
         self.pronunciation = pronunciation
         self.pronouns = pronouns
         self.links = links
+        self.interests = interests
         self.payments = payments
         self.contactInfo = contactInfo
         self.gallery = gallery
@@ -97,6 +101,7 @@ public struct Profile: Codable, Hashable, Sendable {
         case pronunciation
         case pronouns
         case links
+        case interests
         case payments
         case contactInfo = "contact_info"
         case gallery
@@ -122,6 +127,7 @@ public struct Profile: Codable, Hashable, Sendable {
         try container.encode(pronunciation, forKey: .pronunciation)
         try container.encode(pronouns, forKey: .pronouns)
         try container.encodeIfPresent(links, forKey: .links)
+        try container.encodeIfPresent(interests, forKey: .interests)
         try container.encodeIfPresent(payments, forKey: .payments)
         try container.encodeIfPresent(contactInfo, forKey: .contactInfo)
         try container.encodeIfPresent(gallery, forKey: .gallery)

--- a/Sources/Gravatar/OpenApi/Generated/VerifiedAccount.swift
+++ b/Sources/Gravatar/OpenApi/Generated/VerifiedAccount.swift
@@ -3,6 +3,8 @@ import Foundation
 /// A verified account on a user's profile.
 ///
 public struct VerifiedAccount: Codable, Hashable, Sendable {
+    /// The type of the service.
+    public private(set) var serviceType: String
     /// The name of the service.
     public private(set) var serviceLabel: String
     /// The URL to the service's icon.
@@ -10,13 +12,15 @@ public struct VerifiedAccount: Codable, Hashable, Sendable {
     /// The URL to the user's profile on the service.
     public private(set) var url: String
 
-    public init(serviceLabel: String, serviceIcon: String, url: String) {
+    public init(serviceType: String, serviceLabel: String, serviceIcon: String, url: String) {
+        self.serviceType = serviceType
         self.serviceLabel = serviceLabel
         self.serviceIcon = serviceIcon
         self.url = url
     }
 
     public enum CodingKeys: String, CodingKey, CaseIterable {
+        case serviceType = "service_type"
         case serviceLabel = "service_label"
         case serviceIcon = "service_icon"
         case url
@@ -26,6 +30,7 @@ public struct VerifiedAccount: Codable, Hashable, Sendable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(serviceType, forKey: .serviceType)
         try container.encode(serviceLabel, forKey: .serviceLabel)
         try container.encode(serviceIcon, forKey: .serviceIcon)
         try container.encode(url, forKey: .url)

--- a/Tests/GravatarTests/Resources/Profiles/fullProfile.json
+++ b/Tests/GravatarTests/Resources/Profiles/fullProfile.json
@@ -4,12 +4,13 @@
     "profile_url": "https://gravatar.com/notreal",
     "avatar_url": "https://2.gravatar.com/avatar/hashhash",
     "avatar_alt_text": "",
-    "location": "Beach tennis court",
+    "location": "Atlanta GA",
     "description": "I'm a beach tennis player who enjoys the dynamic challenges and camaraderie of the game on the sand. Embracing the strategic aspects, beach tennis has become a fulfilling pastime for me, offering both excitement and a sense of community.\n\nBy Chat GPT.",
     "job_title": "Engineer",
     "company": "A company",
     "verified_accounts": [
         {
+            "service_type": "wordpress",
             "service_label": "WordPress",
             "service_icon": "https://secure.gravatar.com/icons/wordpress.svg",
             "url": "http://notreal.wordpress.com"
@@ -25,6 +26,20 @@
         {
             "label": "Gravatar",
             "url": "https://gravatar.com"
+        }
+    ],
+    "interests": [
+        {
+            "id": 2779,
+            "name": "Beach Tennis"
+        },
+        {
+            "id": 589,
+            "name": "Software Engineering"
+        },
+        {
+            "id": 230,
+            "name": "Music and Audio"
         }
     ],
     "payments": {
@@ -51,7 +66,8 @@
     },
     "gallery": [
         {
-            "url": "https://1.gravatar.com/userimage/133992229/hashhash"
+            "url": "https://1.gravatar.com/userimage/133992229/633cbc8c80ab12275501c908e1a7c33b",
+            "alt_text": ""
         }
     ],
     "number_verified_accounts": 1,

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -13,6 +13,21 @@ tags:
   - name: profiles
     description: Operations about user profiles
 components:
+  headers:
+    X-RateLimit-Limit:
+      description: The number of allowed requests in the current period.
+      schema:
+        type: integer
+    X-RateLimit-Remaining:
+      description: The number of remaining requests in the current period.
+      schema:
+        type: integer
+    X-RateLimit-Reset:
+      description: >-
+        The time at which the current rate limit period resets, in Unix
+        timestamp format.
+      schema:
+        type: integer
   schemas:
     Link:
       type: object
@@ -32,6 +47,23 @@ components:
           description: The URL to the link.
           examples:
             - https://example.com
+    Interest:
+      type: object
+      description: An interest the user has added to their profile.
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          description: The unique identifier for the interest.
+          examples:
+            - 1
+        name:
+          type: string
+          description: The name of the interest.
+          examples:
+            - Photography
     CryptoWalletAddress:
       type: object
       description: A crypto currency wallet address the user accepts.
@@ -53,10 +85,16 @@ components:
       type: object
       description: A verified account on a user's profile.
       required:
+        - service_type
         - service_label
         - service_icon
         - url
       properties:
+        service_type:
+          type: string
+          description: The type of the service.
+          examples:
+            - tumblr
         service_label:
           type: string
           description: The name of the service.
@@ -87,6 +125,11 @@ components:
           examples:
             - >-
               https://0.gravatar.com/userimage/5/04bbd674f72c703f6335e2e7a00acc9a
+        alt_text:
+          type: string
+          description: The image alt text.
+          examples:
+            - A beautiful sunset
     Profile:
       type: object
       description: A user's profile information.
@@ -180,6 +223,13 @@ components:
             provided in authenticated API requests.
           items:
             $ref: '#/components/schemas/Link'
+        interests:
+          type: array
+          description: >-
+            A list of interests the user has added to their profile. This is
+            only provided in authenticated API requests.
+          items:
+            $ref: '#/components/schemas/Interest'
         payments:
           type: object
           required:
@@ -257,19 +307,27 @@ components:
           examples:
             - 3
         last_profile_edit:
-          type: string
+          type:
+            - string
+            - 'null'
+          nullable: true
           description: >-
             The date and time (UTC) the user last edited their profile. This is
             only provided in authenticated API requests.
           format: date-time
+          pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
           examples:
             - '2021-10-01T12:00:00Z'
         registration_date:
-          type: string
+          type:
+            - string
+            - 'null'
+          nullable: true
           description: >-
             The date the user registered their account. This is only provided in
             authenticated API requests.
           format: date-time
+          pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
           examples:
             - '2021-10-01T12:00:00Z'
   securitySchemes:
@@ -303,10 +361,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Profile'
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/X-RateLimit-Limit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/X-RateLimit-Remaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           description: Profile not found
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/X-RateLimit-Limit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/X-RateLimit-Remaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/X-RateLimit-Limit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/X-RateLimit-Remaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           description: Internal server error
 security:


### PR DESCRIPTION
Closes: #314

### Description

This PR updates the openapi spec to bring profile interests.

### Testing Steps

- Have a gravatar account with interests added
- Add you API key to the demo app's secrets file
- Run the Demo app
- Go to "Fetch Profile" screen 
- Fetch for your gravatar account with interests
- Check that the interests are shown on the response text view.

<img src="https://github.com/Automattic/Gravatar-SDK-iOS/assets/9772967/f2951814-eb56-43e6-81b3-2eeefd5c229b" width="60%">

