### PR TITLE
Handle token error

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -103,8 +103,8 @@ struct AvatarPickerView: View {
                 )
             case .failure(APIError.responseError(reason: let reason)) where reason.httpStatusCode == HTTPStatus.unauthorized.rawValue:
                 let buttonTitle = tokenErrorHandler == nil ? "Close" : "Log in"
-                let subtext = tokenErrorHandler == nil ?
-                    "Session expired for security reasons." :
+                let subtext: LocalizedStringKey = tokenErrorHandler == nil ?
+                    "Sorry, it looks like your session has expired. Make sure you're logged in to update your Avatar." :
                     "Session expired for security reasons. Please log in to update your Avatar."
                 contentLoadingErrorView(
                     title: "Session expired",

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -103,7 +103,7 @@ struct AvatarPickerView: View {
                 )
             case .failure(APIError.responseError(reason: let reason)) where reason.httpStatusCode == HTTPStatus.unauthorized.rawValue:
                 let buttonTitle = tokenErrorHandler == nil ? "Close" : "Log in"
-                let subtext: LocalizedStringKey = tokenErrorHandler == nil ?
+                let subtext: String = tokenErrorHandler == nil ?
                     "Sorry, it looks like your session has expired. Make sure you're logged in to update your Avatar." :
                     "Session expired for security reasons. Please log in to update your Avatar."
                 contentLoadingErrorView(

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -24,6 +24,8 @@ struct AvatarPickerView: View {
     @Binding var isPresented: Bool
     @State private var safariURL: URL?
 
+    var tokenErrorHandler: (() -> Void)?
+
     public var body: some View {
         ZStack {
             VStack(spacing: 0) {
@@ -100,14 +102,22 @@ struct AvatarPickerView: View {
                     }
                 )
             case .failure(APIError.responseError(reason: let reason)) where reason.httpStatusCode == HTTPStatus.unauthorized.rawValue:
+                let buttonTitle = tokenErrorHandler == nil ? "Close" : "Log in"
+                let subtext = tokenErrorHandler == nil ?
+                    "Session expired for security reasons." :
+                    "Session expired for security reasons. Please log in to update your Avatar."
                 contentLoadingErrorView(
                     title: "Session expired",
-                    subtext: "Session expired for security reasons. Please log in to update your Avatar.",
+                    subtext: subtext,
                     actionButton: {
                         Button {
-                            // TODO: Log in
+                            if let tokenErrorHandler {
+                                tokenErrorHandler()
+                            } else {
+                                isPresented = false
+                            }
                         } label: {
-                            CTAButtonView("Log in".localized)
+                            CTAButtonView(buttonTitle.localized)
                         }
                     }
                 )

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -37,7 +37,14 @@ struct QuickEditor: View {
     func editorView(with token: String) -> some View {
         switch scope {
         case .avatarPicker:
-            AvatarPickerView(model: .init(email: email, authToken: token), isPresented: $isPresented)
+            AvatarPickerView(
+                model: .init(email: email, authToken: token),
+                isPresented: $isPresented,
+                tokenErrorHandler: {
+                    oauthSession.deleteSession(with: email)
+                    performAuthentication()
+                }
+            )
         }
     }
 


### PR DESCRIPTION
### Description

This PR implements a way to handle an invalid token error:

1. If the authorisation process was made by the SDK, we request the user to log-in again, and show again the OAuth flow.
2. If the token was provided externally, we give the option to the user to close the picker.

The description text for option 2 is not meant to be definitive.

![CleanShot 2024-08-23 at 16 15 39](https://github.com/user-attachments/assets/8e57aefa-ac4f-4fe7-8c08-43d572a2475e)

### Testing Steps

#### Test external token flow:
- Build and run the SwiftUI example app.
- Go to the Avatar picker view example screen.
- Insert a wrong token.
  - Check that a `Close` button is presented on the UI
 
#### Test internal token flow:

- Go to `OAuthSession.swift` line 39
- Generate a wrong token to trigger the expired token error
  -  i.e: ` let token = "2"`
- Build and run the SwiftUI example app
- Go to the Profile Editor example screen.
- **Log Out** if needed. 
- Open the editor
- Accept the authorisation prompt.
  - Check that a `Log in` option is presented to the user.
  - If you try to log in, the oauth flow should be presented
  - The error will appear again.
- Kill the app
-  Restore the original code in `OAuthSession.swift` line 39
- Build and run again.
- Open the Profile Editor **without** pressing on log out.
  - Check that the error is still present.
  - Tap on Log in.
-  Accept the authorisation prompt.
  - Check that now the error is gone, and the picker works as expected.
- THE END.

  