### PR TITLE
Use SPM Caching in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -62,15 +62,14 @@ steps:
   ###################
   - group: ":appcenter: Prototype Builds"
     steps:
-      - label: ":swift: Setting up Swift Packages"
-        key: setup_spm_cache
-        plugins: [$CI_TOOLKIT]
-        command: install_swiftpm_dependencies
-
       - label: "🛠️ Build SwiftUI Demo"
         key: build_swiftui
-        depends_on: [test, setup_spm_cache]
-        command: BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER make build-demo-for-distribution-swiftui
+        depends_on: test
+        plugins: [$CI_TOOLKIT]
+        command: |
+          echo "--- :swift: Setting up Swift Packages"
+          install_swiftpm_dependencies
+          BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER make build-demo-for-distribution-swiftui
         artifact_paths:
           - ".build/artifacts/*.ipa"
           - ".build/artifacts/*.dSYM.zip"
@@ -83,8 +82,12 @@ steps:
 
       - label: "🛠️ Build UIKit Demo"
         key: build_uikit
-        depends_on: [test, setup_spm_cache]
-        command: BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER make build-demo-for-distribution-uikit
+        depends_on: test
+        plugins: [$CI_TOOLKIT]
+        command: |
+          echo "--- :swift: Setting up Swift Packages"
+          install_swiftpm_dependencies
+          BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER make build-demo-for-distribution-uikit
         artifact_paths:
           - ".build/artifacts/*.ipa"
           - ".build/artifacts/*.dSYM.zip"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,12 +63,13 @@ steps:
   - group: ":appcenter: Prototype Builds"
     steps:
       - label: ":swift: Setting up Swift Packages"
+        key: setup_spm_cache
         plugins: [$CI_TOOLKIT]
         command: install_swiftpm_dependencies
 
       - label: "🛠️ Build SwiftUI Demo"
         key: build_swiftui
-        depends_on: test
+        depends_on: [test, setup_spm_cache]
         command: BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER make build-demo-for-distribution-swiftui
         artifact_paths:
           - ".build/artifacts/*.ipa"
@@ -82,7 +83,7 @@ steps:
 
       - label: "🛠️ Build UIKit Demo"
         key: build_uikit
-        depends_on: test
+        depends_on: [test, setup_spm_cache]
         command: BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER make build-demo-for-distribution-uikit
         artifact_paths:
           - ".build/artifacts/*.ipa"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,8 +15,11 @@ steps:
   - label: "🕵️ Lint"
     key: "lint"
     command: |
+      echo "--- :swift: Setting up Swift Packages"
+      install_swiftpm_dependencies
       echo "--- 🛠 Linting"
       make lint
+    plugins: [$CI_TOOLKIT]
 
   #################
   # Build and Test
@@ -24,6 +27,8 @@ steps:
   - label: "📦 Build and Test Swift Package"
     key: "test"
     command: |
+      echo "--- :swift: Setting up Swift Packages"
+      install_swiftpm_dependencies
       validate_swift_package
     plugins: [$CI_TOOLKIT]
 
@@ -57,6 +62,10 @@ steps:
   ###################
   - group: ":appcenter: Prototype Builds"
     steps:
+      - label: ":swift: Setting up Swift Packages"
+        plugins: [$CI_TOOLKIT]
+        command: install_swiftpm_dependencies
+
       - label: "🛠️ Build SwiftUI Demo"
         key: build_swiftui
         depends_on: test

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,4 +5,4 @@
 
 export IMAGE_ID=$(echo "xcode-$(cat .xcode-version)")
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.2.2"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.5.1"


### PR DESCRIPTION
Closes #391 

### Description

This updates the BuildKite pipeline to use caching for Swift Package dependencies

### Testing Steps

- CI should be 🟢 
- Restoring from cache should be successful for this PR, since our Swift Package dependencies are commonly used and already cached.