### PR TITLE
Add `.avatarPickerSheet(...)` modifier

### DIFF
--- a/Demo/Demo/Gravatar-SwiftUI-Demo/DemoAvatarPickerView.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/DemoAvatarPickerView.swift
@@ -7,7 +7,9 @@ struct DemoAvatarPickerView: View {
     @AppStorage("pickerEmail") private var email: String = ""
     @AppStorage("pickerToken") private var token: String = ""
     @State private var isSecure: Bool = true
-    @StateObject private var avatarPickerModel = AvatarPickerViewModel(email: .init(""), authToken: "")
+
+    // You can make this `true` by default to easily test the picker
+    @State private var isPresentingPicker: Bool = false
     
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
@@ -17,17 +19,11 @@ struct DemoAvatarPickerView: View {
                     .textInputAutocapitalization(.never)
                     .keyboardType(.emailAddress)
                     .disableAutocorrection(true)
-                    .onChange(of: email) { oldValue, newValue in
-                        avatarPickerModel.update(email: email)
-                    }
                 HStack {
                     tokenField()
                         .font(.callout)
                         .textInputAutocapitalization(.never)
                         .disableAutocorrection(true)
-                        .onChange(of: token) { oldValue, newValue in
-                            avatarPickerModel.update(authToken: token)
-                        }
                     Button(action: {
                         isSecure.toggle()
                     }) {
@@ -36,14 +32,15 @@ struct DemoAvatarPickerView: View {
                     }
                 }
                 Divider()
+                Button("Tap to open the Avatar Picker") {
+                    isPresentingPicker.toggle()
+                }
+                .avatarPickerSheet(isPresented: $isPresentingPicker,
+                                          email: email,
+                                          authToken: token)
+                Spacer()
             }
             .padding(.horizontal)
-            
-            AvatarPickerView(model: avatarPickerModel).onAppear() {
-                avatarPickerModel.update(email: email)
-                avatarPickerModel.update(authToken: token)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
     

--- a/Demo/Demo/Gravatar-SwiftUI-Demo/DemoAvatarPickerView.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/DemoAvatarPickerView.swift
@@ -7,7 +7,7 @@ struct DemoAvatarPickerView: View {
     @AppStorage("pickerEmail") private var email: String = ""
     @AppStorage("pickerToken") private var token: String = ""
     @State private var isSecure: Bool = true
-
+    
     // You can make this `true` by default to easily test the picker
     @State private var isPresentingPicker: Bool = false
     
@@ -36,8 +36,8 @@ struct DemoAvatarPickerView: View {
                     isPresentingPicker.toggle()
                 }
                 .avatarPickerSheet(isPresented: $isPresentingPicker,
-                                          email: email,
-                                          authToken: token)
+                                   email: email,
+                                   authToken: token)
                 Spacer()
             }
             .padding(.horizontal)

--- a/Sources/GravatarUI/SwiftUI/ModalPresentationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/ModalPresentationModifier.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct ModalPresentationModifier<ModalView: View>: ViewModifier {
+    @Binding var isPresented: Bool
+    let modalView: ModalView
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(isPresented: $isPresented) {
+                modalView
+            }
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 extension View {
     func shape(_ shape: some Shape, borderColor: Color = .clear, borderWidth: CGFloat = 0) -> some View {
         self
@@ -8,5 +9,10 @@ extension View {
                 shape
                     .stroke(borderColor, lineWidth: borderWidth)
             )
+    }
+
+    func avatarPickerSheet(isPresented: Binding<Bool>, email: String, authToken: String) -> some View {
+        let avatarPickerView = AvatarPickerView(model: AvatarPickerViewModel(email: Email(email), authToken: authToken))
+        return modifier(ModalPresentationModifier(isPresented: isPresented, modalView: avatarPickerView))
     }
 }


### PR DESCRIPTION
Closes #

### Description

Adds `.avatarPickerSheet(...)` modifier to encapsulate the AvatarPickerView and display it as a modal.

### Testing Steps

Demo App > Avatar Picker View