### PR TITLE
Add a reusable SwiftUI Toast

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -21,35 +21,41 @@ struct AvatarPickerView: View {
 
     @StateObject var model: AvatarPickerViewModel
     @Environment(\.colorScheme) var colorScheme: ColorScheme
+    @State private var showToast = false
 
     init(model: AvatarPickerViewModel) {
         _model = StateObject(wrappedValue: model)
     }
 
     public var body: some View {
-        VStack {
-            profileView()
-            ScrollView {
-                errorView()
+        ZStack {
+            VStack {
+                profileView()
+                ScrollView {
+                    errorView()
 
-                if case .success(let avatarImageModelList) = model.avatarsResult,
-                   !avatarImageModelList.models.isEmpty
-                {
-                    header()
-                    avatarGrid(with: avatarImageModelList.models)
-                } else if model.isAvatarsLoading {
-                    avatarsLoadingView()
+                    if case .success(let avatarImageModelList) = model.avatarsResult,
+                       !avatarImageModelList.models.isEmpty
+                    {
+                        header()
+                        avatarGrid(with: avatarImageModelList.models)
+                    } else if model.isAvatarsLoading {
+                        avatarsLoadingView()
+                    }
+                }
+                .task {
+                    model.refresh()
+                }
+                if model.avatarsResult?.value()?.models.isEmpty == false {
+                    imagePicker {
+                        CTAButtonView("Upload image")
+                    }
+                    .padding(Constants.padding)
                 }
             }
-            .task {
-                model.refresh()
-            }
-            if model.avatarsResult?.value()?.models.isEmpty == false {
-                imagePicker {
-                    CTAButtonView("Upload image")
-                }
-                .padding(Constants.padding)
-            }
+
+            ToastContainerView(toastManager: model.toastManager)
+                .padding(.horizontal, Constants.horizontalPadding * 2)
         }
     }
 
@@ -241,6 +247,8 @@ struct AvatarPickerView: View {
     private var profileShadowRadius: CGFloat {
         colorScheme == .light ? 30 : 0
     }
+
+    private func showToast(message: String) {}
 }
 
 #Preview("Existing elements") {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -21,7 +21,6 @@ struct AvatarPickerView: View {
 
     @StateObject var model: AvatarPickerViewModel
     @Environment(\.colorScheme) var colorScheme: ColorScheme
-    @State private var showToast = false
 
     init(model: AvatarPickerViewModel) {
         _model = StateObject(wrappedValue: model)
@@ -247,8 +246,6 @@ struct AvatarPickerView: View {
     private var profileShadowRadius: CGFloat {
         colorScheme == .light ? 30 : 0
     }
-
-    private func showToast(message: String) {}
 }
 
 #Preview("Existing elements") {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -45,13 +45,12 @@ class AvatarPickerViewModel: ObservableObject {
     @Published private(set) var isAvatarsLoading: Bool = false
     @Published var avatarIdentifier: AvatarIdentifier?
     @Published var profileModel: AvatarPickerProfileView.Model?
-    @ObservedObject var toastManager: ToastManager
+    @ObservedObject var toastManager: ToastManager = .init()
 
     init(email: Email, authToken: String) {
         self.email = email
         avatarIdentifier = .email(email)
         self.authToken = authToken
-        self.toastManager = ToastManager()
     }
 
     /// Internal init for previewing purposes. Do not make this public.
@@ -65,7 +64,6 @@ class AvatarPickerViewModel: ObservableObject {
         if let profileModel {
             self.profileResult = .success(profileModel)
         }
-        self.toastManager = ToastManager()
     }
 
     func selectAvatar(with id: String) {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -45,11 +45,13 @@ class AvatarPickerViewModel: ObservableObject {
     @Published private(set) var isAvatarsLoading: Bool = false
     @Published var avatarIdentifier: AvatarIdentifier?
     @Published var profileModel: AvatarPickerProfileView.Model?
+    @ObservedObject var toastManager: ToastManager
 
     init(email: Email, authToken: String) {
         self.email = email
         avatarIdentifier = .email(email)
         self.authToken = authToken
+        self.toastManager = ToastManager()
     }
 
     /// Internal init for previewing purposes. Do not make this public.
@@ -63,6 +65,7 @@ class AvatarPickerViewModel: ObservableObject {
         if let profileModel {
             self.profileResult = .success(profileModel)
         }
+        self.toastManager = ToastManager()
     }
 
     func selectAvatar(with id: String) {
@@ -81,6 +84,7 @@ class AvatarPickerViewModel: ObservableObject {
             do {
                 setLoading(to: true, onAvatarWithID: id)
                 try await postAvatarSelection(with: id, identifier: .email(email))
+                toastManager.showToast("Avatar updated! May take a few minutes to appear every where.", type: .info)
             } catch APIError.responseError(let reason) where reason.cancelled {
                 // NoOp.
             } catch {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -84,7 +84,7 @@ class AvatarPickerViewModel: ObservableObject {
             do {
                 setLoading(to: true, onAvatarWithID: id)
                 try await postAvatarSelection(with: id, identifier: .email(email))
-                toastManager.showToast("Avatar updated! May take a few minutes to appear every where.", type: .info)
+                toastManager.showToast("Avatar updated! May take a few minutes to appear everywhere.", type: .info)
             } catch APIError.responseError(let reason) where reason.cancelled {
                 // NoOp.
             } catch {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -84,7 +84,7 @@ class AvatarPickerViewModel: ObservableObject {
             do {
                 setLoading(to: true, onAvatarWithID: id)
                 try await postAvatarSelection(with: id, identifier: .email(email))
-                toastManager.showToast("Avatar updated! May take a few minutes to appear everywhere.", type: .info)
+                toastManager.showToast("Avatar updated! It may take a few minutes to appear everywhere.", type: .info)
             } catch APIError.responseError(let reason) where reason.cancelled {
                 // NoOp.
             } catch {

--- a/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
@@ -39,7 +39,7 @@ struct Toast: View {
 
 #Preview {
     Toast(toast: .init(
-        message: "Avatar updated! May take a few minutes to appear everywhere.",
+        message: "Avatar updated! It may take a few minutes to appear everywhere.",
         type: .info
     )) { _ in
     }

--- a/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
@@ -39,7 +39,7 @@ struct Toast: View {
 
 #Preview {
     Toast(toast: .init(
-        message: "Avatar updated! May take a few minutes to appear every where.",
+        message: "Avatar updated! May take a few minutes to appear everywhere.",
         type: .info
     )) { _ in
     }

--- a/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct Toast: View {
+    private enum Constants {
+        static let backgroundLight: Color = .init(uiColor: .rgba(30, 30, 30))
+        static let backgroundDark: Color = .init(uiColor: .rgba(225, 225, 225))
+    }
+
+    @Environment(\.colorScheme) var colorScheme: ColorScheme
+    private(set) var toast: ToastItem
+    private(set) var dismissHandler: (ToastItem) -> Void
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Text(toast.message.localized)
+                .font(.footnote)
+            Spacer(minLength: .DS.Padding.medium)
+            Button {
+                dismissHandler(toast)
+            } label: {
+                Text("Got it")
+                    .font(.footnote)
+                    .underline(true)
+            }
+        }
+        .padding(.horizontal, .DS.Padding.double)
+        .padding(.vertical, .DS.Padding.split)
+        .background(backgroundColor)
+        .cornerRadius(4)
+        .foregroundColor(Color(UIColor.systemBackground))
+        .shadow(radius: 3, y: 3)
+        .zIndex(1)
+    }
+
+    var backgroundColor: Color {
+        colorScheme == .dark ? Constants.backgroundDark : Constants.backgroundLight
+    }
+}
+
+#Preview {
+    Toast(toast: .init(
+        message: "Avatar updated! May take a few minutes to appear every where.",
+        type: .info
+    )) { _ in
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/Toast/ToastContainerView.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/ToastContainerView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct ToastContainerView: View {
+    @ObservedObject var toastManager: ToastManager
+
+    var body: some View {
+        VStack {
+            Spacer()
+            ForEach(toastManager.toasts) { toast in
+                Toast(toast: toast) { toast in
+                    toastManager.removeToast(toast.id)
+                }
+                .frame(width: .infinity)
+            }
+        }
+        .frame(idealWidth: .infinity)
+        .animation(.spring(), value: toastManager.toasts)
+        .edgesIgnoringSafeArea(.bottom)
+        .padding(.bottom, .DS.Padding.half)
+    }
+}
+
+#Preview {
+    VStack {
+        var toastManager = ToastManager()
+        ToastContainerView(toastManager: toastManager)
+            .frame(width: .infinity)
+            .padding(.horizontal, .DS.Padding.medium)
+        Button {
+            toastManager.showToast("Hi! This is a toast! You can show multiple toasts at a time!")
+        } label: {
+            Text("Show toast!")
+        }
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/Toast/ToastContainerView.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/ToastContainerView.swift
@@ -10,11 +10,11 @@ struct ToastContainerView: View {
                 Toast(toast: toast, dismissHandler: { toast in
                     toastManager.removeToast(toast.id)
                 })
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
         }
         .frame(idealWidth: .infinity)
         .animation(.spring(), value: toastManager.toasts)
-        .transition(.opacity.combined(with: .move(edge: .bottom)))
         .edgesIgnoringSafeArea(.bottom)
         .padding(.bottom, .DS.Padding.half)
     }

--- a/Sources/GravatarUI/SwiftUI/Toast/ToastContainerView.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/ToastContainerView.swift
@@ -22,7 +22,7 @@ struct ToastContainerView: View {
 
 #Preview {
     VStack {
-        var toastManager = ToastManager()
+        let toastManager = ToastManager()
         ToastContainerView(toastManager: toastManager)
             .frame(width: .infinity)
             .padding(.horizontal, .DS.Padding.medium)

--- a/Sources/GravatarUI/SwiftUI/Toast/ToastContainerView.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/ToastContainerView.swift
@@ -14,6 +14,7 @@ struct ToastContainerView: View {
         }
         .frame(idealWidth: .infinity)
         .animation(.spring(), value: toastManager.toasts)
+        .transition(.opacity.combined(with: .move(edge: .bottom)))
         .edgesIgnoringSafeArea(.bottom)
         .padding(.bottom, .DS.Padding.half)
     }

--- a/Sources/GravatarUI/SwiftUI/Toast/ToastContainerView.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/ToastContainerView.swift
@@ -10,7 +10,6 @@ struct ToastContainerView: View {
                 Toast(toast: toast, dismissHandler: { toast in
                     toastManager.removeToast(toast.id)
                 })
-                .frame(width: .infinity)
             }
         }
         .frame(idealWidth: .infinity)

--- a/Sources/GravatarUI/SwiftUI/Toast/ToastContainerView.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/ToastContainerView.swift
@@ -7,9 +7,9 @@ struct ToastContainerView: View {
         VStack {
             Spacer()
             ForEach(toastManager.toasts) { toast in
-                Toast(toast: toast) { toast in
+                Toast(toast: toast, dismissHandler: { toast in
                     toastManager.removeToast(toast.id)
-                }
+                })
                 .frame(width: .infinity)
             }
         }

--- a/Sources/GravatarUI/SwiftUI/Toast/ToastManager.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/ToastManager.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+@MainActor
+class ToastManager: ObservableObject {
+    @Published var toasts: [ToastItem] = []
+
+    func showToast(_ message: String, type: ToastType = .info) {
+        let toast = ToastItem(message: message, type: type)
+        toasts.append(toast)
+        DispatchQueue.main.asyncAfter(deadline: .now() + calculateToastDuration(for: message)) {
+            self.removeToast(toast.id)
+        }
+    }
+
+    func removeToast(_ toastID: UUID) {
+        withAnimation {
+            toasts.removeAll { $0.id == toastID }
+        }
+    }
+
+    private func calculateToastDuration(for message: String) -> TimeInterval {
+        let baseTime: TimeInterval = 2.0
+        let timePerCharacter: TimeInterval = 0.03
+        return baseTime + timePerCharacter * Double(message.count)
+    }
+}
+
+enum ToastType: Int {
+    case info
+    case error
+}
+
+struct ToastItem: Identifiable, Equatable {
+    let id: UUID = .init()
+    let message: String
+    let type: ToastType
+}


### PR DESCRIPTION
Closes #344 

From [figma](https://www.figma.com/design/xgXj4jig9m0DYfKjFq6swG/QE-Native-Experience?node-id=44-1094&t=yLKB0mpLbWKJq07R-0):

<img width="280" alt="Screenshot 2024-08-12 at 15 43 15" src="https://github.com/user-attachments/assets/5bad9544-2b7b-4f55-8de1-f7ff8e9cf436">

### Description

- Adds an easily reusable toast view.
- Each toast is added to the toast queue by the business logic. The queue is observed by the ToastContainerView and reflected to UI.
- We can display multiple toast at a time.
- A Toast will dismiss itself after a while automatically.
- The toast duration is calculated according to a formula so longer messages will be displayed longer.
- Light & dark modes supported.

https://github.com/user-attachments/assets/3d89d702-7a1f-4d1f-a89f-27b761a2af9b

### Testing Steps

* SwiftUI demo app > Avatar Picker > Change avatar

You can also play around with ToastContainerView preview.