### PR TITLE
Remove async from ImageCaching

### DIFF
--- a/Sources/Gravatar/Cache/ImageCaching.swift
+++ b/Sources/Gravatar/Cache/ImageCaching.swift
@@ -9,7 +9,7 @@ public protocol ImageCaching: Sendable {
     /// - Parameters:
     ///   - image: The cache entry to set.
     ///   - key: The entry's key, used to be found via `.getEntry(key:)`.
-    func setEntry(_ entry: CacheEntry?, for key: String) async
+    func setEntry(_ entry: CacheEntry?, for key: String)
 
     /// Gets a `CacheEntry` from cache for the given key, or nil if none is found.
     ///
@@ -18,7 +18,7 @@ public protocol ImageCaching: Sendable {
     ///
     /// `.inProgress(task)`  is used by the image downloader to check if there's already an ongoing download task for the same image. If yes, the image
     /// downloader  awaits that ask instead of starting a new one.
-    func getEntry(with key: String) async -> CacheEntry?
+    func getEntry(with key: String) -> CacheEntry?
 }
 
 /// The default `ImageCaching` used by this SDK.

--- a/Sources/Gravatar/Network/Services/ImageDownloadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageDownloadService.swift
@@ -39,7 +39,7 @@ public struct ImageDownloadService: ImageDownloader, Sendable {
     }
 
     private func cachedImage(for url: URL) async throws -> UIImage? {
-        guard let entry = await imageCache.getEntry(with: url.absoluteString) else { return nil }
+        guard let entry = imageCache.getEntry(with: url.absoluteString) else { return nil }
         switch entry {
         case .inProgress(let task):
             let image = try await task.value
@@ -50,15 +50,15 @@ public struct ImageDownloadService: ImageDownloader, Sendable {
     }
 
     private func awaitAndCacheImage(from task: Task<UIImage, Error>, cacheKey key: String) async throws -> UIImage {
-        await imageCache.setEntry(.inProgress(task), for: key)
+        imageCache.setEntry(.inProgress(task), for: key)
         let image: UIImage
         do {
             image = try await task.value
         } catch {
-            await imageCache.setEntry(nil, for: key)
+            imageCache.setEntry(nil, for: key)
             throw error
         }
-        await imageCache.setEntry(.ready(image), for: key)
+        imageCache.setEntry(.ready(image), for: key)
         return image
     }
 
@@ -79,12 +79,12 @@ public struct ImageDownloadService: ImageDownloader, Sendable {
     }
 
     public func cancelTask(for url: URL) async {
-        if let entry = await imageCache.getEntry(with: url.absoluteString) {
+        if let entry = imageCache.getEntry(with: url.absoluteString) {
             switch entry {
             case .inProgress(let task):
                 if !task.isCancelled {
                     task.cancel()
-                    await imageCache.setEntry(nil, for: url.absoluteString)
+                    imageCache.setEntry(nil, for: url.absoluteString)
                 }
             default:
                 break

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -177,7 +177,7 @@ class AvatarPickerViewModel: ObservableObject {
         let service = AvatarService()
         do {
             let avatar = try await service.upload(squareImage, accessToken: accessToken)
-            await ImageCache.shared.setEntry(.ready(squareImage), for: avatar.url)
+            ImageCache.shared.setEntry(.ready(squareImage), for: avatar.url)
 
             let newModel = AvatarImageModel(id: avatar.id, source: .remote(url: avatar.url))
             grid.replaceModel(withID: localID, with: newModel)


### PR DESCRIPTION
This PR removes the `async` requirement from the `ImageCaching` protocol so that the clients could use it from synchronous contexts.

### Description

### Testing Steps
