### PR TITLE
Renaming for parity

### DIFF
--- a/Demo/Demo/Gravatar-SwiftUI-Demo/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/DemoProfileEditorView.swift
@@ -26,10 +26,10 @@ struct DemoProfileEditorView: View {
             Button("Open Profile Editor with OAuth flow") {
                 isPresentingPicker.toggle()
             }
-            .gravatarEditorSheet(
+            .gravatarQuickEditorSheet(
                 isPresented: $isPresentingPicker,
                 email: email,
-                entryPoint: .avatarPicker,
+                scope: .avatarPicker,
                 onDismiss: {
                     updateHasSession(with: email)
                 }

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -1,25 +1,25 @@
 import SwiftUI
 
-public enum ProfileEditorEntryPoint {
+public enum QuickEditorScope {
     case avatarPicker
 }
 
-struct ProfileEditor: View {
+struct QuickEditor: View {
     private enum Constants {
         static let title: String = "Gravatar" // defined here to avoid translations
     }
 
     @Environment(\.oauthSession) private var oauthSession
     @State var hasSession: Bool = false
-    @State var entryPoint: ProfileEditorEntryPoint
+    @State var scope: QuickEditorScope
     @State var isAuthenticating: Bool = true
     @Binding var isPresented: Bool
 
     let email: Email
 
-    init(email: Email, entryPoint: ProfileEditorEntryPoint, isPresented: Binding<Bool>) {
+    init(email: Email, scope: QuickEditorScope, isPresented: Binding<Bool>) {
         self.email = email
-        self.entryPoint = entryPoint
+        self.scope = scope
         self._isPresented = isPresented
     }
 
@@ -35,7 +35,7 @@ struct ProfileEditor: View {
 
     @MainActor
     func editorView(with token: String) -> some View {
-        switch entryPoint {
+        switch scope {
         case .avatarPicker:
             AvatarPickerView(model: .init(email: email, authToken: token), isPresented: $isPresented)
         }
@@ -79,5 +79,5 @@ struct ProfileEditor: View {
 }
 
 #Preview {
-    ProfileEditor(email: .init(""), entryPoint: .avatarPicker, isPresented: .constant(true))
+    QuickEditor(email: .init(""), scope: .avatarPicker, isPresented: .constant(true))
 }

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -31,13 +31,13 @@ extension View {
             .padding(.vertical, borderWidth) // to prevent borders from getting clipped
     }
 
-    public func gravatarEditorSheet(
+    public func gravatarQuickEditorSheet(
         isPresented: Binding<Bool>,
         email: String,
-        entryPoint: ProfileEditorEntryPoint,
+        scope: QuickEditorScope,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
-        let editor = ProfileEditor(email: .init(email), entryPoint: entryPoint, isPresented: isPresented)
+        let editor = QuickEditor(email: .init(email), scope: scope, isPresented: isPresented)
         return modifier(ModalPresentationModifier(isPresented: isPresented, onDismiss: onDismiss, modalView: editor))
     }
 }


### PR DESCRIPTION
### Description
This PR renames `ProfileEditor` to `QuickEditor` and `entrypoint` to `scope` (and all related instances) to keep parity with Android and Web.

### Testing Steps

- CI should be ✅