### PR TITLE
[DO NOT MERGE] Demonstration using String Catalogs

### DIFF
--- a/Demo/Demo/Localizations/Localizable.xcstrings
+++ b/Demo/Demo/Localizations/Localizable.xcstrings
@@ -1,0 +1,33 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "" : {
+
+    },
+    "Animated" : {
+
+    },
+    "Border color" : {
+
+    },
+    "Email" : {
+
+    },
+    "Email:" : {
+
+    },
+    "Force refresh" : {
+
+    },
+    "Gravatar SwiftUI Demo" : {
+
+    },
+    "Tap to open the Avatar Picker" : {
+
+    },
+    "Token" : {
+
+    }
+  },
+  "version" : "1.0"
+}

--- a/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		495775EE2B5B34980082812A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 495775EC2B5B34980082812A /* LaunchScreen.storyboard */; };
 		497783312BAC8A99008C29F7 /* GravatarUI in Frameworks */ = {isa = PBXBuildFile; productRef = 497783302BAC8A99008C29F7 /* GravatarUI */; };
 		497783332BAC8AA9008C29F7 /* GravatarUI in Frameworks */ = {isa = PBXBuildFile; productRef = 497783322BAC8AA9008C29F7 /* GravatarUI */; };
+		498060C62C6EA7DB00C6848C /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 498060C42C6EA7DB00C6848C /* Localizable.xcstrings */; };
+		498060C72C6EA7DB00C6848C /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 498060C42C6EA7DB00C6848C /* Localizable.xcstrings */; };
 		49C5D60E2B5B33E20067C2A8 /* DemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C5D60D2B5B33E20067C2A8 /* DemoApp.swift */; };
 		49C5D6102B5B33E20067C2A8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C5D60F2B5B33E20067C2A8 /* ContentView.swift */; };
 		49C5D6122B5B33E20067C2A8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 49C5D6112B5B33E20067C2A8 /* Assets.xcassets */; };
@@ -52,6 +54,7 @@
 		495775EA2B5B34980082812A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		495775ED2B5B34980082812A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		495775EF2B5B34980082812A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		498060C42C6EA7DB00C6848C /* Localizable.xcstrings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		49C5D60A2B5B33E20067C2A8 /* Gravatar SwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Gravatar SwiftUI.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		49C5D60D2B5B33E20067C2A8 /* DemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoApp.swift; sourceTree = "<group>"; };
 		49C5D60F2B5B33E20067C2A8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -143,6 +146,15 @@
 			path = "Gravatar-UIKit-Demo";
 			sourceTree = "<group>";
 		};
+		498060C52C6EA7DB00C6848C /* Localizations */ = {
+			isa = PBXGroup;
+			children = (
+				498060C42C6EA7DB00C6848C /* Localizable.xcstrings */,
+			);
+			name = Localizations;
+			path = Demo/Localizations;
+			sourceTree = SOURCE_ROOT;
+		};
 		49C5D6012B5B33E20067C2A8 = {
 			isa = PBXGroup;
 			children = (
@@ -169,6 +181,7 @@
 				3FD478232C51D9280071B8B9 /* Enterprise.xcconfig */,
 				495775E02B5B34970082812A /* Gravatar-UIKit-Demo */,
 				495775DA2B5B34220082812A /* Gravatar-SwiftUI-Demo */,
+				498060C52C6EA7DB00C6848C /* Localizations */,
 			);
 			path = Demo;
 			sourceTree = "<group>";
@@ -281,6 +294,7 @@
 			files = (
 				49EFFB542C51A47C0086589A /* Assets.xcassets in Resources */,
 				91F0B3E32B6281A60025C4F8 /* Main.storyboard in Resources */,
+				498060C62C6EA7DB00C6848C /* Localizable.xcstrings in Resources */,
 				495775EE2B5B34980082812A /* LaunchScreen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -291,6 +305,7 @@
 			files = (
 				49C5D6152B5B33E20067C2A8 /* Preview Assets.xcassets in Resources */,
 				49C5D6122B5B33E20067C2A8 /* Assets.xcassets in Resources */,
+				498060C72C6EA7DB00C6848C /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,12 @@ clean:  # Clean everything, including the checkout of swift-openapi-generator.
 	@echo 'Delete checkout of openapi-generator $(OPENAPI_GENERATOR_CLONE_DIR)? [y/N] ' && read ans && [ $${ans:-N} = y ] || (echo "Aborted"; exit 1)
 	rm -rf "$(OPENAPI_GENERATOR_CLONE_DIR)"
 
+export-localizations:  # Exports `en` localizations
+	xcodebuild -project Demo/Gravatar-Demo.xcodeproj clean build \
+		-sdk iphoneos \
+		-exportLocalizations \
+		-localizationPath localizations_export \
+		-exportLanguage en
 
 dump:  # Dump all derived values used by the Makefile.
 	@echo "CURRENT_MAKEFILE_PATH = $(CURRENT_MAKEFILE_PATH)"

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Gravatar",
+    defaultLocalization: .init("en"),
     platforms: [
         .iOS(.v15),
     ],

--- a/Sources/GravatarUI/Resources/Localizable.xcstrings
+++ b/Sources/GravatarUI/Resources/Localizable.xcstrings
@@ -1,0 +1,117 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Add avatar cell" : {
+
+    },
+    "Avatars" : {
+
+    },
+    "Choose or upload your favorite avatar images and connect them to your email address." : {
+
+    },
+    "Discover Your Gravatar Card →" : {
+
+    },
+    "empty" : {
+
+    },
+    "failure" : {
+
+    },
+    "Got it" : {
+
+    },
+    "gravatarCreateProfile" : {
+      "comment" : "Title for create profile button in Gravatar profile view",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Claim profile"
+          }
+        }
+      }
+    },
+    "gravatarEditProfile" : {
+      "comment" : "Title for edit profile button in Gravatar profile view",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit profile"
+          }
+        }
+      }
+    },
+    "GravatarEmptyProfileAboutMeKey" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tell the world who you are. Your avatar and bio that follows you across the web."
+          }
+        }
+      }
+    },
+    "GravatarEmptyProfileDisplayNameKey" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Name"
+          }
+        }
+      }
+    },
+    "GravatarEmptyProfileInformationKey" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add your location, pronouns, etc"
+          }
+        }
+      }
+    },
+    "gravatarViewProfile" : {
+      "comment" : "Title for view profile button in Gravatar profile view",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "View profile"
+          }
+        }
+      }
+    },
+    "I am a button" : {
+
+    },
+    "Invalid URL" : {
+
+    },
+    "Ooops" : {
+
+    },
+    "Retry" : {
+
+    },
+    "Show toast!" : {
+
+    },
+    "Something went wrong" : {
+
+    },
+    "Upload image" : {
+
+    }
+  },
+  "version" : "1.0"
+}


### PR DESCRIPTION
### Description

This is a demonstration of our SDK and Demo project setup to use String Catalogs. Play around.  Have fun.

In the future, this would be roughly how it would work:

1. Export localizations
2. Upload exported `.xliff` files to GlotPress
3. Download localizations as `.xliff` files from GlotPress
4. Imort `.xliff` files into the project and SDK

### Testing Steps

- Try adding a language to the String Catalog (`Demo/Demo/Localizations/Localizable.xcstrings`)
- Notice:
  - You don't have to leave Xcode, or do anything manually, for strings to be updated 🎉 
  - Changes to a source file appear in the String Catalog immediately after building a target
  - Since these updates happening during the build of a target, only the strings from source files in the current target (which is selected by changing the "Scheme") are updated in the String Catalog.
     - If you change a source file for `SwiftUI` but you are set to build `UIKit`, the Strings Catalog does not update
- Try exporting from Xcode (`Product` --> `Export Localizations...`)
   - Note that it fails.  This is because Xcode needs to build the project and the SDK, and it uses macOS to perform that build.  Since our SDK is only buidable for iOS, this fails.
- Try using the command line to export:

Export using Make
```
make export-localizations
```

Export by manually calling `xcodebuild`
```
xcodebuild -project Demo/Gravatar-Demo.xcodeproj clean build \
  -sdk iphoneos \
  -exportLocalizations \
  -localizationPath localization_export \
  -exportLanguage en
```

Both methods above will  save the export to `localization_export` in root of repo