### PR TITLE
Use `ImageCache.shared` as the default value

### DIFF
--- a/Sources/Gravatar/Network/Services/ImageDownloadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageDownloadService.swift
@@ -17,7 +17,7 @@ public struct ImageDownloadService: ImageDownloader, Sendable {
     ///   - cache: A type which will perform image caching operations.
     public init(client: HTTPClient? = nil, cache: ImageCaching? = nil) {
         self.client = client ?? URLSessionHTTPClient()
-        self.imageCache = cache ?? ImageCache()
+        self.imageCache = cache ?? ImageCache.shared
     }
 
     public func fetchImage(with url: URL, forceRefresh: Bool = false, processingMethod: ImageProcessingMethod = .common()) async throws -> ImageDownloadResult {

--- a/Tests/GravatarTests/AvatarServiceTests.swift
+++ b/Tests/GravatarTests/AvatarServiceTests.swift
@@ -11,7 +11,7 @@ final class AvatarServiceTests: XCTestCase {
     func testFetchImage() async throws {
         let response = HTTPURLResponse.successResponse(with: TestData.urlFromEmail)
         let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
-        let service = avatarService(with: sessionMock)
+        let service = avatarService(with: sessionMock, cache: TestImageCache())
         let options = ImageDownloadOptions()
 
         let imageResponse = try await service.fetch(with: .email(TestData.email), options: options)

--- a/Tests/GravatarTests/ImageDownloadServiceTests.swift
+++ b/Tests/GravatarTests/ImageDownloadServiceTests.swift
@@ -7,7 +7,7 @@ final class ImageDownloadServiceTests: XCTestCase {
         let imageURL = "https://gravatar.com/avatar/HASH"
         let response = HTTPURLResponse.successResponse(with: URL(string: imageURL)!)
         let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
-        let service = imageDownloadService(with: sessionMock)
+        let service = imageDownloadService(with: sessionMock, cache: TestImageCache())
 
         let imageResponse = try await service.fetchImage(with: URL(string: imageURL)!)
         let request = await sessionMock.request

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 module Gravatar
-    VERSION = '2.1.0'.freeze
+    VERSION = '2.1.1'.freeze
 end


### PR DESCRIPTION
Closes # 

### Description

ImageDownloadService defaults to `ImageCache()` when the passed cache is `nil`. It should be `ImageCache.shared`. Fortunately we pass here `ImageCache.shared` in many places so there's no real bug reported about this. But this is still worth a patch release.

### Testing Steps

Smoke testing the UIKit demo app.