### PR TITLE
Add option to pick image by using the camera

### DIFF
--- a/Demo/Demo/Gravatar-SwiftUI-Demo/DemoAvatarPickerView.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/DemoAvatarPickerView.swift
@@ -43,7 +43,7 @@ struct DemoAvatarPickerView: View {
                     .pickerStyle(MenuPickerStyle())
                 }
                 Button("Tap to open the Avatar Picker") {
-                    isPresentingPicker.toggle()
+                    isPresentingPicker = true
                 }
                 .avatarPickerSheet(isPresented: $isPresentingPicker,
                                    email: email,

--- a/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
@@ -559,6 +559,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"Demo/Gravatar-SwiftUI-Demo/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Take a photo to use as avatar";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -588,6 +589,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"Demo/Gravatar-SwiftUI-Demo/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Take a photo to use as avatar";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePickerView.swift
@@ -11,35 +11,84 @@ struct SystemImagePickerView<Label>: View where Label: View {
         // So far, the new SwiftUI PhotosPicker only supports Photos library, no camera, and no cropping, so we are only using legacy for now.
         // The interface (using a Label property as the element to open the picker) is the same as in the new SwiftUI picker,
         // which will make it easy to change it later on.
-        LegacyImagePicker(label: label, onImageSelected: onImageSelected)
+        ImagePicker(label: label, onImageSelected: onImageSelected)
     }
 }
 
-/// UIImagePickerController SwiftUI Representable wrapper.
-struct LegacyImagePicker<Label>: View where Label: View {
+private struct ImagePicker<Label>: View where Label: View {
+    enum SourceType: CaseIterable, Identifiable {
+        case photoLibrary
+        case camera
+
+        var id: Int {
+            self.hashValue
+        }
+    }
+
     @State var isPresented = false
+    @State private var sourceType: SourceType?
+
     @ViewBuilder var label: () -> Label
     let onImageSelected: (UIImage) -> Void
 
     var body: some View {
         VStack {
-            Button(action: {
-                isPresented.toggle()
-            }, label: {
+            Menu {
+                ForEach(SourceType.allCases) { source in
+                    Button {
+                        sourceType = source
+                        isPresented.toggle()
+                    } label: {
+                        SwiftUI.Label(source.localizedTitle, systemImage: source.iconName)
+                    }
+                }
+            } label: {
                 label()
-            })
+            }
         }
-        .sheet(isPresented: $isPresented, content: {
-            LegacyImagePickerRepresentable { image in
-                onImageSelected(image)
-            }.ignoresSafeArea()
+        .sheet(item: $sourceType, content: { source in
+            // This allows to present different kind of pickers for different sources.
+            switch source {
+            case .camera, .photoLibrary:
+                LegacyImagePickerRepresentable(sourceType: source.map()) { image in
+                    onImageSelected(image)
+                }.ignoresSafeArea()
+            }
         })
+    }
+}
+
+extension ImagePicker.SourceType {
+    var iconName: String {
+        switch self {
+        case .camera:
+            "camera"
+        case .photoLibrary:
+            "photo.on.rectangle.angled"
+        }
+    }
+
+    var localizedTitle: String {
+        switch self {
+        case .photoLibrary:
+            "Chose a Photo"
+        case .camera:
+            "Take Photo"
+        }
+    }
+
+    func map() -> UIImagePickerController.SourceType {
+        switch self {
+        case .photoLibrary: .photoLibrary
+        case .camera: .camera
+        }
     }
 }
 
 struct LegacyImagePickerRepresentable: UIViewControllerRepresentable {
     @Environment(\.presentationMode) private var presentationMode
 
+    var sourceType: UIImagePickerController.SourceType
     let onImageSelected: (UIImage) -> Void
 
     @State private var selectedUIImage: UIImage? {
@@ -49,8 +98,6 @@ struct LegacyImagePickerRepresentable: UIViewControllerRepresentable {
             }
         }
     }
-
-    var sourceType: UIImagePickerController.SourceType = .photoLibrary
 
     func makeUIViewController(context: UIViewControllerRepresentableContext<LegacyImagePickerRepresentable>) -> UIImagePickerController {
         let imagePicker = UIImagePickerController()

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePickerView.swift
@@ -37,7 +37,7 @@ private struct ImagePicker<Label>: View where Label: View {
                 ForEach(SourceType.allCases) { source in
                     Button {
                         sourceType = source
-                        isPresented.toggle()
+                        isPresented = true
                     } label: {
                         SwiftUI.Label(source.localizedTitle, systemImage: source.iconName)
                     }
@@ -49,7 +49,14 @@ private struct ImagePicker<Label>: View where Label: View {
         .sheet(item: $sourceType, content: { source in
             // This allows to present different kind of pickers for different sources.
             switch source {
-            case .camera, .photoLibrary:
+            case .camera:
+                ZStack {
+                    Color.black.ignoresSafeArea(edges: .all)
+                    LegacyImagePickerRepresentable(sourceType: source.map()) { image in
+                        onImageSelected(image)
+                    }
+                }
+            case .photoLibrary:
                 LegacyImagePickerRepresentable(sourceType: source.map()) { image in
                     onImageSelected(image)
                 }.ignoresSafeArea()


### PR DESCRIPTION
### Description

Adding the option to upload a new Avatar image by taking a photo using the camera.

<img src="https://github.com/user-attachments/assets/a2a82fb7-cdf8-4581-8531-2c741ba3674a" width="40%">

*Note*: We are forcing the sources to be used by the Avatar Picker. I'm not sure if we should make it an option to the 3rd party dev, since this is Gravatar domain.

In case we want to give this option, we can do it in a next PR.

### Testing Steps

- Build the SwiftUI demo app on device (or use the App Center build).
- Add a new avatar using the device's camera.
- Check that the new image can be selected as the avatar.
