### PR TITLE
Etoledom/adding navigation bar to profile editor

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -49,7 +49,7 @@ struct AvatarPickerView: View {
         }
         .gravatarNavigation(
             title: Constants.title,
-            actionButtonDisabled: $model.isProfileLoading,
+            actionButtonDisabled: model.profileModel?.profileURL == nil,
             onActionButtonPressed: {
                 openProfileInSafari()
             },

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -25,51 +25,38 @@ struct AvatarPickerView: View {
     @State private var safariURL: URL?
 
     public var body: some View {
-        NavigationView {
-            ZStack {
-                VStack(spacing: 0) {
-                    email()
-                    profileView()
-                    ScrollView {
-                        errorView()
-                        if !model.grid.isEmpty {
-                            content()
-                        } else if model.isAvatarsLoading {
-                            avatarsLoadingView()
-                        }
-                        Spacer()
-                            .frame(height: Constants.vStackVerticalSpacing)
+        ZStack {
+            VStack(spacing: 0) {
+                email()
+                profileView()
+                ScrollView {
+                    errorView()
+                    if !model.grid.isEmpty {
+                        content()
+                    } else if model.isAvatarsLoading {
+                        avatarsLoadingView()
                     }
-                    .task {
-                        model.refresh()
-                    }
+                    Spacer()
+                        .frame(height: Constants.vStackVerticalSpacing)
                 }
+                .task {
+                    model.refresh()
+                }
+            }
 
-                ToastContainerView(toastManager: model.toastManager)
-                    .padding(.horizontal, Constants.horizontalPadding * 2)
-            }
-            .navigationTitle(Constants.title)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: {
-                        openProfileInSafari()
-                    }) {
-                        Image("gravatar", bundle: .module)
-                            .tint(Color(UIColor.gravatarBlue))
-                    }
-                    .disabled(model.profileModel?.profileURL == nil)
-                }
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button(action: {
-                        isPresented = false
-                    }) {
-                        Text("Done")
-                            .tint(Color(UIColor.gravatarBlue))
-                    }
-                }
-            }
+            ToastContainerView(toastManager: model.toastManager)
+                .padding(.horizontal, Constants.horizontalPadding * 2)
         }
+        .gravatarNavigation(
+            title: Constants.title,
+            actionButtonDisabled: $model.isProfileLoading,
+            onActionButtonPressed: {
+                openProfileInSafari()
+            },
+            onDoneButtonPressed: {
+                isPresented = false
+            }
+        )
         .fullScreenCover(item: $safariURL) { url in
             SafariView(url: url)
                 .edgesIgnoringSafeArea(.all)

--- a/Sources/GravatarUI/SwiftUI/GravatarNavigationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/GravatarNavigationModifier.swift
@@ -40,11 +40,13 @@ extension View {
         onActionButtonPressed: (() -> Void)? = nil,
         onDoneButtonPressed: (() -> Void)? = nil
     ) -> some View {
-        modifier(GravatarNavigationModifier(
-            title: title,
-            actionButtonDisabled: actionButtonDisabled,
-            onActionButtonPressed: onActionButtonPressed,
-            onDoneButtonPressed: onDoneButtonPressed)
+        modifier(
+            GravatarNavigationModifier(
+                title: title,
+                actionButtonDisabled: actionButtonDisabled,
+                onActionButtonPressed: onActionButtonPressed,
+                onDoneButtonPressed: onDoneButtonPressed
+            )
         )
     }
 }

--- a/Sources/GravatarUI/SwiftUI/GravatarNavigationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/GravatarNavigationModifier.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct GravatarNavigationModifier: ViewModifier {
-    @State var title: String
-    @Binding var actionButtonDisabled: Bool
+    var title: String
+    var actionButtonDisabled: Bool
 
     var onActionButtonPressed: (() -> Void)? = nil
     var onDoneButtonPressed: (() -> Void)? = nil
@@ -36,7 +36,7 @@ struct GravatarNavigationModifier: ViewModifier {
 extension View {
     func gravatarNavigation(
         title: String,
-        actionButtonDisabled: Binding<Bool>,
+        actionButtonDisabled: Bool,
         onActionButtonPressed: (() -> Void)? = nil,
         onDoneButtonPressed: (() -> Void)? = nil
     ) -> some View {

--- a/Sources/GravatarUI/SwiftUI/GravatarNavigationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/GravatarNavigationModifier.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct GravatarNavigationModifier: ViewModifier {
+    @State var title: String
+    @Binding var actionButtonDisabled: Bool
+
+    var onActionButtonPressed: (() -> Void)? = nil
+    var onDoneButtonPressed: (() -> Void)? = nil
+
+    func body(content: Content) -> some View {
+        content
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        onActionButtonPressed?()
+                    }) {
+                        Image("gravatar", bundle: .module)
+                            .tint(Color(UIColor.gravatarBlue))
+                    }
+                    .disabled(actionButtonDisabled)
+                }
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: {
+                        onDoneButtonPressed?()
+                    }) {
+                        Text("Done")
+                            .tint(Color(UIColor.gravatarBlue))
+                    }
+                }
+            }
+    }
+}
+
+extension View {
+    func gravatarNavigation(
+        title: String,
+        actionButtonDisabled: Binding<Bool>,
+        onActionButtonPressed: (() -> Void)? = nil,
+        onDoneButtonPressed: (() -> Void)? = nil
+    ) -> some View {
+        modifier(GravatarNavigationModifier(
+            title: title,
+            actionButtonDisabled: actionButtonDisabled,
+            onActionButtonPressed: onActionButtonPressed,
+            onDoneButtonPressed: onDoneButtonPressed)
+        )
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/ProfileEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/ProfileEditor.swift
@@ -53,9 +53,13 @@ struct ProfileEditor: View {
             } else {
                 ProgressView()
             }
-        }.gravatarNavigation(title: Constants.title, actionButtonDisabled: .constant(true), onDoneButtonPressed: {
-            isPresented = false
-        })
+        }.gravatarNavigation(
+            title: Constants.title,
+            actionButtonDisabled: true,
+            onDoneButtonPressed: {
+                isPresented = false
+            }
+        )
         .task {
             performAuthentication()
         }

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/ProfileEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/ProfileEditor.swift
@@ -8,6 +8,7 @@ struct ProfileEditor: View {
     private enum Constants {
         static let title: String = "Gravatar" // defined here to avoid translations
     }
+
     @Environment(\.oauthSession) private var oauthSession
     @State var hasSession: Bool = false
     @State var entryPoint: ProfileEditorEntryPoint
@@ -52,7 +53,7 @@ struct ProfileEditor: View {
             } else {
                 ProgressView()
             }
-        }.gravatarNavigation(title: Constants.title, actionButtonDisabled: .constant(true), onDoneButtonPressed:  {
+        }.gravatarNavigation(title: Constants.title, actionButtonDisabled: .constant(true), onDoneButtonPressed: {
             isPresented = false
         })
         .task {
@@ -72,7 +73,6 @@ struct ProfileEditor: View {
         }
     }
 }
-
 
 #Preview {
     ProfileEditor(email: .init(""), entryPoint: .avatarPicker, isPresented: .constant(true))

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/ProfileEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/ProfileEditor.swift
@@ -4,45 +4,6 @@ public enum ProfileEditorEntryPoint {
     case avatarPicker
 }
 
-struct NavigationBarModel {
-    let title: String
-    let actionButtonEnabled: Bool
-}
-
-struct GravatarNavigationView<Content>: View where Content: View {
-    @State var model: NavigationBarModel
-    var content: () -> Content
-    var onActionButtonPressed: (() -> Void)? = nil
-    var onDoneButtonPressed: (() -> Void)? = nil
-
-    var body: some View {
-        NavigationView {
-            content()
-                .navigationTitle(model.title)
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        Button(action: {
-                            onActionButtonPressed?()
-                        }) {
-                            Image("gravatar", bundle: .module)
-                                .tint(Color(UIColor.gravatarBlue))
-                        }
-                        .disabled(model.actionButtonEnabled)
-                    }
-                    ToolbarItem(placement: .navigationBarLeading) {
-                        Button(action: {
-                            onDoneButtonPressed?()
-                        }) {
-                            Text("Done")
-                                .tint(Color(UIColor.gravatarBlue))
-                        }
-                    }
-                }
-        }
-    }
-}
-
 struct ProfileEditor: View {
     private enum Constants {
         static let title: String = "Gravatar" // defined here to avoid translations

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -17,7 +17,8 @@ extension View {
             contentLayout: contentLayout,
             isPresented: isPresented
         )
-        return modifier(ModalPresentationModifier(isPresented: isPresented, modalView: avatarPickerView))
+        let navigationWrapped = NavigationView { avatarPickerView }
+        return modifier(ModalPresentationModifier(isPresented: isPresented, modalView: navigationWrapped))
     }
 
     func avatarPickerBorder(colorScheme: ColorScheme, borderWidth: CGFloat = 1) -> some View {


### PR DESCRIPTION
### Description

This PR adds a navigation bar on the Profile Editor.

The idea is that there's only one `NavigationView` at the root of any flow, and each view defines their own navigation modifiers. In a similar way that controllers modify their own `NavigationBarItem`.

I've created a GravatarNavigationModifier to make this easier and share the structure of our nav bar.

<img src="https://github.com/user-attachments/assets/a9384810-9ab0-4f3f-9cf4-33ab67b916fe" width="40%">

### Testing Steps

- Run the SwiftUI demo app
- Go to Profile Editor example screen
  - Check that the Navigation bar shows as expected.