### PR TITLE
Add a error view to authentication

### DIFF
--- a/Demo/Demo/Gravatar-SwiftUI-Demo/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/DemoProfileEditorView.swift
@@ -30,7 +30,7 @@ struct DemoProfileEditorView: View {
                 isPresented: $isPresentingPicker,
                 email: email,
                 scope: .avatarPicker,
-                contentLayout: AvatarPickerContentLayoutWithPresentation.vertical(),
+                contentLayout: .horizontal(),
                 onDismiss: {
                     updateHasSession(with: email)
                 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -19,7 +19,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
     public var body: some View {
         ZStack {
             VStack(spacing: 0) {
-                email()
+                EmailText(email: model.email)
                     .accumulateIntrinsicHeight()
                 profileView()
                     .accumulateIntrinsicHeight()
@@ -58,16 +58,6 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
         .fullScreenCover(item: $safariURL) { url in
             SafariView(url: url)
                 .edgesIgnoringSafeArea(.all)
-        }
-    }
-
-    @ViewBuilder
-    private func email() -> some View {
-        if let email = model.email?.rawValue, !email.isEmpty {
-            Text(email)
-                .padding(.bottom, Constants.emailBottomSpacing / 2)
-                .font(.footnote)
-                .foregroundColor(Color(UIColor.secondaryLabel))
         }
     }
 
@@ -281,7 +271,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
                 .cornerRadius(8)
                 .shadow(color: profileShadowColor, radius: profileShadowRadius, y: 3)
         })
-        .padding(.top, Constants.emailBottomSpacing / 2)
+        .padding(.top, Constants.profileViewTopSpacing / 2)
         .padding(.bottom, Constants.vStackVerticalSpacing)
         .padding(.horizontal, Constants.horizontalPadding)
     }
@@ -312,7 +302,7 @@ private enum AvatarPicker {
         static let lightModeShadowColor = Color(uiColor: UIColor.rgba(25, 30, 35, alpha: 0.2))
         static let title: String = "Gravatar" // defined here to avoid translations
         static let vStackVerticalSpacing: CGFloat = .DS.Padding.medium
-        static let emailBottomSpacing: CGFloat = .DS.Padding.double
+        static let profileViewTopSpacing: CGFloat = .DS.Padding.double
     }
 
     enum Localized {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/EmailText.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/EmailText.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct EmailText: View {
+    enum Constants {
+        static let bottomSpacing: CGFloat = .DS.Padding.double
+    }
+
+    let email: Email?
+    var body: some View {
+        if let email = email?.rawValue, !email.isEmpty {
+            Text(email)
+                .padding(.bottom, Constants.bottomSpacing / 2)
+                .font(.footnote)
+                .foregroundColor(Color(UIColor.secondaryLabel))
+        }
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -68,14 +68,14 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
             if !isAuthenticating {
                 EmailText(email: email)
                 ContentLoadingErrorView(
-                    title: "Error",
-                    subtext: "Please try to authenticate again.",
+                    title: Constants.Localized.LogInError.title,
+                    subtext: Constants.Localized.LogInError.subtext,
                     image: nil,
                     actionButton: {
                         Button {
                             performAuthentication()
                         } label: {
-                            CTAButtonView("Authenticate")
+                            CTAButtonView(Constants.Localized.LogInError.buttonTitle)
                         }
                     },
                     innerPadding: .init(
@@ -111,6 +111,30 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
             }
             hasSession = oauthSession.hasSession(with: email)
             isAuthenticating = false
+        }
+    }
+}
+
+extension QuickEditorConstants {
+    enum Localized {
+        enum LogInError {
+            static let title = SDKLocalizedString(
+                "AvatarPicker.ContentLoading.Failure.LogInError.title",
+                value: "Login required",
+                comment: "Title of a message advising the user that something went wrong while trying to log in."
+            )
+
+            static let buttonTitle = SDKLocalizedString(
+                "AvatarPicker.ContentLoading.Failure.SessionExpired.LogInError.buttonTitle",
+                value: "Log in",
+                comment: "Title of a button that will begin the process of authenticating the user, appearing beneath a message stating that a previous log in attept has failed."
+            )
+
+            static let subtext = SDKLocalizedString(
+                "AvatarPicker.ContentLoading.Failure.SessionExpired.LogInError.subtext",
+                value: "To modify your Gravatar profile, you need to log in first.",
+                comment: "A message describing the error and advising the user to login again to resolve the issue"
+            )
         }
     }
 }

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -66,11 +66,27 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
     func noticeView() -> some View {
         VStack {
             if !isAuthenticating {
-                Button("Authenticate (Future error view)") {
-                    Task {
-                        performAuthentication()
-                    }
-                }
+                EmailText(email: email)
+                ContentLoadingErrorView(
+                    title: "Error",
+                    subtext: "Please try to authenticate again.",
+                    image: nil,
+                    actionButton: {
+                        Button {
+                            performAuthentication()
+                        } label: {
+                            CTAButtonView("Authenticate")
+                        }
+                    },
+                    innerPadding: .init(
+                        top: .DS.Padding.double,
+                        leading: .DS.Padding.double,
+                        bottom: .DS.Padding.double,
+                        trailing: .DS.Padding.double
+                    )
+                )
+                .padding(.horizontal, .DS.Padding.double)
+                Spacer()
             } else {
                 ProgressView()
             }


### PR DESCRIPTION
Closes #

### Description

This PR add an error view when Authorization fails or is cancelled.

- [x] **Note: The copy still to be defined**

<img src="https://github.com/user-attachments/assets/c7c9ac8f-b5b1-4097-b983-f055240c22f3" width="40%">


### Testing Steps

- Run the SwiftUI demo app
- Go to `Profile editor with auth` screen
- Log out if needed
- Tap `Open Profile Editor ... `
- Cancel the alert.
  - Check the error message
- Tap on authenticate  
  - Check that the authentication flow triggers again. 
