### PR TITLE
Handling url session errors

### DIFF
--- a/Sources/Gravatar/Network/Errors.swift
+++ b/Sources/Gravatar/Network/Errors.swift
@@ -36,6 +36,18 @@ public enum ResponseErrorReason: Sendable {
         }
         return false
     }
+
+    public var isURLSessionError: Bool {
+        guard case .URLSessionError(let error as NSError) = self else { return false }
+        return  error.domain == NSURLErrorDomain
+    }
+
+    public var urlSessionErrorLocalizedDescription: String? {
+        if case .URLSessionError(let error as NSError) = self, error.domain == NSURLErrorDomain {
+            return error.localizedDescription
+        }
+        return nil
+    }
 }
 
 public enum RequestErrorReason: Sendable {

--- a/Sources/Gravatar/Network/Errors.swift
+++ b/Sources/Gravatar/Network/Errors.swift
@@ -39,7 +39,7 @@ public enum ResponseErrorReason: Sendable {
 
     public var isURLSessionError: Bool {
         guard case .URLSessionError(let error as NSError) = self else { return false }
-        return  error.domain == NSURLErrorDomain
+        return error.domain == NSURLErrorDomain
     }
 
     public var urlSessionErrorLocalizedDescription: String? {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -121,11 +121,29 @@ struct AvatarPickerView: View {
                         }
                     }
                 )
+            case .failure(APIError.responseError(reason: let reason)) where reason.isURLSessionError:
+                let subtext: String = {
+                    if let reason = reason.urlSessionErrorLocalizedDescription {
+                        reason
+                    } else {
+                        "Something went wrong and we couldn’t connect to Gravatar servers."
+                    }
+                }()
+                contentLoadingErrorView(
+                    title: "Ooops",
+                    subtext: subtext,
+                    actionButton: {
+                        Button {
+                            model.refresh()
+                        } label: {
+                            CTAButtonView("Try again".localized)
+                        }
+                    }
+                )
             case .failure:
                 contentLoadingErrorView(
                     title: "Ooops",
                     subtext: "Something went wrong and we couldn’t connect to Gravatar servers.",
-                    image: nil,
                     actionButton: {
                         Button {
                             model.refresh()

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -122,13 +122,11 @@ struct AvatarPickerView: View {
                     }
                 )
             case .failure(APIError.responseError(reason: let reason)) where reason.isURLSessionError:
-                let subtext: String = {
-                    if let reason = reason.urlSessionErrorLocalizedDescription {
-                        reason
-                    } else {
-                        "Something went wrong and we couldn’t connect to Gravatar servers."
-                    }
-                }()
+                let subtext: String = if let reason = reason.urlSessionErrorLocalizedDescription {
+                    reason
+                } else {
+                    "Something went wrong and we couldn’t connect to Gravatar servers."
+                }
                 contentLoadingErrorView(
                     title: "Ooops",
                     subtext: subtext,

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -127,16 +127,16 @@ struct AvatarPickerView: View {
                 let subtext: String = if let reason = reason.urlSessionErrorLocalizedDescription {
                     reason
                 } else {
-                    "Something went wrong and we couldn’t connect to Gravatar servers."
+                    Localized.ContentLoading.Failure.Retry.subtext
                 }
                 contentLoadingErrorView(
-                    title: "Ooops",
+                    title: Localized.ContentLoading.Failure.Retry.title,
                     subtext: subtext,
                     actionButton: {
                         Button {
                             model.refresh()
                         } label: {
-                            CTAButtonView("Try again".localized)
+                            CTAButtonView(Localized.buttonRetry)
                         }
                     }
                 )


### PR DESCRIPTION
Closes #372 

### Description

Handling URLSessionErrors, including errors like no internet, and time out.

<img src="https://github.com/user-attachments/assets/73bed8b9-1a11-4b52-a2ec-7c26347e0683" width="44%">
<img src="https://github.com/user-attachments/assets/a9dfc65d-76d0-4bc9-9783-f1b9aa48a83f" width="44%">


### Testing Steps

- Use the network link conditioner to control the internet connection.
- Run the SwiftUI demo project.
- Test loading the picker without internet.
- Test loading the picker with 100% loss condition (will take a while to show the error)
