### PR TITLE
Adjust `TestHelper` access, drop use of `@testable import`

### DIFF
--- a/Sources/TestHelpers/HTTPClientMock.swift
+++ b/Sources/TestHelpers/HTTPClientMock.swift
@@ -1,19 +1,19 @@
 import Foundation
 import Gravatar
 
-struct HTTPClientMock: HTTPClient {
+package struct HTTPClientMock: HTTPClient {
     private let session: URLSessionMock
 
-    init(session: URLSessionMock) {
+    package init(session: URLSessionMock) {
         self.session = session
     }
 
-    func fetchData(with request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+    package func fetchData(with request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         await session.update(request: request)
         return (session.returnData, session.response)
     }
 
-    func uploadData(with request: URLRequest, data: Data) async throws -> HTTPURLResponse {
+    package func uploadData(with request: URLRequest, data: Data) async throws -> HTTPURLResponse {
         session.response
     }
 }

--- a/Sources/TestHelpers/HTTPClientMock.swift
+++ b/Sources/TestHelpers/HTTPClientMock.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Gravatar
+
+struct HTTPClientMock: HTTPClient {
+    private let session: URLSessionMock
+
+    init(session: URLSessionMock) {
+        self.session = session
+    }
+
+    func fetchData(with request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        await session.update(request: request)
+        return (session.returnData, session.response)
+    }
+
+    func uploadData(with request: URLRequest, data: Data) async throws -> HTTPURLResponse {
+        session.response
+    }
+}

--- a/Sources/TestHelpers/HTTPURLResponse+Extension.swift
+++ b/Sources/TestHelpers/HTTPURLResponse+Extension.swift
@@ -10,22 +10,3 @@ extension HTTPURLResponse {
         HTTPURLResponse(url: url!, statusCode: code, httpVersion: nil, headerFields: nil)!
     }
 }
-
-// MARK: - HTTPClient
-
-struct HTTPClientMock: HTTPClient {
-    private let session: URLSessionMock
-
-    init(session: URLSessionMock) {
-        self.session = session
-    }
-
-    func fetchData(with request: URLRequest) async throws -> (Data, HTTPURLResponse) {
-        await session.update(request: request)
-        return (session.returnData, session.response)
-    }
-
-    func uploadData(with request: URLRequest, data: Data) async throws -> HTTPURLResponse {
-        session.response
-    }
-}

--- a/Sources/TestHelpers/HTTPURLResponse+Extension.swift
+++ b/Sources/TestHelpers/HTTPURLResponse+Extension.swift
@@ -2,11 +2,11 @@ import Foundation
 import Gravatar
 
 extension HTTPURLResponse {
-    static func successResponse(with url: URL? = URL(string: "https://gravatar.com")) -> HTTPURLResponse {
+    package static func successResponse(with url: URL? = URL(string: "https://gravatar.com")) -> HTTPURLResponse {
         HTTPURLResponse(url: url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
     }
 
-    static func errorResponse(with url: URL? = URL(string: "https://gravatar.com"), code: Int) -> HTTPURLResponse {
+    package static func errorResponse(with url: URL? = URL(string: "https://gravatar.com"), code: Int) -> HTTPURLResponse {
         HTTPURLResponse(url: url!, statusCode: code, httpVersion: nil, headerFields: nil)!
     }
 }

--- a/Sources/TestHelpers/ImageDownloadService+Extension.swift
+++ b/Sources/TestHelpers/ImageDownloadService+Extension.swift
@@ -1,7 +1,7 @@
 @testable import Gravatar
 
 extension ImageDownloadService {
-    static func mock(with session: URLSessionProtocol, cache: ImageCaching? = nil) -> ImageDownloadService {
+    package static func mock(with session: URLSessionProtocol, cache: ImageCaching? = nil) -> ImageDownloadService {
         let client = URLSessionHTTPClient(urlSession: session)
         let service = ImageDownloadService(client: client, cache: cache)
         return service

--- a/Sources/TestHelpers/ImageHelper.swift
+++ b/Sources/TestHelpers/ImageHelper.swift
@@ -13,11 +13,11 @@ package class ImageHelper {
         dataFromImage(named: "test", type: "png")!
     }
 
-    static var placeholderImage: UIImage {
+    package static var placeholderImage: UIImage {
         image(named: "placeholder", type: "png")!
     }
 
-    static var exampleAvatarImage: UIImage {
+    package static var exampleAvatarImage: UIImage {
         image(named: "example_avatar", type: "png")!
     }
 

--- a/Sources/TestHelpers/ImageHelper.swift
+++ b/Sources/TestHelpers/ImageHelper.swift
@@ -1,15 +1,15 @@
 import UIKit
 
-class ImageHelper {
+package class ImageHelper {
     private init() {}
 
     static let testResourcesDir = "Gravatar_Gravatar-Tests.bundle/ResourceFiles/"
 
-    static var testImage: UIImage {
+    package static var testImage: UIImage {
         image(named: "test", type: "png")!
     }
 
-    static var testImageData: Data {
+    package static var testImageData: Data {
         dataFromImage(named: "test", type: "png")!
     }
 

--- a/Sources/TestHelpers/TestImageCache.swift
+++ b/Sources/TestHelpers/TestImageCache.swift
@@ -1,14 +1,16 @@
 import Gravatar
 import UIKit
 
-actor TestImageCache: ImageCaching {
+package actor TestImageCache: ImageCaching {
     var dict: [String: CacheEntryWrapper] = [:]
 
-    private(set) var getImageCallsCount = 0
-    private(set) var setImageCallsCount = 0
-    private(set) var setTaskCallsCount = 0
+    package private(set) var getImageCallsCount = 0
+    package private(set) var setImageCallsCount = 0
+    package private(set) var setTaskCallsCount = 0
 
-    func setEntry(_ entry: Gravatar.CacheEntry?, for key: String) async {
+    package init() {}
+
+    package func setEntry(_ entry: Gravatar.CacheEntry?, for key: String) async {
         guard let entry else {
             dict[key] = nil
             return
@@ -22,15 +24,15 @@ actor TestImageCache: ImageCaching {
         dict[key] = CacheEntryWrapper(entry)
     }
 
-    func getEntry(with key: String) async -> Gravatar.CacheEntry? {
+    package func getEntry(with key: String) async -> Gravatar.CacheEntry? {
         getImageCallsCount += 1
         return dict[key]?.cacheEntry
     }
 }
 
-struct CacheEntryWrapper: Sendable {
+package struct CacheEntryWrapper: Sendable {
     let cacheEntry: CacheEntry
-    init(_ cacheEntry: CacheEntry) {
+    package init(_ cacheEntry: CacheEntry) {
         self.cacheEntry = cacheEntry
     }
 }

--- a/Sources/TestHelpers/TestImageProcessor.swift
+++ b/Sources/TestHelpers/TestImageProcessor.swift
@@ -14,8 +14,10 @@ package final class TestImageProcessor: ImageProcessor {
     }
 }
 
-final class FailingImageProcessor: ImageProcessor {
-    func process(_: Data) -> UIImage? {
+package final class FailingImageProcessor: ImageProcessor {
+    package func process(_: Data) -> UIImage? {
         nil
     }
+
+    package init() {}
 }

--- a/Sources/TestHelpers/TestImageProcessor.swift
+++ b/Sources/TestHelpers/TestImageProcessor.swift
@@ -1,13 +1,13 @@
 import Gravatar
 import UIKit
 
-final class TestImageProcessor: ImageProcessor {
+package final class TestImageProcessor: ImageProcessor {
     let identifier: String
-    init(identifier: String = "") {
+    package init(identifier: String = "") {
         self.identifier = identifier
     }
 
-    func process(_: Data) -> UIImage? {
+    package func process(_: Data) -> UIImage? {
         let image = UIImage()
         image.accessibilityIdentifier = identifier
         return image

--- a/Sources/TestHelpers/URLSessionMock.swift
+++ b/Sources/TestHelpers/URLSessionMock.swift
@@ -2,7 +2,7 @@ import Foundation
 import Gravatar
 
 package actor URLSessionMock: URLSessionProtocol {
-    static let jsonData = """
+    package static let jsonData = """
     {
         "name": "John",
         "surname": "Appleseed"
@@ -63,11 +63,11 @@ package actor URLSessionMock: URLSessionProtocol {
         self.request = request
     }
 
-    func update(isCancellable: Bool) async {
+    package func update(isCancellable: Bool) async {
         self.isCancellable = isCancellable
     }
 
-    func update(maxDurationSeconds: Double) async {
+    package func update(maxDurationSeconds: Double) async {
         self.maxDurationSeconds = maxDurationSeconds
     }
 }

--- a/Sources/TestHelpers/URLSessionMock.swift
+++ b/Sources/TestHelpers/URLSessionMock.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Gravatar
 
-actor URLSessionMock: URLSessionProtocol {
+package actor URLSessionMock: URLSessionProtocol {
     static let jsonData = """
     {
         "name": "John",
@@ -14,21 +14,24 @@ actor URLSessionMock: URLSessionProtocol {
     let error: NSError?
     private(set) var isCancellable: Bool = false
     private(set) var maxDurationSeconds: Double = 2
-    private(set) var callsCount = 0
-    private(set) var request: URLRequest? = nil
-    private(set) var uploadData: Data? = nil
+    package private(set) var callsCount = 0
+    package private(set) var request: URLRequest? = nil
+    package private(set) var uploadData: Data? = nil
 
-    init(returnData: Data, response: HTTPURLResponse, error: NSError? = nil) {
+    package init(returnData: Data, response: HTTPURLResponse, error: NSError? = nil) {
         self.returnData = returnData
         self.response = response
         self.error = error
     }
 
-    nonisolated func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+    package nonisolated func dataTask(
+        with request: URLRequest,
+        completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void
+    ) -> URLSessionDataTask {
         fatalError()
     }
 
-    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+    package func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         callsCount += 1
         self.request = request
         if isCancellable {
@@ -47,7 +50,7 @@ actor URLSessionMock: URLSessionProtocol {
         return (returnData, response)
     }
 
-    func upload(for request: URLRequest, from bodyData: Data) async throws -> (Data, URLResponse) {
+    package func upload(for request: URLRequest, from bodyData: Data) async throws -> (Data, URLResponse) {
         self.request = request
         self.uploadData = bodyData
         if let error {

--- a/Tests/GravatarTests/AvatarServiceTests.swift
+++ b/Tests/GravatarTests/AvatarServiceTests.swift
@@ -1,5 +1,5 @@
 @testable import Gravatar
-@testable import TestHelpers
+import TestHelpers
 import XCTest
 
 final class AvatarServiceTests: XCTestCase {

--- a/Tests/GravatarTests/GravatarImageCacheTests.swift
+++ b/Tests/GravatarTests/GravatarImageCacheTests.swift
@@ -1,5 +1,5 @@
 import Gravatar
-@testable import TestHelpers
+import TestHelpers
 import XCTest
 
 final class GravatarImageCacheTests: XCTestCase {

--- a/Tests/GravatarTests/ImageDownloadServiceTests.swift
+++ b/Tests/GravatarTests/ImageDownloadServiceTests.swift
@@ -1,5 +1,5 @@
 @testable import Gravatar
-@testable import TestHelpers
+import TestHelpers
 import XCTest
 
 final class ImageDownloadServiceTests: XCTestCase {

--- a/Tests/GravatarTests/ProfileServiceTests.swift
+++ b/Tests/GravatarTests/ProfileServiceTests.swift
@@ -1,5 +1,5 @@
 @testable import Gravatar
-@testable import TestHelpers
+import TestHelpers
 import XCTest
 
 final class ProfileServiceTests: XCTestCase {

--- a/Tests/GravatarTests/URLSessionHTTPClientTests.swift
+++ b/Tests/GravatarTests/URLSessionHTTPClientTests.swift
@@ -1,5 +1,5 @@
 @testable import Gravatar
-@testable import TestHelpers
+import TestHelpers
 import XCTest
 
 final class URLSessionHTTPClientTests: XCTestCase {

--- a/Tests/GravatarUITests/GravatarOptionsTests.swift
+++ b/Tests/GravatarUITests/GravatarOptionsTests.swift
@@ -1,6 +1,6 @@
 @testable import Gravatar
 @testable import GravatarUI
-@testable import TestHelpers
+import TestHelpers
 import XCTest
 
 final class GravatarOptionsTests: XCTestCase {

--- a/Tests/GravatarUITests/GravatarWrapper+UIImageViewTests.swift
+++ b/Tests/GravatarUITests/GravatarWrapper+UIImageViewTests.swift
@@ -1,5 +1,5 @@
 import GravatarUI
-@testable import TestHelpers
+import TestHelpers
 import XCTest
 
 final class GravatarWrapper_UIImageViewTests: XCTestCase {

--- a/Tests/GravatarUITests/ProfileViewModelTests.swift
+++ b/Tests/GravatarUITests/ProfileViewModelTests.swift
@@ -2,7 +2,7 @@ import Combine
 @testable import Gravatar
 import GravatarUI
 import SnapshotTesting
-@testable import TestHelpers
+import TestHelpers
 import XCTest
 
 final class ProfileViewModelTests: XCTestCase {

--- a/Tests/GravatarUITests/ProvileViewSnapshots.swift
+++ b/Tests/GravatarUITests/ProvileViewSnapshots.swift
@@ -1,7 +1,7 @@
 import Gravatar
 import GravatarUI
 import SnapshotTesting
-@testable import TestHelpers
+import TestHelpers
 import XCTest
 
 final class ProfileViewSnapshots: XCTestCase {

--- a/Tests/GravatarUITests/TestImageFetcher.swift
+++ b/Tests/GravatarUITests/TestImageFetcher.swift
@@ -1,5 +1,5 @@
 import GravatarUI
-@testable import TestHelpers
+import TestHelpers
 import XCTest
 
 enum GravatarImageSetMockResult {


### PR DESCRIPTION
Closes #

### Description

Since the `TestHelper` target is not listed as a Product in the `Package.swift`, it is not available for use by third parties who integrate our SDK.

Instead of using `@testable`, let's set the access levels in the `TestHelper` module such that they reflect our usage of the module from the `GravatarTests` and `GravatarUITests` modules.

- Stops using`@testable import` imports when importning `TestHelper` in the `GravatarTests` and `GravatarUITests` unit tests.
- Makes the bare minimum access changes within the `TestHelper` module to accommodate this change
- Uses `package` access

### Testing Steps

- [ ] All `GravatarTests` should pass locally
- [ ] All `GravatarUITests` should pass locally
- [ ] `make validate-pod` should pass locally (note: there is one warning about deprecation, which CI ignores)
- [ ] You should _not_ be able to `import TestHelper` from the Demo App
- [ ] CI should be 🟢 