### PR TITLE
Fix DoCC generation for Github Pages

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -3,7 +3,7 @@ name: Deploy Gravatar DocC
 on:
   # Runs on pushes and PRs targeting the default branch
   push:
-    branches: [ "trunk", "andrewdmontgomery/fix-docc-generation-gh-pages" ]
+    branches: [ "trunk" ]
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -3,7 +3,7 @@ name: Deploy Gravatar DocC
 on:
   # Runs on pushes and PRs targeting the default branch
   push:
-    branches: [ "trunk" ]
+    branches: [ "trunk", "andrewdmontgomery/fix-docc-generation-gh-pages" ]
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -41,7 +41,8 @@ jobs:
         run: |
           xcodebuild docbuild -scheme Gravatar-Package \
             -derivedDataPath /tmp/docbuild \
-            -destination 'generic/platform=iOS';
+            -destination 'generic/platform=iOS' \
+            -skipPackagePluginValidation;
           
       - name: Process Gravatar DocC
         run: |


### PR DESCRIPTION
Closes #

### Description

This updates the `docc` workflow so that it properly skips validation of Swift Package Plugins.
https://forums.swift.org/t/telling-xcode-14-beta-4-to-trust-build-tool-plugins-programatically/59305

### Testing Steps

To test this, we temporarily allow this workflow to build this branch instead of `trunk`.

- [ ] DoCC job should complete successfully
https://github.com/Automattic/Gravatar-SDK-iOS/deployments/github-pages

#### Test Result
Successful job: https://github.com/Automattic/Gravatar-SDK-iOS/actions/runs/10832822564/job/30058209288
![image](https://github.com/user-attachments/assets/430f7ef4-47fa-49e4-84bb-7eaab2d83181)
