### PR TITLE
Fix Swift Package Index documentation generation

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -31,9 +31,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Switch Xcode 🔄
         run: sudo xcode-select --switch /Applications/Xcode_15.4.app
-      - name: Build Gravatar DocC
+      - name: Build Gravatar SDK DocC Archive
         run: |
-          xcodebuild docbuild -scheme Gravatar \
+          xcodebuild docbuild -scheme Gravatar-Package \
             -derivedDataPath /tmp/docbuild \
             -destination 'generic/platform=iOS';
           $(xcrun --find docc) process-archive \
@@ -41,12 +41,16 @@ jobs:
             --hosting-base-path /Gravatar-SDK-iOS/$GRAVATAR_URL \
             --output-path gravatar-docs;
           echo "<script>window.location.href += \"documentation/gravatar\"</script>" > gravatar-docs/index.html;
-
-      - name: Build GravatarUI DocC
+          
+      - name: Process Gravatar DocC
         run: |
-          xcodebuild docbuild -scheme GravatarUI \
-            -derivedDataPath /tmp/docbuild \
-            -destination 'generic/platform=iOS';
+          $(xcrun --find docc) process-archive \
+            transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/Gravatar.doccarchive \
+            --hosting-base-path /Gravatar-SDK-iOS/$GRAVATAR_URL \
+            --output-path gravatar-docs;
+          echo "<script>window.location.href += \"documentation/gravatar\"</script>" > gravatar-docs/index.html;
+      - name: Process GravatarUI DocC
+        run: |
           $(xcrun --find docc) process-archive \
             transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/GravatarUI.doccarchive \
             --hosting-base-path /Gravatar-SDK-iOS/$GRAVATAR_UI_URL \

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -39,7 +39,8 @@ jobs:
           $(xcrun --find docc) process-archive \
             transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/Gravatar.doccarchive \
             --hosting-base-path /Gravatar-SDK-iOS/$GRAVATAR_URL \
-            --output-path gravatar-docs
+            --output-path gravatar-docs;
+          echo "<script>window.location.href += \"documentation/gravatar\"</script>" > gravatar-docs/index.html;
 
       - name: Build GravatarUI DocC
         run: |
@@ -49,7 +50,8 @@ jobs:
           $(xcrun --find docc) process-archive \
             transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/GravatarUI.doccarchive \
             --hosting-base-path /Gravatar-SDK-iOS/$GRAVATAR_UI_URL \
-            --output-path gravatar-ui-docs
+            --output-path gravatar-ui-docs;
+          echo "<script>window.location.href += \"documentation/gravatarui\"</script>" > gravatar-ui-docs/index.html;
 
       - name: Move generated docs to branch directory
         run: |

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -38,7 +38,7 @@ jobs:
             -destination 'generic/platform=iOS';
           $(xcrun --find docc) process-archive \
             transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/Gravatar.doccarchive \
-            --hosting-base-path Gravatar-SDK-iOS/$GRAVATAR_URL \
+            --hosting-base-path /Gravatar-SDK-iOS/$GRAVATAR_URL \
             --output-path gravatar-docs
 
       - name: Build GravatarUI DocC
@@ -48,7 +48,7 @@ jobs:
             -destination 'generic/platform=iOS';
           $(xcrun --find docc) process-archive \
             transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/GravatarUI.doccarchive \
-            --hosting-base-path Gravatar-SDK-iOS/$GRAVATAR_UI_URL \
+            --hosting-base-path /Gravatar-SDK-iOS/$GRAVATAR_UI_URL \
             --output-path gravatar-ui-docs
 
       - name: Move generated docs to branch directory

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -39,8 +39,7 @@ jobs:
           $(xcrun --find docc) process-archive \
             transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/Gravatar.doccarchive \
             --hosting-base-path Gravatar-SDK-iOS/$GRAVATAR_URL \
-            --output-path gravatar-docs;
-          echo "<script>window.location.href += \"documentation/gravatar\"</script>" > gravatar-docs/index.html;
+            --output-path gravatar-docs
 
       - name: Build GravatarUI DocC
         run: |
@@ -50,8 +49,7 @@ jobs:
           $(xcrun --find docc) process-archive \
             transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/GravatarUI.doccarchive \
             --hosting-base-path Gravatar-SDK-iOS/$GRAVATAR_UI_URL \
-            --output-path gravatar-ui-docs;
-          echo "<script>window.location.href += \"documentation/gravatarui\"</script>" > gravatar-ui-docs/index.html;
+            --output-path gravatar-ui-docs
 
       - name: Move generated docs to branch directory
         run: |

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -31,36 +31,32 @@ jobs:
         uses: actions/checkout@v4
       - name: Switch Xcode 🔄
         run: sudo xcode-select --switch /Applications/Xcode_15.4.app
-      - name: Build Gravatar SDK DocC Archive
+
+      - name: Prepare Site
+        run: |
+          mkdir -p ./_site/$GRAVATAR_URL;
+          mkdir -p ./_site/$GRAVATAR_UI_URL;
+
+      - name: Build Gravatar SDK DocC Archives
         run: |
           xcodebuild docbuild -scheme Gravatar-Package \
             -derivedDataPath /tmp/docbuild \
             -destination 'generic/platform=iOS';
-          $(xcrun --find docc) process-archive \
-            transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/Gravatar.doccarchive \
-            --hosting-base-path /Gravatar-SDK-iOS/$GRAVATAR_URL \
-            --output-path gravatar-docs;
-          echo "<script>window.location.href += \"documentation/gravatar\"</script>" > gravatar-docs/index.html;
           
       - name: Process Gravatar DocC
         run: |
           $(xcrun --find docc) process-archive \
             transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/Gravatar.doccarchive \
             --hosting-base-path /Gravatar-SDK-iOS/$GRAVATAR_URL \
-            --output-path gravatar-docs;
-          echo "<script>window.location.href += \"documentation/gravatar\"</script>" > gravatar-docs/index.html;
+            --output-path ./_site/$GRAVATAR_URL;
+          echo "<script>window.location.href += \"documentation/gravatar\"</script>" > ./_site/$GRAVATAR_URL/index.html;
       - name: Process GravatarUI DocC
         run: |
           $(xcrun --find docc) process-archive \
             transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/GravatarUI.doccarchive \
             --hosting-base-path /Gravatar-SDK-iOS/$GRAVATAR_UI_URL \
-            --output-path gravatar-ui-docs;
-          echo "<script>window.location.href += \"documentation/gravatarui\"</script>" > gravatar-ui-docs/index.html;
-
-      - name: Move generated docs to branch directory
-        run: |
-          mkdir -p ./_site/$GRAVATAR_URL && mv ./gravatar-docs/* ./_site/$GRAVATAR_URL/;
-          mkdir -p ./_site/$GRAVATAR_UI_URL && mv ./gravatar-ui-docs/* ./_site/$GRAVATAR_UI_URL/;
+            --output-path ./_site/$GRAVATAR_UI_URL;
+          echo "<script>window.location.href += \"documentation/gravatarui\"</script>" > ./_site/$GRAVATAR_UI_URL/index.html;
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Switch Xcode 🔄
         run: sudo xcode-select --switch /Applications/Xcode_15.4.app
       - name: Build Gravatar SDK DocC Archive
@@ -63,10 +63,10 @@ jobs:
           mkdir -p ./_site/$GRAVATAR_UI_URL && mv ./gravatar-ui-docs/* ./_site/$GRAVATAR_UI_URL/;
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload only docs directory
           path: '_site'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -40,7 +40,7 @@ jobs:
             transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/Gravatar.doccarchive \
             --hosting-base-path Gravatar-SDK-iOS/$GRAVATAR_URL \
             --output-path gravatar-docs;
-          echo "<script>window.location.href += \"$GRAVATAR_URL/documentation/gravatar\"</script>" > gravatar-docs/index.html;
+          echo "<script>window.location.href += \"documentation/gravatar\"</script>" > gravatar-docs/index.html;
 
       - name: Build GravatarUI DocC
         run: |
@@ -51,7 +51,7 @@ jobs:
             transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/GravatarUI.doccarchive \
             --hosting-base-path Gravatar-SDK-iOS/$GRAVATAR_UI_URL \
             --output-path gravatar-ui-docs;
-          echo "<script>window.location.href += \"$GRAVATAR_UI_URL/documentation/gravatar\"</script>" > gravatar-ui-docs/index.html;
+          echo "<script>window.location.href += \"documentation/gravatar\"</script>" > gravatar-ui-docs/index.html;
 
       - name: Move generated docs to branch directory
         run: |

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -3,7 +3,7 @@ name: Deploy Gravatar DocC
 on:
   # Runs on pushes and PRs targeting the default branch
   push:
-    branches: [ "andrewdmontgomery/fix-swiftpackageindex-docs" ]
+    branches: [ "trunk" ]
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -51,7 +51,7 @@ jobs:
             transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/GravatarUI.doccarchive \
             --hosting-base-path Gravatar-SDK-iOS/$GRAVATAR_UI_URL \
             --output-path gravatar-ui-docs;
-          echo "<script>window.location.href += \"documentation/gravatar\"</script>" > gravatar-ui-docs/index.html;
+          echo "<script>window.location.href += \"documentation/gravatarui\"</script>" > gravatar-ui-docs/index.html;
 
       - name: Move generated docs to branch directory
         run: |

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -3,7 +3,7 @@ name: Deploy Gravatar DocC
 on:
   # Runs on pushes and PRs targeting the default branch
   push:
-    branches: [ "trunk" ]
+    branches: [ "andrewdmontgomery/fix-swiftpackageindex-docs" ]
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read

--- a/.spi.yml
+++ b/.spi.yml
@@ -8,4 +8,3 @@ builder:
     configs:
     - documentation_targets: [Gravatar]
       platform: ios
-      custom_documentation_parameters: [--include-extended-types]


### PR DESCRIPTION
Closes #332 

### Description

This does two things:
- Attempts to fix the Swift Package Index documentation generation by removing an option that is causing the `docc` command to Exit non-zero
- Fixes the refresh in the `index.html` that we are writing

---
#### Attempt to fix the Swift Package Index doc generation
Here we can see the `iOS/Swift 5.10` build that produces an error when attempting to build the documentation:
https://swiftpackageindex.com/builds/F8582B6A-864E-40BE-B0C6-32ACE9076F7A

```
/Applications/Xcode-15.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/docc convert --index --fallback-display-name Gravatar --fallback-bundle-identifier Gravatar --fallback-bundle-version 0 --output-dir /Users/admin/builder/spi-builder-workspace/.derivedData/Build/Products/Debug-iphoneos/Gravatar.doccarchive --ide-console-output --diagnostics-file /Users/admin/builder/spi-builder-workspace/.derivedData/Build/Intermediates.noindex/Gravatar.build/Debug-iphoneos/Gravatar.build/Gravatar-diagnostics.json --emit-digest --include-extended-types --source-service github --source-service-base-url https://github.com/Automattic/Gravatar-SDK-iOS/blob/trunk --checkout-path /Users/admin/builder/spi-builder-workspace /Users/admin/builder/spi-builder-workspace/Sources/Gravatar/Gravatar.docc --additional-symbol-graph-dir /Users/admin/builder/spi-builder-workspace/.derivedData/Build/Intermediates.noindex/Gravatar.build/Debug-iphoneos/Gravatar.build/symbol-graph
Error: Unknown option '--include-extended-types'
Usage: docc convert [<options>] [<source-bundle-path>]
  See 'docc convert --help' for more information.
Command CompileDocumentation failed with a nonzero exit code
** BUILD DOCUMENTATION FAILED **
The following build commands failed:
	CompileDocumentation /Users/admin/builder/spi-builder-workspace/Sources/Gravatar/Gravatar.docc (in target 'Gravatar' from project 'Gravatar')
(1 failure)
Error while generating docs: retryLimitExceeded(lastError: Optional(Shell command failed:
    env DEVELOPER_DIR=/Applications/Xcode-15.4.0.app xcrun xcodebuild -IDEClonedSourcePackagesDirPathOverride=$PWD/.dependencies -skipMacroValidation -skipPackagePluginValidation -derivedDataPath $PWD/.derivedData docbuild OTHER_DOCC_FLAGS=--emit-digest --include-extended-types --source-service github --source-service-base-url https://github.com/Automattic/Gravatar-SDK-iOS/blob/trunk --checkout-path $PWD -scheme Gravatar -destination generic/platform=iOS))
```

At first I got hung up on the `Error while generating docs: retryLimitExceeded`.  But after looking more closely, I suspect that just means that the "retry limit" is set to "none", and so the error causes a build failure.

I think the underlying problem is this:

```
Error: Unknown option '--include-extended-types'
```

The `docc convert` command doesn't support that option.  So it is exiting immediately with an error code.  This PR simply removes that custom option from the configuration.

---
#### Fixes the refresh in the root `index.html`

That second point doesn't affect the documentation generation at Swift Package Index.  But it should allow us to visit the following URL's and have them appropriately refresh to the deeper `index.html`:
- https://automattic.github.io/Gravatar-SDK-iOS/gravatar/
- https://automattic.github.io/Gravatar-SDK-iOS/gravatarui/

### Testing Steps

I'm not aware of a way to test these without merging into `trunk`.