### PR TITLE
Allow 3rd party apps to inject their existing image editors to the QuickEditor

### DIFF
--- a/Demo/Demo/Gravatar-SwiftUI-Demo/DemoAvatarPickerView.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/DemoAvatarPickerView.swift
@@ -10,6 +10,7 @@ struct DemoAvatarPickerView: View {
 
     // You can make this `true` by default to easily test the picker
     @State private var isPresentingPicker: Bool = false
+    @State var enableCustomImageCropper: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
@@ -42,17 +43,30 @@ struct DemoAvatarPickerView: View {
                     }
                     .pickerStyle(MenuPickerStyle())
                 }
+                Toggle("Custom image cropper", isOn: $enableCustomImageCropper)
+
                 Button("Tap to open the Avatar Picker") {
                     isPresentingPicker = true
                 }
                 .avatarPickerSheet(isPresented: $isPresentingPicker,
                                    email: email,
-                                   authToken: token, 
-                                   contentLayout: contentLayout)
+                                   authToken: token,
+                                   contentLayout: contentLayout,
+                                   customImageEditor: customImageEditor())
                 Spacer()
             }
             .padding(.horizontal)
         }
+    }
+    
+    func customImageEditor() -> ImageEditorBlock<TestImageCropper>? {
+        if enableCustomImageCropper {
+            let block = { image, editingDidFinish in
+                TestImageCropper(inputImage: image, editingDidFinish: editingDidFinish)
+            }
+            return block
+        }
+        return nil as ImageEditorBlock<TestImageCropper>?
     }
     
     @ViewBuilder

--- a/Demo/Demo/Gravatar-SwiftUI-Demo/TestImageCropper.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/TestImageCropper.swift
@@ -32,8 +32,6 @@ struct TestImageCropper: View, ImageEditorView {
 }
 
 #Preview {
-    TestImageCropper(inputImage: UIImage()) { _ in
-        
-    }
+    TestImageCropper(inputImage: UIImage()) { _ in }
 }
 

--- a/Demo/Demo/Gravatar-SwiftUI-Demo/TestImageCropper.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/TestImageCropper.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+import GravatarUI
+
+struct TestImageCropper: View, ImageEditorView {
+    var inputImage: UIImage
+    var editingDidFinish: ((UIImage) -> Void)
+    
+    init(inputImage: UIImage, editingDidFinish: @escaping (UIImage) -> Void) {
+        self.inputImage = inputImage
+        self.editingDidFinish = editingDidFinish
+    }
+    
+    var body: some View {
+        Text("This is a dummy image cropper for solely test purposes. It doesn't do anything. It just passes the image as it is when the button is tapped.")
+            .padding()
+        Image(uiImage: inputImage)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(height: 100)
+        Button(action: cropImage) {
+            Text("Crop Image")
+                .foregroundColor(.white)
+                .padding()
+                .background(Color.blue)
+                .cornerRadius(10)
+        }
+    }
+    
+    private func cropImage() {
+        editingDidFinish(inputImage)
+    }
+}
+
+#Preview {
+    TestImageCropper(inputImage: UIImage()) { _ in
+        
+    }
+}
+

--- a/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		914AC0192BD7FF08005DA4A5 /* DemoBaseProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914AC0172BD7FF08005DA4A5 /* DemoBaseProfileViewController.swift */; };
 		914AC01A2BD7FF08005DA4A5 /* DemoProfilePresentationStylesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914AC0182BD7FF08005DA4A5 /* DemoProfilePresentationStylesViewController.swift */; };
 		914AC0202BDAAC3C005DA4A5 /* DemoRemoteSVGViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914AC01F2BDAAC3C005DA4A5 /* DemoRemoteSVGViewController.swift */; };
+		917DEEC92C7F639F00E43774 /* TestImageCropper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917DEEC82C7F619100E43774 /* TestImageCropper.swift */; };
 		91956A522B6793AF00BF3CF0 /* SwitchWithLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91956A512B6793AF00BF3CF0 /* SwitchWithLabel.swift */; };
 		91956A542B67943A00BF3CF0 /* DemoUIImageViewExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91956A532B67943A00BF3CF0 /* DemoUIImageViewExtensionViewController.swift */; };
 		91B73B372C404F6E00E7D325 /* DemoAvatarPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B73B362C404F6E00E7D325 /* DemoAvatarPickerView.swift */; };
@@ -67,6 +68,7 @@
 		914AC0172BD7FF08005DA4A5 /* DemoBaseProfileViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoBaseProfileViewController.swift; sourceTree = "<group>"; };
 		914AC0182BD7FF08005DA4A5 /* DemoProfilePresentationStylesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoProfilePresentationStylesViewController.swift; sourceTree = "<group>"; };
 		914AC01F2BDAAC3C005DA4A5 /* DemoRemoteSVGViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoRemoteSVGViewController.swift; sourceTree = "<group>"; };
+		917DEEC82C7F619100E43774 /* TestImageCropper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImageCropper.swift; sourceTree = "<group>"; };
 		91956A512B6793AF00BF3CF0 /* SwitchWithLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchWithLabel.swift; sourceTree = "<group>"; };
 		91956A532B67943A00BF3CF0 /* DemoUIImageViewExtensionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoUIImageViewExtensionViewController.swift; sourceTree = "<group>"; };
 		91B73B362C404F6E00E7D325 /* DemoAvatarPickerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoAvatarPickerView.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 				49C5D6132B5B33E20067C2A8 /* Preview Content */,
 				49EFFB572C51AA3E0086589A /* Gravatar-SwiftUI-Demo.Base.xcconfig */,
 				3FD478222C51D7E20071B8B9 /* Gravatar-SwiftUI-Demo.Release.xcconfig */,
+				917DEEC82C7F619100E43774 /* TestImageCropper.swift */,
 			);
 			path = "Gravatar-SwiftUI-Demo";
 			sourceTree = "<group>";
@@ -376,6 +379,7 @@
 				9146A7AE2C3BD8F000E07C63 /* DemoAvatarView.swift in Sources */,
 				91B73B372C404F6E00E7D325 /* DemoAvatarPickerView.swift in Sources */,
 				49C5D60E2B5B33E20067C2A8 /* DemoApp.swift in Sources */,
+				917DEEC92C7F639F00E43774 /* TestImageCropper.swift in Sources */,
 				1E3FA2452C75E403002901F2 /* DemoProfileEditorView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -8,19 +8,10 @@ public enum AvatarPickerContentLayout: String, CaseIterable, Identifiable {
     case horizontal
 }
 
-private enum AvatarPicker {
-    enum Constants {
-        static let horizontalPadding: CGFloat = .DS.Padding.double
-        static let lightModeShadowColor = Color(uiColor: UIColor.rgba(25, 30, 35, alpha: 0.2))
-        static let title: String = "Gravatar" // defined here to avoid translations
-        static let vStackVerticalSpacing: CGFloat = .DS.Padding.medium
-        static let emailBottomSpacing: CGFloat = .DS.Padding.double
-    }
-}
-
 @MainActor
 struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
     fileprivate typealias Constants = AvatarPicker.Constants
+    fileprivate typealias Localized = AvatarPicker.Localized
 
     @ObservedObject var model: AvatarPickerViewModel
     @State var contentLayout: AvatarPickerContentLayout = .vertical
@@ -295,8 +286,16 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
 
 // MARK: - Localized Strings
 
-extension AvatarPickerView {
-    private enum Localized {
+private enum AvatarPicker {
+    enum Constants {
+        static let horizontalPadding: CGFloat = .DS.Padding.double
+        static let lightModeShadowColor = Color(uiColor: UIColor.rgba(25, 30, 35, alpha: 0.2))
+        static let title: String = "Gravatar" // defined here to avoid translations
+        static let vStackVerticalSpacing: CGFloat = .DS.Padding.medium
+        static let emailBottomSpacing: CGFloat = .DS.Padding.double
+    }
+
+    enum Localized {
         static let buttonUploadImage = NSLocalizedString(
             "AvatarPicker.ContentLoading.Success.ctaButtonTitle",
             value: "Upload image",

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -150,10 +150,10 @@ class AvatarPickerViewModel: ObservableObject {
         }
     }
 
-    func upload(_ image: UIImage) async {
+    func upload(_ image: UIImage, shouldSquareImage: Bool) async {
         guard let authToken else { return }
 
-        let squareImage = image.squared()
+        let squareImage = shouldSquareImage ? image.squared() : image
         let localID = UUID().uuidString
 
         let localImageModel = AvatarImageModel(id: localID, source: .local(image: squareImage), isLoading: true)

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/ImageEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/ImageEditorView.swift
@@ -1,22 +1,22 @@
 import Foundation
 import SwiftUI
 
-/// Describes an image editor to be used after picking the image from photo picker.
-/// Caution: The output needs to be a square image otherwise the Gravatar backend will not accept it.
+/// Describes an image editor to be used after picking the image from the photo picker.
+/// Caution: The output needs to be a square image; otherwise, the Gravatar backend will not accept it.
 public protocol ImageEditorView: View {
     /// The image to edit.
     var inputImage: UIImage { get }
 
-    /// Callback to call when the editing is done. Pass the edited image here..
+    /// Callback to call when the editing is done. Pass the edited image here.
     var editingDidFinish: (UIImage) -> Void { get set }
 }
 
 public typealias ImageEditorBlock<ImageEditor: ImageEditorView> = (UIImage, _ editingDidFinish: @escaping (UIImage) -> Void) -> ImageEditor
 
-/// A type to use to help the compiler resolve the generic type when the custom image editor needs to be passed as `nil`.
+/// Because of how generics work, the compiler must resolve the image editor's concrete type.
+/// When its value is `nil` though, the compiler can't resolve the concrete type, and it complains. This type here is used to make the compiler happy when the passed value is `nil`.
 public struct NoCustomEditor: ImageEditorView {
     public var inputImage: UIImage
-
     public var editingDidFinish: (UIImage) -> Void
 
     public var body: some View {
@@ -24,5 +24,5 @@ public struct NoCustomEditor: ImageEditorView {
     }
 }
 
-/// A type to use to help the compiler resolve the generic type when the custom image editor needs to be passed as `nil`.
+/// This exists for the same reason with `NoCustomEditor`.
 public typealias NoCustomEditorBlock = (UIImage, _ editingDidFinish: @escaping (UIImage) -> Void) -> NoCustomEditor

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/ImageEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/ImageEditorView.swift
@@ -14,7 +14,8 @@ public protocol ImageEditorView: View {
 public typealias ImageEditorBlock<ImageEditor: ImageEditorView> = (UIImage, _ editingDidFinish: @escaping (UIImage) -> Void) -> ImageEditor
 
 /// Because of how generics work, the compiler must resolve the image editor's concrete type.
-/// When its value is `nil` though, the compiler can't resolve the concrete type, and it complains. This type here is used to make the compiler happy when the passed value is `nil`.
+/// When its value is `nil` though, the compiler can't resolve the concrete type, and it complains. This type here is used to make the compiler happy when the
+/// passed value is `nil`.
 public struct NoCustomEditor: ImageEditorView {
     public var inputImage: UIImage
     public var editingDidFinish: (UIImage) -> Void

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/ImageEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/ImageEditorView.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftUI
+
+/// Describes an image editor to be used after picking the image from photo picker.
+/// Caution: The output needs to be a square image otherwise the Gravatar backend will not accept it.
+public protocol ImageEditorView: View {
+    /// The image to edit.
+    var inputImage: UIImage { get }
+
+    /// Callback to call when the editing is done. Pass the edited image here..
+    var editingDidFinish: (UIImage) -> Void { get set }
+}
+
+public typealias ImageEditorBlock<ImageEditor: ImageEditorView> = (UIImage, _ editingDidFinish: @escaping (UIImage) -> Void) -> ImageEditor
+
+/// A type to use to help the compiler resolve the generic type when the custom image editor needs to be passed as `nil`.
+public struct NoCustomEditor: ImageEditorView {
+    public var inputImage: UIImage
+
+    public var editingDidFinish: (UIImage) -> Void
+
+    public var body: some View {
+        EmptyView()
+    }
+}
+
+/// A type to use to help the compiler resolve the generic type when the custom image editor needs to be passed as `nil`.
+public typealias NoCustomEditorBlock = (UIImage, _ editingDidFinish: @escaping (UIImage) -> Void) -> NoCustomEditor

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePickerView.swift
@@ -11,11 +11,17 @@ struct SystemImagePickerView<Label>: View where Label: View {
         // So far, the new SwiftUI PhotosPicker only supports Photos library, no camera, and no cropping, so we are only using legacy for now.
         // The interface (using a Label property as the element to open the picker) is the same as in the new SwiftUI picker,
         // which will make it easy to change it later on.
-        ImagePicker(label: label, onImageSelected: onImageSelected)
+        ImagePicker() {
+            label()
+        } onImageSelected: { image in
+            onImageSelected(image)
+        } customCropper: { image, croppingDidFinish in
+            TestCropper(inputImage: image, croppingDidFinish: croppingDidFinish)
+        }
     }
 }
 
-private struct ImagePicker<Label>: View where Label: View {
+private struct ImagePicker<Label, ImageCropper: ImageCropperView>: View where Label: View {
     enum SourceType: CaseIterable, Identifiable {
         case photoLibrary
         case camera
@@ -30,7 +36,9 @@ private struct ImagePicker<Label>: View where Label: View {
 
     @ViewBuilder var label: () -> Label
     let onImageSelected: (UIImage) -> Void
-
+    var customCropper: ((UIImage, _ croppingDidFinish: @escaping (UIImage) -> Void) -> ImageCropper)?
+    @State var imagePickerSelectedItem: ImagePickerItem?
+    
     var body: some View {
         VStack {
             Menu {
@@ -48,20 +56,71 @@ private struct ImagePicker<Label>: View where Label: View {
         }
         .sheet(item: $sourceType, content: { source in
             // This allows to present different kind of pickers for different sources.
-            switch source {
-            case .camera:
-                ZStack {
-                    Color.black.ignoresSafeArea(edges: .all)
-                    LegacyImagePickerRepresentable(sourceType: source.map()) { image in
-                        onImageSelected(image)
+            displayPickerOrCamera(source)
+                .sheet(item: $imagePickerSelectedItem, content: { item in
+                    if let customCropper {
+                        customCropper(item.image) { croppedImage in
+                            imagePickerSelectedItem = nil
+                            onImageSelected(croppedImage)
+                        }
                     }
-                }
-            case .photoLibrary:
-                LegacyImagePickerRepresentable(sourceType: source.map()) { image in
-                    onImageSelected(image)
-                }.ignoresSafeArea()
-            }
+                })
         })
+    }
+    
+    @ViewBuilder
+    private func displayPickerOrCamera(_ source: SourceType) -> some View {
+        switch source {
+        case .camera:
+            ZStack {
+                Color.black.ignoresSafeArea(edges: .all)
+                LegacyImagePickerRepresentable(sourceType: source.map(), useBuiltInCropper: customCropper == nil) { item in
+                    pickerDidSelectImage(item)
+                }
+            }
+        case .photoLibrary:
+            LegacyImagePickerRepresentable(sourceType: source.map(), useBuiltInCropper: customCropper == nil) { item in
+                pickerDidSelectImage(item)
+            }.ignoresSafeArea()
+        }
+    }
+    
+    private func pickerDidSelectImage(_ item: ImagePickerItem) {
+        if customCropper != nil {
+            imagePickerSelectedItem = item
+        }
+        else {
+            onImageSelected(item.image)
+        }
+    }
+}
+
+protocol ImageCropperView: View {
+    var inputImage: UIImage { get }
+    var croppingDidFinish: ((UIImage) -> Void) { get set }
+}
+
+struct TestCropper: View, ImageCropperView {
+    var inputImage: UIImage
+    var croppingDidFinish: ((UIImage) -> Void)
+    
+    init(inputImage: UIImage, croppingDidFinish: @escaping (UIImage) -> Void) {
+        self.inputImage = inputImage
+        self.croppingDidFinish = croppingDidFinish
+    }
+    
+    var body: some View {
+        Button(action: cropImage) {
+            Text("Crop Image")
+                .foregroundColor(.white)
+                .padding()
+                .background(Color.blue)
+                .cornerRadius(10)
+        }
+    }
+    
+    private func cropImage() {
+        croppingDidFinish(inputImage)
     }
 }
 
@@ -96,19 +155,20 @@ struct LegacyImagePickerRepresentable: UIViewControllerRepresentable {
     @Environment(\.presentationMode) private var presentationMode
 
     var sourceType: UIImagePickerController.SourceType
-    let onImageSelected: (UIImage) -> Void
-
-    @State private var selectedUIImage: UIImage? {
+    var useBuiltInCropper: Bool
+    let onImageSelected: (ImagePickerItem) -> Void
+    
+    @State private var pickedImage: ImagePickerItem? {
         didSet {
-            if let selectedUIImage {
-                onImageSelected(selectedUIImage)
+            if let pickedImage {
+                onImageSelected(pickedImage)
             }
         }
     }
 
     func makeUIViewController(context: UIViewControllerRepresentableContext<LegacyImagePickerRepresentable>) -> UIImagePickerController {
         let imagePicker = UIImagePickerController()
-        imagePicker.allowsEditing = true
+        imagePicker.allowsEditing = useBuiltInCropper
         imagePicker.sourceType = sourceType
         imagePicker.delegate = context.coordinator
 
@@ -126,17 +186,29 @@ struct LegacyImagePickerRepresentable: UIViewControllerRepresentable {
 
     final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
         var parent: LegacyImagePickerRepresentable
-
+        
         init(_ parent: LegacyImagePickerRepresentable) {
             self.parent = parent
         }
-
+        
         func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
-            if let image = info[UIImagePickerController.InfoKey.editedImage] as? UIImage {
-                parent.selectedUIImage = image
+            guard let url = info[UIImagePickerController.InfoKey.imageURL] as? URL else { return }
+            if picker.allowsEditing, let image = info[UIImagePickerController.InfoKey.editedImage] as? UIImage {
+                parent.pickedImage = .init(image: image, url: url)
+            }
+            else if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+                parent.pickedImage = .init(image: image, url: url)
             }
 
             parent.presentationMode.wrappedValue.dismiss()
         }
     }
+}
+
+struct ImagePickerItem: Identifiable {
+    var id: String {
+        url.absoluteString
+    }
+    let image: UIImage
+    let url: URL
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePickerView.swift
@@ -50,7 +50,7 @@ private struct ImagePicker<Label, ImageEditor: ImageEditorView>: View where Labe
         }
         .sheet(item: $sourceType, content: { source in
             // This allows to present different kind of pickers for different sources.
-            displayPickerOrCamera(source)
+            displayImagePicker(for: source)
                 .sheet(item: $imagePickerSelectedItem, content: { item in
                     if let customEditor {
                         customEditor(item.image) { croppedImage in
@@ -64,7 +64,7 @@ private struct ImagePicker<Label, ImageEditor: ImageEditorView>: View where Labe
     }
 
     @ViewBuilder
-    private func displayPickerOrCamera(_ source: SourceType) -> some View {
+    private func displayImagePicker(for source: SourceType) -> some View {
         switch source {
         case .camera:
             ZStack {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePickerView.swift
@@ -1,9 +1,9 @@
 import PhotosUI
 import SwiftUI
 
-struct SystemImagePickerView<Label>: View where Label: View {
+struct SystemImagePickerView<Label, ImageEditor: ImageEditorView>: View where Label: View {
     @ViewBuilder var label: () -> Label
-
+    var customEditor: ImageEditorBlock<ImageEditor>?
     let onImageSelected: (UIImage) -> Void
 
     var body: some View {
@@ -11,17 +11,11 @@ struct SystemImagePickerView<Label>: View where Label: View {
         // So far, the new SwiftUI PhotosPicker only supports Photos library, no camera, and no cropping, so we are only using legacy for now.
         // The interface (using a Label property as the element to open the picker) is the same as in the new SwiftUI picker,
         // which will make it easy to change it later on.
-        ImagePicker() {
-            label()
-        } onImageSelected: { image in
-            onImageSelected(image)
-        } customCropper: { image, croppingDidFinish in
-            TestCropper(inputImage: image, croppingDidFinish: croppingDidFinish)
-        }
+        ImagePicker(label: label, onImageSelected: onImageSelected, customEditor: customEditor)
     }
 }
 
-private struct ImagePicker<Label, ImageCropper: ImageCropperView>: View where Label: View {
+private struct ImagePicker<Label, ImageEditor: ImageEditorView>: View where Label: View {
     enum SourceType: CaseIterable, Identifiable {
         case photoLibrary
         case camera
@@ -36,9 +30,9 @@ private struct ImagePicker<Label, ImageCropper: ImageCropperView>: View where La
 
     @ViewBuilder var label: () -> Label
     let onImageSelected: (UIImage) -> Void
-    var customCropper: ((UIImage, _ croppingDidFinish: @escaping (UIImage) -> Void) -> ImageCropper)?
+    var customEditor: ImageEditorBlock<ImageEditor>?
     @State var imagePickerSelectedItem: ImagePickerItem?
-    
+
     var body: some View {
         VStack {
             Menu {
@@ -58,69 +52,41 @@ private struct ImagePicker<Label, ImageCropper: ImageCropperView>: View where La
             // This allows to present different kind of pickers for different sources.
             displayPickerOrCamera(source)
                 .sheet(item: $imagePickerSelectedItem, content: { item in
-                    if let customCropper {
-                        customCropper(item.image) { croppedImage in
+                    if let customEditor {
+                        customEditor(item.image) { croppedImage in
                             imagePickerSelectedItem = nil
+                            sourceType = nil
                             onImageSelected(croppedImage)
                         }
                     }
                 })
         })
     }
-    
+
     @ViewBuilder
     private func displayPickerOrCamera(_ source: SourceType) -> some View {
         switch source {
         case .camera:
             ZStack {
                 Color.black.ignoresSafeArea(edges: .all)
-                LegacyImagePickerRepresentable(sourceType: source.map(), useBuiltInCropper: customCropper == nil) { item in
+                LegacyImagePickerRepresentable(sourceType: source.map(), useBuiltInCropper: customEditor == nil) { item in
                     pickerDidSelectImage(item)
                 }
             }
         case .photoLibrary:
-            LegacyImagePickerRepresentable(sourceType: source.map(), useBuiltInCropper: customCropper == nil) { item in
+            LegacyImagePickerRepresentable(sourceType: source.map(), useBuiltInCropper: customEditor == nil) { item in
                 pickerDidSelectImage(item)
             }.ignoresSafeArea()
         }
     }
-    
+
     private func pickerDidSelectImage(_ item: ImagePickerItem) {
-        if customCropper != nil {
+        if customEditor != nil {
             imagePickerSelectedItem = item
-        }
-        else {
+        } else {
+            sourceType = nil
             onImageSelected(item.image)
         }
-    }
-}
-
-protocol ImageCropperView: View {
-    var inputImage: UIImage { get }
-    var croppingDidFinish: ((UIImage) -> Void) { get set }
-}
-
-struct TestCropper: View, ImageCropperView {
-    var inputImage: UIImage
-    var croppingDidFinish: ((UIImage) -> Void)
-    
-    init(inputImage: UIImage, croppingDidFinish: @escaping (UIImage) -> Void) {
-        self.inputImage = inputImage
-        self.croppingDidFinish = croppingDidFinish
-    }
-    
-    var body: some View {
-        Button(action: cropImage) {
-            Text("Crop Image")
-                .foregroundColor(.white)
-                .padding()
-                .background(Color.blue)
-                .cornerRadius(10)
-        }
-    }
-    
-    private func cropImage() {
-        croppingDidFinish(inputImage)
     }
 }
 
@@ -157,7 +123,7 @@ struct LegacyImagePickerRepresentable: UIViewControllerRepresentable {
     var sourceType: UIImagePickerController.SourceType
     var useBuiltInCropper: Bool
     let onImageSelected: (ImagePickerItem) -> Void
-    
+
     @State private var pickedImage: ImagePickerItem? {
         didSet {
             if let pickedImage {
@@ -186,21 +152,18 @@ struct LegacyImagePickerRepresentable: UIViewControllerRepresentable {
 
     final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
         var parent: LegacyImagePickerRepresentable
-        
+
         init(_ parent: LegacyImagePickerRepresentable) {
             self.parent = parent
         }
-        
+
         func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
             guard let url = info[UIImagePickerController.InfoKey.imageURL] as? URL else { return }
             if picker.allowsEditing, let image = info[UIImagePickerController.InfoKey.editedImage] as? UIImage {
                 parent.pickedImage = .init(image: image, url: url)
-            }
-            else if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+            } else if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
                 parent.pickedImage = .init(image: image, url: url)
             }
-
-            parent.presentationMode.wrappedValue.dismiss()
         }
     }
 }
@@ -209,6 +172,7 @@ struct ImagePickerItem: Identifiable {
     var id: String {
         url.absoluteString
     }
+
     let image: UIImage
     let url: URL
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarGrid.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarGrid.swift
@@ -9,7 +9,7 @@ enum AvatarGridConstants {
     static let avatarCornerRadius: CGFloat = .DS.Padding.single
 }
 
-struct AvatarGrid: View {
+struct AvatarGrid<ImageEditor: ImageEditorView>: View {
     let gridItems: [GridItem] = [GridItem(
         .adaptive(
             minimum: AvatarGridConstants.minAvatarWidth,
@@ -19,18 +19,22 @@ struct AvatarGrid: View {
     )]
 
     @ObservedObject var grid: AvatarGridModel
-
+    var customImageEditor: ImageEditorBlock<ImageEditor>?
     let onAvatarTap: (AvatarImageModel) -> Void
     let onImagePickerDidPickImage: (UIImage) -> Void
     let onRetryUpload: (AvatarImageModel) -> Void
 
     var body: some View {
         LazyVGrid(columns: gridItems, spacing: AvatarGridConstants.avatarSpacing) {
-            SystemImagePickerView {
-                PlusButtonView(minSize: AvatarGridConstants.minAvatarWidth, maxSize: AvatarGridConstants.maxAvatarWidth)
-            } onImageSelected: { image in
-                onImagePickerDidPickImage(image)
-            }
+            SystemImagePickerView(
+                label: {
+                    PlusButtonView(minSize: AvatarGridConstants.minAvatarWidth, maxSize: AvatarGridConstants.maxAvatarWidth)
+                },
+                customEditor: customImageEditor,
+                onImageSelected: { image in
+                    onImagePickerDidPickImage(image)
+                }
+            )
 
             ForEach(grid.avatars) { avatar in
                 AvatarPickerAvatarView(
@@ -58,7 +62,7 @@ struct AvatarGrid: View {
     )
     grid.selectAvatar(initialAvatarCell)
     return VStack {
-        AvatarGrid(grid: grid) { avatar in
+        AvatarGrid<NoCustomEditor>(grid: grid) { avatar in
             grid.selectAvatar(withID: avatar.id)
         } onImagePickerDidPickImage: { image in
             grid.append(newAvatarModel(image))

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -4,23 +4,26 @@ public enum QuickEditorScope {
     case avatarPicker
 }
 
-struct QuickEditor: View {
-    private enum Constants {
-        static let title: String = "Gravatar" // defined here to avoid translations
-    }
+private enum QuickEditorConstants {
+    static let title: String = "Gravatar" // defined here to avoid translations
+}
+
+struct QuickEditor<ImageEditor: ImageEditorView>: View {
+    fileprivate typealias Constants = QuickEditorConstants
 
     @Environment(\.oauthSession) private var oauthSession
     @State var hasSession: Bool = false
     @State var scope: QuickEditorScope
     @State var isAuthenticating: Bool = true
     @Binding var isPresented: Bool
-
     let email: Email
+    var customImageEditor: ImageEditorBlock<ImageEditor>?
 
-    init(email: Email, scope: QuickEditorScope, isPresented: Binding<Bool>) {
+    init(email: Email, scope: QuickEditorScope, isPresented: Binding<Bool>, customImageEditor: ImageEditorBlock<ImageEditor>? = nil) {
         self.email = email
         self.scope = scope
         self._isPresented = isPresented
+        self.customImageEditor = customImageEditor
     }
 
     var body: some View {
@@ -40,6 +43,7 @@ struct QuickEditor: View {
             AvatarPickerView(
                 model: .init(email: email, authToken: token),
                 isPresented: $isPresented,
+                customImageEditor: customImageEditor,
                 tokenErrorHandler: {
                     oauthSession.deleteSession(with: email)
                     performAuthentication()
@@ -86,5 +90,5 @@ struct QuickEditor: View {
 }
 
 #Preview {
-    QuickEditor(email: .init(""), scope: .avatarPicker, isPresented: .constant(true))
+    QuickEditor<NoCustomEditor>(email: .init(""), scope: .avatarPicker, isPresented: .constant(true))
 }

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -11,11 +11,18 @@ extension View {
             )
     }
 
-    public func avatarPickerSheet(isPresented: Binding<Bool>, email: String, authToken: String, contentLayout: AvatarPickerContentLayout) -> some View {
+    public func avatarPickerSheet(
+        isPresented: Binding<Bool>,
+        email: String,
+        authToken: String,
+        contentLayout: AvatarPickerContentLayout,
+        customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?
+    ) -> some View {
         let avatarPickerView = AvatarPickerView(
             model: AvatarPickerViewModel(email: Email(email), authToken: authToken),
             contentLayout: contentLayout,
-            isPresented: isPresented
+            isPresented: isPresented,
+            customImageEditor: customImageEditor
         )
         let navigationWrapped = NavigationView { avatarPickerView }
         return modifier(ModalPresentationModifier(isPresented: isPresented, modalView: navigationWrapped))
@@ -35,9 +42,10 @@ extension View {
         isPresented: Binding<Bool>,
         email: String,
         scope: QuickEditorScope,
+        customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
-        let editor = QuickEditor(email: .init(email), scope: scope, isPresented: isPresented)
+        let editor = QuickEditor(email: .init(email), scope: scope, isPresented: isPresented, customImageEditor: customImageEditor)
         return modifier(ModalPresentationModifier(isPresented: isPresented, onDismiss: onDismiss, modalView: editor))
     }
 }


### PR DESCRIPTION
Closes #365 

### Description

Allows 3rd party apps to inject their existing image editors to the QuickEditor. This is basically for cropping the image but it doesn't have to be limited to it.

### Testing Steps

SwiftUI Demo app > Avatar Picker view > "Custom image cropper" switch opens a dummy image cropper.