### PR TITLE
Extract Grid view from Picker view

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarGridModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarGridModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Describes and manages a grid of avatars.
-class GridModel: ObservableObject {
+class AvatarGridModel: ObservableObject {
     @Published var avatars: [AvatarImageModel]
     @Published var selectedAvatar: AvatarImageModel?
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarImageModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarImageModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import UIKit
 
-struct AvatarImageModel: Hashable, Identifiable {
+struct AvatarImageModel: Hashable, Identifiable, Sendable {
     enum Source: Hashable {
         case remote(url: String)
         case local(image: UIImage)

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -24,12 +24,17 @@ struct AvatarPickerView: View {
                 profileView()
                 ScrollView {
                     errorView()
-
-                    if case .success(let avatarImageModelList) = model.avatarsResult,
-                       !avatarImageModelList.models.isEmpty
-                    {
+                    if !model.grid.isEmpty {
                         header()
-                        avatarGrid(with: avatarImageModelList.models)
+                        AvatarGrid(
+                            grid: model.grid,
+                            onAvatarTap: { avatar in
+                                model.selectAvatar(with: avatar.id)
+                            },
+                            onImageSelected: { image in
+                                uploadImage(image)
+                            }
+                        ).padding(Constants.padding)
                     } else if model.isAvatarsLoading {
                         avatarsLoadingView()
                     }
@@ -37,7 +42,7 @@ struct AvatarPickerView: View {
                 .task {
                     model.refresh()
                 }
-                if model.avatarsResult?.value()?.models.isEmpty == false {
+                if model.grid.isEmpty == false {
                     imagePicker {
                         CTAButtonView("Upload image")
                     }
@@ -130,9 +135,13 @@ struct AvatarPickerView: View {
 
     private func imagePicker(label: @escaping () -> some View) -> some View {
         SystemImagePickerView(label: label) { image in
-            Task {
-                await model.upload(image)
-            }
+            uploadImage(image)
+        }
+    }
+
+    private func uploadImage(_ image: UIImage) {
+        Task {
+            await model.upload(image)
         }
     }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -5,26 +5,18 @@ import SwiftUI
 struct AvatarPickerView: View {
     private enum Constants {
         static let horizontalPadding: CGFloat = .DS.Padding.double
-        static let maxAvatarWidth: CGFloat = 100
-        static let minAvatarWidth: CGFloat = 80
-        static let avatarSpacing: CGFloat = 20
         static let padding: EdgeInsets = .init(
             top: .DS.Padding.double,
             leading: horizontalPadding,
             bottom: .DS.Padding.double,
             trailing: horizontalPadding
         )
-        static let selectedBorderWidth: CGFloat = .DS.Padding.half
-        static let avatarCornerRadius: CGFloat = .DS.Padding.single
         static let lightModeShadowColor = Color(uiColor: UIColor.rgba(25, 30, 35, alpha: 0.2))
     }
 
-    @StateObject var model: AvatarPickerViewModel
-    @Environment(\.colorScheme) var colorScheme: ColorScheme
+    @ObservedObject var model: AvatarPickerViewModel
 
-    init(model: AvatarPickerViewModel) {
-        _model = StateObject(wrappedValue: model)
-    }
+    @Environment(\.colorScheme) var colorScheme: ColorScheme
 
     public var body: some View {
         VStack {
@@ -32,11 +24,16 @@ struct AvatarPickerView: View {
             ScrollView {
                 errorView()
 
-                if case .success(let avatarImageModelList) = model.avatarsResult,
-                   !avatarImageModelList.models.isEmpty
-                {
+                if !model.grid.isEmpty {
                     header()
-                    avatarGrid(with: avatarImageModelList.models)
+                    AvatarGrid(
+                        grid: model.grid,
+                        onAvatarTap: { avatar in
+                            model.selectAvatar(with: avatar.id)
+                        }, onImageSelected: { image in
+                            await model.upload(image)
+                        }
+                    ).padding(Constants.padding)
                 } else if model.isAvatarsLoading {
                     avatarsLoadingView()
                 }
@@ -44,7 +41,7 @@ struct AvatarPickerView: View {
             .task {
                 model.refresh()
             }
-            if model.avatarsResult?.value()?.models.isEmpty == false {
+            if model.grid.isEmpty == false {
                 imagePicker {
                     CTAButtonView("Upload image")
                 }
@@ -66,8 +63,8 @@ struct AvatarPickerView: View {
 
     private func errorView() -> some View {
         VStack(alignment: .center) {
-            switch model.avatarsResult {
-            case .success(let modelList) where modelList.models.isEmpty:
+            switch model.gridResponseStatus {
+            case .success where model.grid.isEmpty:
                 contentLoadingErrorView(
                     title: "Let's setup your avatar",
                     subtext: "Choose or upload your favorite avatar images and connect them to your email address.",
@@ -137,57 +134,6 @@ struct AvatarPickerView: View {
                 await model.upload(image)
             }
         }
-    }
-
-    @ViewBuilder
-    private func avatarGrid(with avatarImageModels: [AvatarImageModel]) -> some View {
-        let gridItems = [GridItem(
-            .adaptive(
-                minimum: Constants.minAvatarWidth,
-                maximum: Constants.maxAvatarWidth
-            ),
-            spacing: Constants.avatarSpacing
-        )]
-
-        LazyVGrid(columns: gridItems, spacing: Constants.avatarSpacing) {
-            imagePicker {
-                PlusButtonView(minSize: Constants.minAvatarWidth, maxSize: Constants.maxAvatarWidth)
-            }
-
-            ForEach(avatarImageModels) { avatar in
-                AvatarView(
-                    url: avatar.url,
-                    placeholder: avatar.localImage,
-                    loadingView: {
-                        ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle())
-                    }
-                )
-                .scaledToFill()
-                .frame(
-                    minWidth: Constants.minAvatarWidth,
-                    maxWidth: Constants.maxAvatarWidth,
-                    minHeight: Constants.minAvatarWidth,
-                    maxHeight: Constants.maxAvatarWidth
-                )
-                .background(Color(UIColor.secondarySystemBackground))
-                .aspectRatio(1, contentMode: .fill)
-                .shape(
-                    RoundedRectangle(cornerRadius: Constants.avatarCornerRadius),
-                    borderColor: .accentColor,
-                    borderWidth: model.selectedAvatarID == avatar.id ? Constants.selectedBorderWidth : 0
-                )
-                .overlay {
-                    if avatar.isLoading {
-                        OverlayActivityIndicatorView()
-                            .cornerRadius(Constants.avatarCornerRadius)
-                    }
-                }.onTapGesture {
-                    model.selectAvatar(with: avatar.id)
-                }
-            }
-        }
-        .padding(Constants.padding)
     }
 
     private func avatarsLoadingView() -> some View {
@@ -278,7 +224,7 @@ struct AvatarPickerView: View {
         }
     }
 
-    return AvatarPickerView(model: .init(
+    let model = AvatarPickerViewModel(
         avatarImageModels: [
             .init(id: "0", source: .local(image: UIImage()), isLoading: true),
             .init(id: "1", source: .remote(url: "https://gravatar.com/userimage/110207384/aa5f129a2ec75162cee9a1f0c472356a.jpeg?size=256")),
@@ -290,7 +236,9 @@ struct AvatarPickerView: View {
         ],
         selectedImageID: "5",
         profileModel: PreviewModel()
-    ))
+    )
+
+    return AvatarPickerView(model: model)
 }
 
 #Preview("Empty elements") {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -28,7 +28,7 @@ class AvatarPickerViewModel: ObservableObject {
     @Published var selectedAvatarURL: URL?
     @Published private(set) var gridResponseStatus: Result<Void, Error>?
 
-    let grid: GridModel = .init(avatars: [])
+    let grid: AvatarGridModel = .init(avatars: [])
 
     private var profileResult: Result<ProfileSummaryModel, Error>? {
         didSet {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/GridModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/GridModel.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Describes and manages a grid of avatars.
+class GridModel: ObservableObject {
+    @Published var avatars: [AvatarImageModel]
+    @Published var selectedAvatar: AvatarImageModel?
+
+    var isEmpty: Bool {
+        avatars.isEmpty
+    }
+
+    init(avatars: [AvatarImageModel], selectedAvatar: AvatarImageModel? = nil) {
+        self.avatars = avatars
+        self.selectedAvatar = selectedAvatar
+    }
+
+    func model(with id: String) -> AvatarImageModel? {
+        avatars.first { $0.id == id }
+    }
+
+    func index(of id: String) -> Int? {
+        avatars.firstIndex { $0.id == id }
+    }
+
+    func updateModel(_ currentModel: AvatarImageModel, with model: AvatarImageModel) {
+        guard let index = index(of: currentModel.id) else { return }
+        avatars[index] = model
+    }
+
+    func removeModel(_ id: String) {
+        avatars.removeAll { $0.id == id }
+    }
+
+    func setLoading(to isLoading: Bool, onAvatarWithID id: String) {
+        guard let imageModel = model(with: id) else { return }
+        let toggledModel = imageModel.settingLoading(to: isLoading)
+        updateModel(imageModel, with: toggledModel)
+    }
+
+    func append(_ newModel: AvatarImageModel) {
+        avatars.insert(newModel, at: 0)
+    }
+
+    func selectAvatar(_ selected: AvatarImageModel?) {
+        selectedAvatar = selected
+    }
+
+    func selectAvatar(withID selectedID: String?) {
+        guard let selectedID else {
+            selectedAvatar = nil
+            return
+        }
+        selectedAvatar = model(with: selectedID)
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarGrid.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarGrid.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+struct AvatarGrid: View {
+    private enum Constants {
+        static let horizontalPadding: CGFloat = .DS.Padding.double
+        static let maxAvatarWidth: CGFloat = 100
+        static let minAvatarWidth: CGFloat = 80
+        static let avatarSpacing: CGFloat = 20
+        static let selectedBorderWidth: CGFloat = .DS.Padding.half
+        static let avatarCornerRadius: CGFloat = .DS.Padding.single
+    }
+
+    let gridItems: [GridItem] = [GridItem(
+        .adaptive(
+            minimum: Constants.minAvatarWidth,
+            maximum: Constants.maxAvatarWidth
+        ),
+        spacing: Constants.avatarSpacing
+    )]
+
+    @ObservedObject var grid: GridModel
+
+    let onAvatarTap: (AvatarImageModel) -> Void
+    let onImageSelected: @Sendable (UIImage) async -> Void
+
+    var body: some View {
+        LazyVGrid(columns: gridItems, spacing: Constants.avatarSpacing) {
+            SystemImagePickerView {
+                PlusButtonView(minSize: Constants.minAvatarWidth, maxSize: Constants.maxAvatarWidth)
+            } onImageSelected: { image in
+                Task {
+                    await onImageSelected(image)
+                }
+            }
+
+            ForEach(grid.avatars) { avatar in
+                AvatarView(
+                    url: avatar.url,
+                    placeholder: avatar.localImage,
+                    loadingView: {
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle())
+                    }
+                )
+                .scaledToFill()
+                .frame(
+                    minWidth: Constants.minAvatarWidth,
+                    maxWidth: Constants.maxAvatarWidth,
+                    minHeight: Constants.minAvatarWidth,
+                    maxHeight: Constants.maxAvatarWidth
+                )
+                .background(Color(UIColor.secondarySystemBackground))
+                .aspectRatio(1, contentMode: .fill)
+                .shape(
+                    RoundedRectangle(cornerRadius: Constants.avatarCornerRadius),
+                    borderColor: .accentColor,
+                    borderWidth: grid.selectedAvatar?.id == avatar.id ? Constants.selectedBorderWidth : 0
+                )
+                .overlay {
+                    if avatar.isLoading {
+                        OverlayActivityIndicatorView()
+                            .cornerRadius(Constants.avatarCornerRadius)
+                    }
+                }.onTapGesture {
+                    onAvatarTap(avatar)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    let newAvatarModel: (UIImage?) -> AvatarImageModel = { image in
+        AvatarImageModel(id: UUID().uuidString, source: .local(image: image ?? UIImage()))
+    }
+    let initialAvatarCell = newAvatarModel(nil)
+    let grid = GridModel(
+        avatars: [initialAvatarCell]
+    )
+    grid.selectAvatar(initialAvatarCell)
+    return VStack {
+        AvatarGrid(grid: grid) { avatar in
+            grid.selectAvatar(withID: avatar.id)
+        } onImageSelected: { image in
+            grid.append(newAvatarModel(image))
+        }.padding()
+        Button("Add avatar cell") {
+            grid.append(newAvatarModel(nil))
+        }
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarGrid.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarGrid.swift
@@ -18,19 +18,17 @@ struct AvatarGrid: View {
         spacing: Constants.avatarSpacing
     )]
 
-    @ObservedObject var grid: GridModel
+    @ObservedObject var grid: AvatarGridModel
 
     let onAvatarTap: (AvatarImageModel) -> Void
-    let onImageSelected: @Sendable (UIImage) async -> Void
+    let onImageSelected: (UIImage) -> Void
 
     var body: some View {
         LazyVGrid(columns: gridItems, spacing: Constants.avatarSpacing) {
             SystemImagePickerView {
                 PlusButtonView(minSize: Constants.minAvatarWidth, maxSize: Constants.maxAvatarWidth)
             } onImageSelected: { image in
-                Task {
-                    await onImageSelected(image)
-                }
+                onImageSelected(image)
             }
 
             ForEach(grid.avatars) { avatar in
@@ -70,11 +68,11 @@ struct AvatarGrid: View {
 }
 
 #Preview {
-    let newAvatarModel: (UIImage?) -> AvatarImageModel = { image in
+    let newAvatarModel: @Sendable (UIImage?) -> AvatarImageModel = { image in
         AvatarImageModel(id: UUID().uuidString, source: .local(image: image ?? UIImage()))
     }
     let initialAvatarCell = newAvatarModel(nil)
-    let grid = GridModel(
+    let grid = AvatarGridModel(
         avatars: [initialAvatarCell]
     )
     grid.selectAvatar(initialAvatarCell)


### PR DESCRIPTION
Closes #

### Description

This PR tries to simplify the logic on AvatarPickerView and AvatarPickerViewModel.

I don't think this is a big simplification, but there's one big conceptual change which I like:

The avatar grid itself is now completely independent of the AvatarPickerView, with its own model which managed the status of the grid as a whole and of individual avatar cells, including avatar loading, selection, and (in the future) error state.

Avatar Grid model and view are independent of any networking (expect of image loading). All requests are managed by the  `AvatarPickerViewModel`, and updates the grid accordingly.

`AvatarPickerViewModel` holds a reference to the GridModel and updates it as needed, while `AvatarPickerView` will pass the grid model reference to the grid view.

In this way `AvatarPickerViewModel` is not responsible for holding the list of avatars, which avatar is selected, or individual avatar cell status, but it still holds the responses from networking.

### Testing Steps

- Using the SwiftUI example project.
- Upload avatars
- Select different avatars
  - Check that everything works as expected.
