### PR TITLE
Deprecating public CodingKeys and init methods

### DIFF
--- a/Sources/Gravatar/OpenApi/Generated/CryptoWalletAddress.swift
+++ b/Sources/Gravatar/OpenApi/Generated/CryptoWalletAddress.swift
@@ -8,12 +8,19 @@ public struct CryptoWalletAddress: Codable, Hashable, Sendable {
     /// The wallet address for the crypto currency.
     public private(set) var address: String
 
+    @available(*, deprecated, message: "init will become internal on the next release")
     public init(label: String, address: String) {
         self.label = label
         self.address = address
     }
 
+    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
     public enum CodingKeys: String, CodingKey, CaseIterable {
+        case label
+        case address
+    }
+
+    enum InternalCodingKeys: String, CodingKey, CaseIterable {
         case label
         case address
     }
@@ -21,7 +28,7 @@ public struct CryptoWalletAddress: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.container(keyedBy: InternalCodingKeys.self)
         try container.encode(label, forKey: .label)
         try container.encode(address, forKey: .address)
     }

--- a/Sources/Gravatar/OpenApi/Generated/GalleryImage.swift
+++ b/Sources/Gravatar/OpenApi/Generated/GalleryImage.swift
@@ -6,18 +6,24 @@ public struct GalleryImage: Codable, Hashable, Sendable {
     /// The URL to the image.
     public private(set) var url: String
 
+    @available(*, deprecated, message: "init will become internal on the next release")
     public init(url: String) {
         self.url = url
     }
 
+    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
     public enum CodingKeys: String, CodingKey, CaseIterable {
+        case url
+    }
+
+    enum InternalCodingKeys: String, CodingKey, CaseIterable {
         case url
     }
 
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.container(keyedBy: InternalCodingKeys.self)
         try container.encode(url, forKey: .url)
     }
 }

--- a/Sources/Gravatar/OpenApi/Generated/Link.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Link.swift
@@ -8,12 +8,19 @@ public struct Link: Codable, Hashable, Sendable {
     /// The URL to the link.
     public private(set) var url: String
 
+    @available(*, deprecated, message: "init will become internal on the next release")
     public init(label: String, url: String) {
         self.label = label
         self.url = url
     }
 
+    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
     public enum CodingKeys: String, CodingKey, CaseIterable {
+        case label
+        case url
+    }
+
+    enum InternalCodingKeys: String, CodingKey, CaseIterable {
         case label
         case url
     }
@@ -21,7 +28,7 @@ public struct Link: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.container(keyedBy: InternalCodingKeys.self)
         try container.encode(label, forKey: .label)
         try container.encode(url, forKey: .url)
     }

--- a/Sources/Gravatar/OpenApi/Generated/Profile.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Profile.swift
@@ -41,6 +41,7 @@ public struct Profile: Codable, Hashable, Sendable {
     /// The date the user registered their account. This is only provided in authenticated API requests.
     public private(set) var registrationDate: Date?
 
+    @available(*, deprecated, message: "init will become internal on the next release")
     public init(
         hash: String,
         displayName: String,
@@ -83,7 +84,30 @@ public struct Profile: Codable, Hashable, Sendable {
         self.registrationDate = registrationDate
     }
 
+    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
     public enum CodingKeys: String, CodingKey, CaseIterable {
+        case hash
+        case displayName = "display_name"
+        case profileUrl = "profile_url"
+        case avatarUrl = "avatar_url"
+        case avatarAltText = "avatar_alt_text"
+        case location
+        case description
+        case jobTitle = "job_title"
+        case company
+        case verifiedAccounts = "verified_accounts"
+        case pronunciation
+        case pronouns
+        case links
+        case payments
+        case contactInfo = "contact_info"
+        case gallery
+        case numberVerifiedAccounts = "number_verified_accounts"
+        case lastProfileEdit = "last_profile_edit"
+        case registrationDate = "registration_date"
+    }
+
+    enum InternalCodingKeys: String, CodingKey, CaseIterable {
         case hash
         case displayName = "display_name"
         case profileUrl = "profile_url"
@@ -108,7 +132,7 @@ public struct Profile: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.container(keyedBy: InternalCodingKeys.self)
         try container.encode(hash, forKey: .hash)
         try container.encode(displayName, forKey: .displayName)
         try container.encode(profileUrl, forKey: .profileUrl)

--- a/Sources/Gravatar/OpenApi/Generated/ProfileContactInfo.swift
+++ b/Sources/Gravatar/OpenApi/Generated/ProfileContactInfo.swift
@@ -16,6 +16,7 @@ public struct ProfileContactInfo: Codable, Hashable, Sendable {
     /// The URL to the user's calendar.
     public private(set) var calendar: String?
 
+    @available(*, deprecated, message: "init will become internal on the next release")
     public init(
         homePhone: String? = nil,
         workPhone: String? = nil,
@@ -32,7 +33,17 @@ public struct ProfileContactInfo: Codable, Hashable, Sendable {
         self.calendar = calendar
     }
 
+    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
     public enum CodingKeys: String, CodingKey, CaseIterable {
+        case homePhone = "home_phone"
+        case workPhone = "work_phone"
+        case cellPhone = "cell_phone"
+        case email
+        case contactForm = "contact_form"
+        case calendar
+    }
+
+    enum InternalCodingKeys: String, CodingKey, CaseIterable {
         case homePhone = "home_phone"
         case workPhone = "work_phone"
         case cellPhone = "cell_phone"
@@ -44,7 +55,7 @@ public struct ProfileContactInfo: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.container(keyedBy: InternalCodingKeys.self)
         try container.encodeIfPresent(homePhone, forKey: .homePhone)
         try container.encodeIfPresent(workPhone, forKey: .workPhone)
         try container.encodeIfPresent(cellPhone, forKey: .cellPhone)

--- a/Sources/Gravatar/OpenApi/Generated/ProfilePayments.swift
+++ b/Sources/Gravatar/OpenApi/Generated/ProfilePayments.swift
@@ -8,12 +8,19 @@ public struct ProfilePayments: Codable, Hashable, Sendable {
     /// A list of crypto currencies the user accepts.
     public private(set) var cryptoWallets: [CryptoWalletAddress]
 
+    @available(*, deprecated, message: "init will become internal on the next release")
     public init(links: [Link], cryptoWallets: [CryptoWalletAddress]) {
         self.links = links
         self.cryptoWallets = cryptoWallets
     }
 
+    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
     public enum CodingKeys: String, CodingKey, CaseIterable {
+        case links
+        case cryptoWallets = "crypto_wallets"
+    }
+
+    enum InternalCodingKeys: String, CodingKey, CaseIterable {
         case links
         case cryptoWallets = "crypto_wallets"
     }
@@ -21,7 +28,7 @@ public struct ProfilePayments: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.container(keyedBy: InternalCodingKeys.self)
         try container.encode(links, forKey: .links)
         try container.encode(cryptoWallets, forKey: .cryptoWallets)
     }

--- a/Sources/Gravatar/OpenApi/Generated/VerifiedAccount.swift
+++ b/Sources/Gravatar/OpenApi/Generated/VerifiedAccount.swift
@@ -10,13 +10,21 @@ public struct VerifiedAccount: Codable, Hashable, Sendable {
     /// The URL to the user's profile on the service.
     public private(set) var url: String
 
+    @available(*, deprecated, message: "init will become internal on the next release")
     public init(serviceLabel: String, serviceIcon: String, url: String) {
         self.serviceLabel = serviceLabel
         self.serviceIcon = serviceIcon
         self.url = url
     }
 
+    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
     public enum CodingKeys: String, CodingKey, CaseIterable {
+        case serviceLabel = "service_label"
+        case serviceIcon = "service_icon"
+        case url
+    }
+
+    enum InternalCodingKeys: String, CodingKey, CaseIterable {
         case serviceLabel = "service_label"
         case serviceIcon = "service_icon"
         case url
@@ -25,7 +33,7 @@ public struct VerifiedAccount: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.container(keyedBy: InternalCodingKeys.self)
         try container.encode(serviceLabel, forKey: .serviceLabel)
         try container.encode(serviceIcon, forKey: .serviceIcon)
         try container.encode(url, forKey: .url)

--- a/openapi/modelObject.mustache
+++ b/openapi/modelObject.mustache
@@ -51,6 +51,8 @@
 {{/allVars}}
 {{#hasVars}}
 
+{{! DEPRECARED public init }}
+    @available(*, deprecated, message: "init will become internal on the next release")
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init({{#allVars}}{{{name}}}: {{#vendorExtensions.x-null-encodable}}NullEncodable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-null-encodable}}{{^vendorExtensions.x-null-encodable}}{{{datatypeWithEnum}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}}{{/vendorExtensions.x-null-encodable}}{{#defaultValue}} = {{#vendorExtensions.x-null-encodable}}{{{vendorExtensions.x-null-encodable-default-value}}}{{/vendorExtensions.x-null-encodable}}{{^vendorExtensions.x-null-encodable}}{{{.}}}{{/vendorExtensions.x-null-encodable}}{{/defaultValue}}{{^defaultValue}}{{^required}} = {{#vendorExtensions.x-null-encodable}}.encodeNull{{/vendorExtensions.x-null-encodable}}{{^vendorExtensions.x-null-encodable}}nil{{/vendorExtensions.x-null-encodable}}{{/required}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/allVars}}) {
         {{#allVars}}
         self.{{{name}}} = {{{name}}}
@@ -58,6 +60,8 @@
     }
 {{/hasVars}}
 
+{{! DEPRECARED public coding keys }}
+    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum CodingKeys: {{#hasVars}}String, {{/hasVars}}CodingKey, CaseIterable {
         {{#allVars}}
         case {{{name}}}{{#vendorExtensions.x-codegen-escaped-property-name}} = "{{{baseName}}}"{{/vendorExtensions.x-codegen-escaped-property-name}}
@@ -79,10 +83,40 @@
         }
     }{{/additionalPropertiesType}}{{/generateModelAdditionalProperties}}
 
+
+
+{{!----- BEGINNING OF INTERNAL CODING KEYS ------ }}
+{{! When the public CodingKeys get removed, we can rename this one back to "CodingKeys", making it internal }}
+
+    internal enum InternalCodingKeys: {{#hasVars}}String, {{/hasVars}}CodingKey, CaseIterable {
+        {{#allVars}}
+        case {{{name}}}{{#vendorExtensions.x-codegen-escaped-property-name}} = "{{{baseName}}}"{{/vendorExtensions.x-codegen-escaped-property-name}}
+        {{/allVars}}
+    }{{#generateModelAdditionalProperties}}{{#additionalPropertiesType}}
+
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} {{#readonlyProperties}}private(set) {{/readonlyProperties}}var additionalProperties: [String: {{{additionalPropertiesType}}}] = [:]
+
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} subscript(key: String) -> {{{additionalPropertiesType}}}? {
+        get {
+            if let value = additionalProperties[key] {
+                return value
+            }
+            return nil
+        }
+
+        set {
+            additionalProperties[key] = newValue
+        }
+    }{{/additionalPropertiesType}}{{/generateModelAdditionalProperties}}
+
+{{!----- END OF INTERNAL CODING KEYS ------ }}
+
+
+
     // Encodable protocol methods
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.container(keyedBy: InternalCodingKeys.self)
         {{#allVars}}
         {{#vendorExtensions.x-null-encodable}}
         switch {{{name}}} {
@@ -105,7 +139,7 @@
     // Decodable protocol methods
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}}{{#objcCompatible}} required{{/objcCompatible}} init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
 
         {{#allVars}}
         {{{name}}} = try container.decode{{#required}}{{#isNullable}}IfPresent{{/isNullable}}{{/required}}{{^required}}IfPresent{{/required}}({{{datatypeWithEnum}}}.self, forKey: .{{{name}}})


### PR DESCRIPTION
### Description

On this PR we modify the OpenApi template used to generate the swift struct from the OpenApi specs.

The idea is to deprecate the public `CodingKeys` and the  parametrised `init` method from the generated structs, since they are prone to generate breaking changes on updates to the structures.

We can remove these changes from the template once the deprecation takes effect.

### Testing Steps

- CI should be 🍏 