### PR TITLE
Add navigation bar to the avatar picker

### DIFF
--- a/Sources/GravatarUI/Base/URL+Additions.swift
+++ b/Sources/GravatarUI/Base/URL+Additions.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension URL: Identifiable {
+    public var id: String {
+        absoluteString
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
@@ -19,7 +19,7 @@ struct AvatarPickerProfileView: View {
     @StateObject private var placeholderColorManager: ProfileViewPlaceholderColorManager = .init()
     @Environment(\.colorScheme) var colorScheme: ColorScheme
 
-    private(set) var viewProfileAction: ((URL?) -> Void)? = nil
+    private(set) var viewProfileAction: (() -> Void)? = nil
 
     var body: some View {
         HStack(alignment: .center, spacing: .DS.Padding.single) {
@@ -32,8 +32,8 @@ struct AvatarPickerProfileView: View {
                     Text(model.location)
                         .font(.footnote)
                         .foregroundColor(Color(UIColor.secondaryLabel))
-                    Button("Discover Your Gravatar Card →") {
-                        viewProfileAction?(model.profileURL)
+                    Button("View profile →") {
+                        viewProfileAction?()
                     }
                     .font(.footnote)
                     .foregroundColor(Color(UIColor.label))

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -12,13 +12,8 @@ public enum AvatarPickerContentLayout: String, CaseIterable, Identifiable {
 struct AvatarPickerView: View {
     private enum Constants {
         static let horizontalPadding: CGFloat = .DS.Padding.double
-        static let padding: EdgeInsets = .init(
-            top: .DS.Padding.double,
-            leading: horizontalPadding,
-            bottom: .DS.Padding.double,
-            trailing: horizontalPadding
-        )
         static let lightModeShadowColor = Color(uiColor: UIColor.rgba(25, 30, 35, alpha: 0.2))
+        static let title: String = "Gravatar" // defined here to avoid translations
     }
 
     @ObservedObject var model: AvatarPickerViewModel
@@ -30,7 +25,7 @@ struct AvatarPickerView: View {
     public var body: some View {
         NavigationView {
             ZStack {
-                VStack {
+                VStack(spacing: .DS.Padding.medium) {
                     profileView()
                     ScrollView {
                         errorView()
@@ -48,8 +43,8 @@ struct AvatarPickerView: View {
                 ToastContainerView(toastManager: model.toastManager)
                     .padding(.horizontal, Constants.horizontalPadding * 2)
             }
-            .navigationTitle("Gravatar") // Set the title for the navigation bar
-            .navigationBarTitleDisplayMode(.inline) // Display title inline or large
+            .navigationTitle(Constants.title)
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: {
@@ -215,12 +210,7 @@ struct AvatarPickerView: View {
             avatarGrid()
         }
         .avatarPickerBorder(colorScheme: colorScheme)
-        .padding(.init(
-            top: .DS.Padding.double,
-            leading: Constants.horizontalPadding,
-            bottom: .DS.Padding.double,
-            trailing: Constants.horizontalPadding
-        ))
+        .padding(.horizontal, Constants.horizontalPadding)
     }
 
     private func avatarsLoadingView() -> some View {
@@ -259,7 +249,8 @@ struct AvatarPickerView: View {
                 .cornerRadius(8)
                 .shadow(color: profileShadowColor, radius: profileShadowRadius, y: 3)
         })
-        .padding(Constants.padding)
+        .padding(.top, .DS.Padding.double)
+        .padding(.horizontal, Constants.horizontalPadding)
     }
 
     @ViewBuilder

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -65,7 +65,7 @@ struct AvatarPickerView: View {
                 }
             }
         }
-        .sheet(item: $safariURL) { url in
+        .fullScreenCover(item: $safariURL) { url in
             SafariView(url: url)
                 .edgesIgnoringSafeArea(.all)
         }

--- a/Sources/GravatarUI/SwiftUI/SafariView.swift
+++ b/Sources/GravatarUI/SwiftUI/SafariView.swift
@@ -1,0 +1,14 @@
+import SafariServices
+import SwiftUI
+
+struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<SafariView>) -> SFSafariViewController {
+        SFSafariViewController(url: url)
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: UIViewControllerRepresentableContext<SafariView>) {
+        // No updates needed for SafariViewController
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -12,7 +12,11 @@ extension View {
     }
 
     public func avatarPickerSheet(isPresented: Binding<Bool>, email: String, authToken: String, contentLayout: AvatarPickerContentLayout) -> some View {
-        let avatarPickerView = AvatarPickerView(model: AvatarPickerViewModel(email: Email(email), authToken: authToken), contentLayout: contentLayout)
+        let avatarPickerView = AvatarPickerView(
+            model: AvatarPickerViewModel(email: Email(email), authToken: authToken),
+            contentLayout: contentLayout,
+            isPresented: isPresented
+        )
         return modifier(ModalPresentationModifier(isPresented: isPresented, modalView: avatarPickerView))
     }
 


### PR DESCRIPTION
Closes #343 

### Description

Adds navigation bar. I used `NavigationView` for now since it is supported in iOS 15. `NavigationStack` is supported only for iOS 16+.

- Adds "Done" button to close the picker
- Gravatar icon opens Safari with profile url

Updates the "Discover Your Gravatar Card" to "View profile" based on designs. Ties the action to open the profile in Safari.

Refactors some of the paddings based on the designs.

<img src="https://github.com/user-attachments/assets/6f748c0a-4449-4288-824d-61d639cbb9f6" width=300/>

### Testing Steps

- Play around with the SwiftUI demo app.