### PR TITLE
Adding secrets config for CI (and a8c devs)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,6 +60,7 @@ steps:
       - label: "🛠️ Build SwiftUI Demo"
         key: build_swiftui
         depends_on: test
+        plugins: [$CI_TOOLKIT]
         command: |
           install_gems
           BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER make build-demo-for-distribution-swiftui
@@ -76,6 +77,7 @@ steps:
       - label: "🛠️ Build UIKit Demo"
         key: build_uikit
         depends_on: test
+        plugins: [$CI_TOOLKIT]
         command: |
           install_gems
           BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER make build-demo-for-distribution-uikit

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,7 +60,9 @@ steps:
       - label: "🛠️ Build SwiftUI Demo"
         key: build_swiftui
         depends_on: test
-        command: BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER make build-demo-for-distribution-swiftui
+        command: |
+          install_gems
+          BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER make build-demo-for-distribution-swiftui
         artifact_paths:
           - ".build/artifacts/*.ipa"
           - ".build/artifacts/*.dSYM.zip"
@@ -74,7 +76,9 @@ steps:
       - label: "🛠️ Build UIKit Demo"
         key: build_uikit
         depends_on: test
-        command: BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER make build-demo-for-distribution-uikit
+        command: |
+          install_gems
+          BUILD_NUMBER=$BUILDKITE_BUILD_NUMBER make build-demo-for-distribution-uikit
         artifact_paths:
           - ".build/artifacts/*.ipa"
           - ".build/artifacts/*.dSYM.zip"

--- a/.configure
+++ b/.configure
@@ -1,7 +1,7 @@
 {
   "project_name": "Gravatar-SDK-iOS",
   "branch": "trunk",
-  "pinned_hash": "21d3c90afdd7adfca9f3a8faab1dd070b1d2395b",
+  "pinned_hash": "1761b0a77a5371f9127c5d0575c90f938d864537",
   "files_to_copy": [
     {
       "file": "iOS/GravatarSDK/Secrets.swift",
@@ -9,5 +9,7 @@
       "encrypt": true
     }
   ],
-  "file_dependencies": []
+  "file_dependencies": [
+
+  ]
 }

--- a/.configure
+++ b/.configure
@@ -1,7 +1,7 @@
 {
   "project_name": "Gravatar-SDK-iOS",
   "branch": "trunk",
-  "pinned_hash": "007f867fd2c02537ea9185312afd38646d4cdb91",
+  "pinned_hash": "21d3c90afdd7adfca9f3a8faab1dd070b1d2395b",
   "files_to_copy": [
     {
       "file": "iOS/GravatarSDK/Secrets.swift",

--- a/.configure
+++ b/.configure
@@ -1,0 +1,13 @@
+{
+  "project_name": "Gravatar-SDK-iOS",
+  "branch": "trunk",
+  "pinned_hash": "007f867fd2c02537ea9185312afd38646d4cdb91",
+  "files_to_copy": [
+    {
+      "file": "iOS/GravatarSDK/Secrets.swift",
+      "destination": "Demo/Demo/Secrets.swift",
+      "encrypt": true
+    }
+  ],
+  "file_dependencies": []
+}

--- a/.configure-files/Secrets.swift.enc
+++ b/.configure-files/Secrets.swift.enc
@@ -1,1 +1,2 @@
-ømòâ	!u*ò¡;h™i¸ÄftH#L(¬ï~}H+^Ç*_(,ƒTg Ÿ¦ÞñÉ¥< ÷g¼fŸÖø.º¢ª.Úl)Ì™é—Z~×Oë(s9·1î_Òfhþê°éÕŽ•€½RRèÌÛ‡x6ˆ]d67²¬:C¸j2²ÈpÃ…2î/5èª"g{F}:-»H‡%kõ,-ï&©ÅVÊñ˜Äå’~•h#ƒ„ y0=õtŠQ¡Yç…®›h7 ¹Û¤DlýeD!9çÅûo€Æ÷´¯Ä1{`|6b`M‡ÔZþXQŽÒUÇRTª·BÀK0>—^ÿÐ(lÝ/—•Ð™¾‹)¢´U±gI<xP{ii¥ÞêÈ=aÜÃ‰$®¤½ÄìJÅzÔ‹ý Ný­XâÇ¤× >ê;;ç–@^0XTIy6EïÁÁr „mó›Î<Ï
+ømòâ	!u*ò¡;h™i¸ÄftH#L(¬ï~}H+^Ç*_(,ƒTg Ÿ¦ÞñÉ¥< ÷g¼fŸÖø.º¢ª.Úl)Ì™é—Z~×Oë(s9·1î_Òfhþê°éÕŽ•€½RRèÌÛ‡x6ˆ]d67²¬:C¸j2²ÈpÃ…2î/5èª"g{F}:-»H‡%kõ,-ï&©ÅVÊñ˜Äå’~•h#ƒ„ y0=õtŠQ¡Yç…®›h7 ¹Û¤DlýeD!9çÅûo€Æ÷´¯Ä1{`|6b`M‡ÔZþXQŽÒUÇRTª·BÀK0>—^ÿÐ(lÝ/—•Ð™¾‹)¢´U±gI<xP{ii¥ÞêÈ=aÜÃ‰$®¤½ÄìJÅzÔÒœ¥j”Ývõñ{H’r`ÓÑBX€´'XŽ¹¯:‹š¡Ñþpm
+¦Çõ	ul&‰P—w

--- a/.configure-files/Secrets.swift.enc
+++ b/.configure-files/Secrets.swift.enc
@@ -1,0 +1,1 @@
+ømòâ	!u*ò¡;h™i¸ÄftH#L(¬ï~}H+^Ç*_(,ƒTg Ÿ¦ÞñÉ¥< ÷g¼fŸÖø.º¢ª.Úl)Ì™é—Z~×Oë(s9·1î_Òfhþê°éÕŽ•€½RRèÌÛ‡x6ˆ]d67²¬:C¸j2²ÈpÃ…2î/5èª"g{F}:-»H‡%kõ,-ï&©ÅVÊñ˜Äå’~•h#ƒ„ y0=õtŠQ¡Yç…®›h7 ¹Û¤DlýeD!9çÅûo€Æ÷´¯Ä1{`|6b`M‡ÔZþXQŽÒUÇRTª·BÀK0>—^ÿÐ(lÝ/—•Ð™¾‹)¢´U±gI<xP{ii¥ÞêÈ=aÜÃ‰$®¤½ÄìJÅzÔ‹ý Ný­XâÇ¤× >ê;;ç–@^0XTIy6EïÁÁr „mó›Î<Ï

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,6 @@ gem 'fastlane', '~> 2.222'
 gem 'fastlane-plugin-appcenter', '~> 2.1'
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 12.0'
 gem 'rubocop', '~> 1.65'
+
+plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
+eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,3 @@ gem 'fastlane', '~> 2.222'
 gem 'fastlane-plugin-appcenter', '~> 2.1'
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 12.0'
 gem 'rubocop', '~> 1.65'
-
-plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ bundle-install:
 fetch-code-signing: bundle-install
 	bundle exec fastlane configure_code_signing
 
-setup-secrets:
+setup-secrets: bundle-install
 	bundle exec fastlane run configure_apply
 
 swiftformat: # Automatically find and fixes lint issues

--- a/Makefile
+++ b/Makefile
@@ -50,12 +50,12 @@ build-demo-swiftui: bundle-install
 
 build-demo-for-distribution: build-demo-for-distribution-swiftui build-demo-for-distribution-uikit
 
-build-demo-for-distribution-swiftui: fetch-code-signing check-build-number
+build-demo-for-distribution-swiftui: fetch-code-signing check-build-number setup-secrets
 	bundle exec fastlane build_demo_for_distribution \
 		scheme:$(SCHEME_DEMO_SWIFTUI) \
 		build_number:$(BUILD_NUMBER)
 
-build-demo-for-distribution-uikit: fetch-code-signing check-build-number
+build-demo-for-distribution-uikit: fetch-code-signing check-build-number setup-secrets
 	bundle exec fastlane build_demo_for_distribution \
 		scheme:$(SCHEME_DEMO_UIKIT) \
 		build_number:$(BUILD_NUMBER)
@@ -71,6 +71,9 @@ bundle-install:
 
 fetch-code-signing: bundle-install
 	bundle exec fastlane configure_code_signing
+
+setup-secrets:
+	bundle exec fastlane run configure_apply
 
 swiftformat: # Automatically find and fixes lint issues
 	swift package plugin \


### PR DESCRIPTION
Closes #395 

### Description

This PR adds the needed configuration for CI to use the oauth secrets.

### Testing Steps

#### Pre-requisites:
- Have `.mobile-secrets` set up, and up to date (fetch+pull latests changes).

#### On the local project:
- Remove the local copy of `Demo/Demo/Secrets.swift`.
- Run `make setup-secrets`
  - Check that the `Secrets.swift` file gets created.
- Build and run.
  - Check the oauth works.

#### On CI:
- Download the build on a device from https://github.com/Automattic/Gravatar-SDK-iOS/pull/405#issuecomment-2347351534
- Open the downloaded demo app
  - Check that oauth works. 
