### PR TITLE
Implementing v3 version of image upload endpoint

### DIFF
--- a/Demo/Demo/Gravatar-UIKit-Demo/DemoUploadImageViewController.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/DemoUploadImageViewController.swift
@@ -111,29 +111,19 @@ class DemoUploadImageViewController: UIViewController {
         let service = Gravatar.AvatarService()
         Task {
             do {
-               try await service.upload(image, accessToken: token)
-                resultLabel.text = "✅"
+               let avatarModel = try await service.upload(image, accessToken: token)
+                resultLabel.text = "✅ New avatar id \(avatarModel.imageId)"
             } catch {
-                uploadResult(with: error)
+                resultLabel.text = "Error \((error as NSError).code): \(error.localizedDescription)"
             }
             activityIndicator.stopAnimating()
-        }
-    }
-
-    func uploadResult(with error: Error?) {
-        activityIndicator.stopAnimating()
-        if let error = error as? NSError {
-            print("Error: \(error)")
-            resultLabel.text = "Error \(error.code): \(error.localizedDescription)"
-        } else {
-            resultLabel.text = "Success! 🎉"
         }
     }
 }
 
 extension DemoUploadImageViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-        guard let image = info[.editedImage] as? UIImage, let rect = info[.cropRect] else { return }
+        guard let image = info[.editedImage] as? UIImage else { return }
 
         let squareImage = makeSquare(image)
         avatarImageView.image = squareImage

--- a/Demo/Demo/Gravatar-UIKit-Demo/DemoUploadImageViewController.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/DemoUploadImageViewController.swift
@@ -111,10 +111,12 @@ class DemoUploadImageViewController: UIViewController {
         let service = Gravatar.AvatarService()
         Task {
             do {
-               try await service.upload(image, email: Email(email), accessToken: token)
+               try await service.upload(image, accessToken: token)
+                resultLabel.text = "✅"
             } catch {
                 uploadResult(with: error)
             }
+            activityIndicator.stopAnimating()
         }
     }
 
@@ -131,9 +133,27 @@ class DemoUploadImageViewController: UIViewController {
 
 extension DemoUploadImageViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-        guard let image = info[.editedImage] as? UIImage else { return }
-        avatarImageView.image = image
+        guard let image = info[.editedImage] as? UIImage, let rect = info[.cropRect] else { return }
+
+        let squareImage = makeSquare(image)
+        avatarImageView.image = squareImage
 
         dismiss(animated: true)
+    }
+
+    /// Squares the given image by fitting it into a square shape.
+    /// Think of it as the mode "aspect fit".
+    private func makeSquare(_ image: UIImage) -> UIImage {
+        let squareSide = max(image.size.height, image.size.width)
+        let squareSize = CGSize(width: squareSide, height: squareSide)
+        let imageOrigin = CGPoint(x: (squareSide - image.size.width) / 2, y: (squareSide - image.size.height) / 2)
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        return UIGraphicsImageRenderer(size: squareSize, format: format).image { context in
+            UIColor.black.setFill()
+            context.fill(CGRect(origin: .zero, size: squareSize))
+            image.draw(in: CGRect(origin: imageOrigin, size: image.size))
+        }
     }
 }

--- a/Sources/Gravatar/Network/Data+Extension.swift
+++ b/Sources/Gravatar/Network/Data+Extension.swift
@@ -8,7 +8,6 @@ extension Data {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = dateDecodingStrategy
         decoder.keyDecodingStrategy = keyDecodingStrategy
-        let result = try decoder.decode(T.self, from: self)
-        return result
+        return try decoder.decode(T.self, from: self)
     }
 }

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -45,7 +45,19 @@ public struct AvatarService: Sendable {
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
     /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
     @discardableResult
+    @available(*, deprecated, renamed: "upload(_:accessToken:)")
     public func upload(_ image: UIImage, email: Email, accessToken: String) async throws -> URLResponse {
-        try await imageUploader.uploadImage(image, email: email, accessToken: accessToken, additionalHTTPHeaders: [(name: "Client-Type", value: "ios")])
+        try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: [(name: "Client-Type", value: "ios")])
+    }
+
+    /// Uploads an image to be used as the user's Gravatar profile image, and returns the `URLResponse` of the network tasks asynchronously. Throws
+    /// ``ImageUploadError``.
+    /// - Parameters:
+    ///   - image: The image to be uploaded.
+    ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
+    /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
+    @discardableResult
+    public func upload(_ image: UIImage, accessToken: String) async throws -> URLResponse {
+        try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: [(name: "Client-Type", value: "ios")])
     }
 }

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -55,7 +55,7 @@ public struct AvatarService: Sendable {
     /// - Parameters:
     ///   - image: The image to be uploaded.
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
-    /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
+    /// - Returns: An asynchronously-delivered `AvatarModel` instance, containing data of the newly created avatar.
     @discardableResult
     public func upload(_ image: UIImage, accessToken: String) async throws -> AvatarModel {
         let (data, _) = try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: [(name: "Client-Type", value: "ios")])

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -47,7 +47,7 @@ public struct AvatarService: Sendable {
     @discardableResult
     @available(*, deprecated, renamed: "upload(_:accessToken:)")
     public func upload(_ image: UIImage, email: Email, accessToken: String) async throws -> URLResponse {
-        try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: [(name: "Client-Type", value: "ios")])
+        try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: [(name: "Client-Type", value: "ios")]).response
     }
 
     /// Uploads an image to be used as the user's Gravatar profile image, and returns the `URLResponse` of the network tasks asynchronously. Throws
@@ -57,7 +57,20 @@ public struct AvatarService: Sendable {
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
     /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
     @discardableResult
-    public func upload(_ image: UIImage, accessToken: String) async throws -> URLResponse {
-        try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: [(name: "Client-Type", value: "ios")])
+    public func upload(_ image: UIImage, accessToken: String) async throws -> AvatarModel {
+        let (data, _) = try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: [(name: "Client-Type", value: "ios")])
+        do {
+            return try data.decode(keyDecodingStrategy: .convertFromSnakeCase)
+        } catch {
+            throw ImageUploadError.responseError(reason: .unexpected(error))
+        }
     }
+}
+
+// NOTE: This will be replaced by open-api spec
+public struct AvatarModel: Decodable {
+    public let imageId: String
+    public let imageUrl: String
+    public let rating: String
+    public let altText: String
 }

--- a/Sources/Gravatar/Network/Services/HTTPClient.swift
+++ b/Sources/Gravatar/Network/Services/HTTPClient.swift
@@ -15,5 +15,5 @@ public protocol HTTPClient: Sendable {
     ///   - request: A URL request object that provides request-specific information such as the URL and cache policy.
     ///   - data: The data to be uploaded.
     /// - Returns: An asynchronously-delivered instance of the returned HTTPURLResponse.
-    func uploadData(with request: URLRequest, data: Data) async throws -> HTTPURLResponse
+    func uploadData(with request: URLRequest, data: Data) async throws -> (Data, HTTPURLResponse)
 }

--- a/Sources/Gravatar/Network/Services/ImageUploader.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploader.swift
@@ -15,7 +15,6 @@ protocol ImageUploader: Sendable {
     @discardableResult
     func uploadImage(
         _ image: UIImage,
-        email: Email,
         accessToken: String,
         additionalHTTPHeaders: [HTTPHeaderField]?
     ) async throws -> URLResponse

--- a/Sources/Gravatar/Network/Services/ImageUploader.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploader.swift
@@ -17,5 +17,5 @@ protocol ImageUploader: Sendable {
         _ image: UIImage,
         accessToken: String,
         additionalHTTPHeaders: [HTTPHeaderField]?
-    ) async throws -> URLResponse
+    ) async throws -> (data: Data, response: HTTPURLResponse)
 }

--- a/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
+++ b/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
@@ -25,14 +25,14 @@ struct URLSessionHTTPClient: HTTPClient {
         return (result.data, httpResponse)
     }
 
-    func uploadData(with request: URLRequest, data: Data) async throws -> HTTPURLResponse {
+    func uploadData(with request: URLRequest, data: Data) async throws -> (Data, HTTPURLResponse) {
         let result: (data: Data, response: URLResponse)
         do {
             result = try await urlSession.upload(for: request, from: data)
         } catch {
             throw HTTPClientError.URLSessionError(error)
         }
-        return try validatedHTTPResponse(result.response)
+        return try (result.data, validatedHTTPResponse(result.response))
     }
 }
 

--- a/Sources/TestHelpers/HTTPClientMock.swift
+++ b/Sources/TestHelpers/HTTPClientMock.swift
@@ -13,7 +13,7 @@ package struct HTTPClientMock: HTTPClient {
         return (session.returnData, session.response)
     }
 
-    package func uploadData(with request: URLRequest, data: Data) async throws -> HTTPURLResponse {
-        session.response
+    package func uploadData(with request: URLRequest, data: Data) async throws -> (Data, HTTPURLResponse) {
+        (session.returnData, session.response)
     }
 }

--- a/Tests/GravatarTests/AvatarServiceTests.swift
+++ b/Tests/GravatarTests/AvatarServiceTests.swift
@@ -22,10 +22,12 @@ final class AvatarServiceTests: XCTestCase {
 
     func testUploadImage() async throws {
         let successResponse = HTTPURLResponse.successResponse()
-        let sessionMock = URLSessionMock(returnData: "Success".data(using: .utf8)!, response: successResponse)
+        let sessionMock = URLSessionMock(returnData: Bundle.imageUploadJsonData!, response: successResponse)
         let service = avatarService(with: sessionMock)
 
-        try await service.upload(ImageHelper.testImage, accessToken: "AccessToken")
+        let avatar = try await service.upload(ImageHelper.testImage, accessToken: "AccessToken")
+
+        XCTAssertEqual(avatar.imageId, "6f3eac1c67f970f2a0c2ea8")
 
         let request = await sessionMock.request
         XCTAssertEqual(request?.url?.absoluteString, "https://api.gravatar.com/v3/me/avatars")

--- a/Tests/GravatarTests/ProfileServiceTests.swift
+++ b/Tests/GravatarTests/ProfileServiceTests.swift
@@ -89,4 +89,8 @@ extension Bundle {
     static var fullProfileJsonData: Data? {
         testsBundle.jsonData(forResource: "fullProfile")
     }
+
+    static var imageUploadJsonData: Data? {
+        testsBundle.jsonData(forResource: "avatarUploadResponse")
+    }
 }

--- a/Tests/GravatarTests/Resources/avatarUploadResponse.json
+++ b/Tests/GravatarTests/Resources/avatarUploadResponse.json
@@ -1,0 +1,9 @@
+{
+  "image_id": "6f3eac1c67f970f2a0c2ea8",
+  "image_url": "/userimage/000000001/6f3eac1c67f970f2a0c2ea8.jpeg",
+  "is_cropped": false,
+  "format": 0,
+  "rating": "G",
+  "updated_date": "",
+  "altText": "John Appleseed's avatar"
+}


### PR DESCRIPTION
### Description

This PR implements `POST api.gravatar.com/v3/me/avatars`.

One big difference between v1 and v3 is that v1 was able to square an image if it wasn't square already. V3 in contrast won't square the image but expect it to be square or return an error otherwise.

The Native image picker on iOS won't always crop a perfect square:
- Sometimes will be off by 1 or 2 pixels
- It won't square an image in landscape if its completely zoomed out, which makes it not ideal.

<img src="https://github.com/user-attachments/assets/e78ac8fe-df0d-4bcc-a59e-aab016a24d79" width="30%">


On this PR, we solve the problem in the demo app side, by rendering a square image and embedding the original photo in it, which is what the v1 endpoint was doing on the backend.

For example:

<img src="https://github.com/user-attachments/assets/972bd74d-162e-47da-9abd-bf915a0dbfb1" width="40%">

On the image picker, we can have this logic internally, or build our own cropper without these issues.

### Testing Steps

- Upload an image on the UIKit demo app.
