### PR TITLE
Add image cropper

### DIFF
--- a/Demo/Demo/Gravatar-UIKit-Demo/DemoImageCropperViewController.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/DemoImageCropperViewController.swift
@@ -26,7 +26,9 @@ class DemoImageCropperViewController: UIViewController {
     
     lazy var sizeLabel: UILabel = {
         let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = UIColor.label
+        label.numberOfLines = 0
         return label
     }()
     
@@ -35,7 +37,7 @@ class DemoImageCropperViewController: UIViewController {
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .vertical
         stack.spacing = 12
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.alignment = .center
         return stack
     }()
@@ -86,13 +88,35 @@ extension DemoImageCropperViewController: PHPickerViewControllerDelegate {
     func showCropper(with image: UIImage) {
         let cropperVC = ImageCropperViewController.wrappedInNavigationViewController(image: image) { image, _ in
             self.croppedImageView.image = image
-            self.sizeLabel.text = "\(image.size.width) x \(image.size.height)"
+            self.sizeLabel.text = "\(image.size.width) x \(image.size.height) - scale: \(image.scale) - \(image.calculateSizeInMB())MB"
             self.dismiss(animated: true)
         } onCancel: {
             self.dismiss(animated: true)
         }
 
         present(cropperVC, animated: true, completion: nil)
+    }
+}
+
+private extension UIImage {
+    // Function to calculate and print the size of the UIImage in megabytes
+    func calculateSizeInMB() -> Double {
+        guard let cgImage = self.cgImage else { return 0.0 }
+        
+        // Get the width and height of the image
+        let width = cgImage.width
+        let height = cgImage.height
+        
+        // Assume 4 bytes per pixel for RGBA (32-bit color depth)
+        let bytesPerPixel = 4
+        
+        // Calculate the total number of bytes
+        let totalBytes = width * height * bytesPerPixel
+        
+        // Convert bytes to megabytes
+        let totalMB = Double(totalBytes) / (1024.0 * 1024.0)
+        
+        return Double(round(100 * totalMB) / 100)
     }
 }
 

--- a/Demo/Demo/Gravatar-UIKit-Demo/DemoImageCropperViewController.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/DemoImageCropperViewController.swift
@@ -1,0 +1,99 @@
+#if DEBUG
+
+import UIKit
+@testable import GravatarUI
+import PhotosUI
+
+class DemoImageCropperViewController: UIViewController {
+    
+    lazy var selectImageButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("Select Image", for: .normal)
+        button.addTarget(self, action: #selector(selectImage), for: .touchUpInside)
+        return button
+    }()
+    
+    lazy var croppedImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        imageView.widthAnchor.constraint(equalToConstant: 300).isActive = true
+        imageView.heightAnchor.constraint(equalToConstant: 300).isActive = true
+        imageView.backgroundColor = UIColor.secondarySystemBackground
+        return imageView
+    }()
+    
+    lazy var sizeLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = UIColor.label
+        return label
+    }()
+    
+    lazy var rootStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [selectImageButton, croppedImageView, sizeLabel])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.distribution = .fillProportionally
+        stack.alignment = .center
+        return stack
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIColor.systemBackground
+        view.addSubview(rootStackView)
+        NSLayoutConstraint.activate([
+            rootStackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            rootStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            rootStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+    }
+    
+    @objc private func selectImage() {
+        var configuration = PHPickerConfiguration()
+        configuration.filter = .images // Only show images in picker
+        configuration.selectionLimit = 1 // Limit selection to one image
+        
+        let picker = PHPickerViewController(configuration: configuration)
+        picker.delegate = self
+        present(picker, animated: true, completion: nil)
+    }
+}
+
+extension DemoImageCropperViewController: PHPickerViewControllerDelegate {
+    
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        dismiss(animated: true, completion: nil)
+        
+        // Ensure the user selected an image and that it can be loaded as a UIImage
+        guard let result = results.first else { return }
+        
+        // Load the selected image
+        if result.itemProvider.canLoadObject(ofClass: UIImage.self) {
+            result.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] (object, error) in
+                if let image = object as? UIImage {
+                    DispatchQueue.main.async {
+                        self?.showCropper(with: image)
+                    }
+                }
+            }
+        }
+    }
+    
+    // Show the cropper with the selected image
+    func showCropper(with image: UIImage) {
+        let cropperVC = ImageCropperViewController.wrappedInNavigationViewController(image: image) { image, _ in
+            self.croppedImageView.image = image
+            self.sizeLabel.text = "\(image.size.width) x \(image.size.height)"
+            self.dismiss(animated: true)
+        } onCancel: {
+            self.dismiss(animated: true)
+        }
+
+        present(cropperVC, animated: true, completion: nil)
+    }
+}
+
+#endif

--- a/Demo/Demo/Gravatar-UIKit-Demo/MainTableViewController.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/MainTableViewController.swift
@@ -20,9 +20,10 @@ class MainTableViewController: UITableViewController {
         case profileViewController
         #if DEBUG
         case displayRemoteSVG
+        case imageCropper
         #endif
     }
-    
+
     private static let reuseID =  "DefaultCell"
     
     override func viewDidLoad() {
@@ -57,6 +58,8 @@ class MainTableViewController: UITableViewController {
         #if DEBUG
         case .displayRemoteSVG:
             content.text = "Display remote SVG"
+        case .imageCropper:
+            content.text = "Image Cropper"
         #endif
         }
         cell.contentConfiguration = content
@@ -87,6 +90,8 @@ class MainTableViewController: UITableViewController {
         #if DEBUG
         case .displayRemoteSVG:
             navigationController?.pushViewController(DemoRemoteSVGViewController(), animated: true)
+        case .imageCropper:
+            navigationController?.pushViewController(DemoImageCropperViewController(), animated: true)
         #endif
         }
     }

--- a/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		49C5D6122B5B33E20067C2A8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 49C5D6112B5B33E20067C2A8 /* Assets.xcassets */; };
 		49C5D6152B5B33E20067C2A8 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 49C5D6142B5B33E20067C2A8 /* Preview Assets.xcassets */; };
 		49EFFB542C51A47C0086589A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 495775EA2B5B34980082812A /* Assets.xcassets */; };
+		9133058E2C91F8D1009F5C0B /* DemoImageCropperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9133058D2C91F2C8009F5C0B /* DemoImageCropperViewController.swift */; };
 		9146A7AE2C3BD8F000E07C63 /* DemoAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9146A7AD2C3BD8F000E07C63 /* DemoAvatarView.swift */; };
 		914AC0192BD7FF08005DA4A5 /* DemoBaseProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914AC0172BD7FF08005DA4A5 /* DemoBaseProfileViewController.swift */; };
 		914AC01A2BD7FF08005DA4A5 /* DemoProfilePresentationStylesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914AC0182BD7FF08005DA4A5 /* DemoProfilePresentationStylesViewController.swift */; };
@@ -115,6 +116,7 @@
 		49C5D6142B5B33E20067C2A8 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		49EFFB552C51AA280086589A /* Gravatar-UIKit-Demo.Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Gravatar-UIKit-Demo.Base.xcconfig"; sourceTree = "<group>"; };
 		49EFFB572C51AA3E0086589A /* Gravatar-SwiftUI-Demo.Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Gravatar-SwiftUI-Demo.Base.xcconfig"; sourceTree = "<group>"; };
+		9133058D2C91F2C8009F5C0B /* DemoImageCropperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoImageCropperViewController.swift; sourceTree = "<group>"; };
 		9146A7AD2C3BD8F000E07C63 /* DemoAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAvatarView.swift; sourceTree = "<group>"; };
 		914AC0172BD7FF08005DA4A5 /* DemoBaseProfileViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoBaseProfileViewController.swift; sourceTree = "<group>"; };
 		914AC0182BD7FF08005DA4A5 /* DemoProfilePresentationStylesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoProfilePresentationStylesViewController.swift; sourceTree = "<group>"; };
@@ -192,6 +194,7 @@
 				91956A532B67943A00BF3CF0 /* DemoUIImageViewExtensionViewController.swift */,
 				914AC01F2BDAAC3C005DA4A5 /* DemoRemoteSVGViewController.swift */,
 				91F0B3DB2B62815F0025C4F8 /* MainTableViewController.swift */,
+				9133058D2C91F2C8009F5C0B /* DemoImageCropperViewController.swift */,
 				495775EA2B5B34980082812A /* Assets.xcassets */,
 				495775EC2B5B34980082812A /* LaunchScreen.storyboard */,
 				495775EF2B5B34980082812A /* Info.plist */,
@@ -446,6 +449,7 @@
 				495775E42B5B34970082812A /* SceneDelegate.swift in Sources */,
 				1ECAB5072BC984440043A331 /* DemoProfileConfigurationViewController.swift in Sources */,
 				91E2FB042BC0276E00265E8E /* DemoProfileViewsViewController.swift in Sources */,
+				9133058E2C91F8D1009F5C0B /* DemoImageCropperViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/GravatarUI/ImageCropper/CropFrameOverlayView.swift
+++ b/Sources/GravatarUI/ImageCropper/CropFrameOverlayView.swift
@@ -1,0 +1,25 @@
+import UIKit
+
+class CropFrameOverlayView: UIView {
+    var scrollViewFrame: CGRect = .zero {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+
+    override func draw(_ rect: CGRect) {
+        guard let context = UIGraphicsGetCurrentContext() else { return }
+
+        // Fill the entire view with a black color with 0.2 alpha
+        context.setFillColor(UIColor.black.withAlphaComponent(0.5).cgColor)
+        context.fill(rect)
+
+        // Clear the scrollView's area to make it transparent
+        context.clear(scrollViewFrame)
+
+        // Optional: Draw a border around the scrollView area
+        context.setStrokeColor(UIColor.white.cgColor)
+        context.setLineWidth(1)
+        context.stroke(scrollViewFrame)
+    }
+}

--- a/Sources/GravatarUI/ImageCropper/CropFrameOverlayView.swift
+++ b/Sources/GravatarUI/ImageCropper/CropFrameOverlayView.swift
@@ -10,14 +10,14 @@ class CropFrameOverlayView: UIView {
     override func draw(_ rect: CGRect) {
         guard let context = UIGraphicsGetCurrentContext() else { return }
 
-        // Fill the entire view with a black color with 0.2 alpha
+        // Fill the entire view with a semi black color
         context.setFillColor(UIColor.black.withAlphaComponent(0.5).cgColor)
         context.fill(rect)
 
         // Clear the scrollView's area to make it transparent
         context.clear(scrollViewFrame)
 
-        // Optional: Draw a border around the scrollView area
+        // Draw a border around the crop frame
         context.setStrokeColor(UIColor.white.cgColor)
         context.setLineWidth(1)
         context.stroke(scrollViewFrame)

--- a/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
+++ b/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
@@ -1,0 +1,236 @@
+import UIKit
+
+class ImageCropperViewController: UIViewController, UIScrollViewDelegate {
+    private enum Constants {
+        static let overlayColor = UIColor.black.withAlphaComponent(0.2)
+        static let backgroundColor = UIColor.black
+        static let scrollViewHorizontalPadding: CGFloat = .DS.Padding.medium
+        static let cropSize: CGFloat = 320
+    }
+
+    // ScrollView for zooming and panning
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.isScrollEnabled = true
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.bouncesZoom = true
+        scrollView.bounces = true
+        scrollView.contentMode = .scaleAspectFit
+        return scrollView
+    }()
+
+    // ImageView for displaying the image
+    private let imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.isUserInteractionEnabled = true
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    // View to show the cropping frame
+    private let cropFrameView: CropFrameOverlayView = {
+        let cropFrameView = CropFrameOverlayView()
+        cropFrameView.translatesAutoresizingMaskIntoConstraints = false
+        cropFrameView.backgroundColor = .clear
+        cropFrameView.isUserInteractionEnabled = false
+        return cropFrameView
+    }()
+
+    let inputImage: UIImage
+    var onCompletion: ((UIImage, Bool) -> Void)?
+    var onCancel: (() -> Void)?
+
+    init(image: UIImage) {
+        self.inputImage = image
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let appearance = UINavigationBarAppearance()
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+
+        view.addSubview(scrollView)
+        scrollView.addSubview(imageView)
+        view.addSubview(cropFrameView)
+        configureConstraints()
+
+        title = Localized.title
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            title: Localized.useButtonTitle,
+            style: .plain,
+            target: self,
+            action: #selector(cropWasPressed)
+        )
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            title: Localized.cancelButtonTitle,
+            style: .plain,
+            target: self,
+            action: #selector(cancelWasPressed)
+        )
+
+        view.backgroundColor = Constants.backgroundColor
+        scrollView.delegate = self
+
+        setImageToCrop(image: inputImage)
+    }
+
+    private func configureConstraints() {
+        let scrollViewWidthConstraint = scrollView.widthAnchor.constraint(equalToConstant: Constants.cropSize)
+        scrollViewWidthConstraint.priority = .defaultLow
+
+        NSLayoutConstraint.activate([
+            // scrollView
+            scrollView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor),
+            view.trailingAnchor.constraint(greaterThanOrEqualTo: scrollView.trailingAnchor),
+            view.safeAreaLayoutGuide.bottomAnchor.constraint(greaterThanOrEqualTo: scrollView.bottomAnchor),
+            scrollView.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor, constant: .DS.Padding.half),
+            scrollView.heightAnchor.constraint(equalTo: scrollView.widthAnchor),
+            scrollView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            scrollView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            scrollViewWidthConstraint,
+            // imageView
+            imageView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            imageView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            imageView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            // crop frame
+            cropFrameView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            cropFrameView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            cropFrameView.topAnchor.constraint(equalTo: view.topAnchor),
+            cropFrameView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        imageView.frame = CGRect(x: 0, y: 0, width: scrollView.frame.width, height: scrollView.frame.height)
+    }
+
+    func setImageToCrop(image: UIImage) {
+        imageView.image = image
+        scrollView.layoutIfNeeded()
+        scrollView.clipsToBounds = false
+        imageView.frame = CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
+        scrollView.contentSize = image.size
+        let scaleHeight = scrollView.frame.size.height / scrollView.contentSize.height
+        let scaleWidth = scrollView.frame.size.width / scrollView.contentSize.width
+        let minScale = max(scaleWidth, scaleHeight) // chosing the "max" to avoid having empty black space inside the crop frame
+        scrollView.minimumZoomScale = minScale
+        scrollView.maximumZoomScale = 1
+        scrollView.zoomScale = minScale
+
+        centerScrollViewContent()
+    }
+
+    private func centerScrollViewContent() {
+        let scrollViewSize = scrollView.bounds.size
+        let contentSize = scrollView.contentSize
+
+        // Calculate the horizontal and vertical offsets to center the content
+        let horizontalOffset = max(0, (contentSize.width - scrollViewSize.width) / 2)
+        let verticalOffset = max(0, (contentSize.height - scrollViewSize.height) / 2)
+
+        // Set the contentOffset to scroll to the calculated position
+        scrollView.setContentOffset(CGPoint(x: horizontalOffset, y: verticalOffset), animated: false)
+    }
+
+    // MARK: - Action Handlers
+
+    @objc
+    func cropWasPressed() {
+        let screenScale = UIScreen.main.scale
+        let zoomScale = scrollView.zoomScale
+        let oldSize = inputImage.size
+        let resizeRect = CGRect(x: 0, y: 0, width: oldSize.width * zoomScale, height: oldSize.height * zoomScale)
+        let clippingRect = CGRect(
+            x: scrollView.contentOffset.x * screenScale,
+            y: scrollView.contentOffset.y * screenScale,
+            width: scrollView.frame.width * screenScale,
+            height: scrollView.frame.height * screenScale
+        )
+
+        if scrollView.contentOffset.x == 0 &&
+            scrollView.contentOffset.y == 0 &&
+            oldSize.width == clippingRect.width &&
+            oldSize.height == clippingRect.height
+        {
+            onCompletion?(inputImage, false)
+            return
+        }
+
+        // Resize
+        UIGraphicsBeginImageContextWithOptions(resizeRect.size, false, screenScale)
+        inputImage.draw(in: resizeRect)
+        let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        // Crop
+        guard let clippedImageRef = scaledImage?.cgImage?.cropping(to: clippingRect.integral) else {
+            return
+        }
+
+        let clippedImage = UIImage(cgImage: clippedImageRef, scale: screenScale, orientation: .up)
+        onCompletion?(clippedImage, true)
+    }
+
+    @objc
+    func cancelWasPressed() {
+        onCancel?()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        // Update the scrollViewFrame in the overlay view when the layout changes
+        let scrollViewFrameInSuperview = scrollView.convert(scrollView.bounds, to: view)
+        cropFrameView.scrollViewFrame = scrollViewFrameInSuperview
+    }
+
+    // MARK: - UIScrollViewDelegate Methods
+
+    func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+        imageView
+    }
+
+    func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
+        // NO-OP:
+        // Required to enable scrollView Zooming
+    }
+
+    static func wrappedInNavigationViewController(
+        image: UIImage,
+        onCompletion: @escaping ((UIImage, Bool) -> Void),
+        onCancel: @escaping (() -> Void)
+    ) -> UINavigationController {
+        let imageCropController = ImageCropperViewController(image: image)
+        imageCropController.onCancel = onCancel
+        imageCropController.onCompletion = onCompletion
+        let navigationController = UINavigationController(rootViewController: imageCropController)
+        navigationController.modalPresentationStyle = .formSheet
+        return navigationController
+    }
+
+    private enum Localized {
+        static let title = SDKLocalizedString(
+            "ImageCropper.title",
+            value: "Resize & Crop",
+            comment: "Screen title. Resize and crop an image."
+        )
+        static let useButtonTitle = SDKLocalizedString(
+            "ImageCropper.useButtonTitle",
+            value: "Use",
+            comment: "Use the current image"
+        )
+        static let cancelButtonTitle = SDKLocalizedString(
+            "ImageCropper.cropButtonTitle",
+            value: "Cancel",
+            comment: "Cancel the crop"
+        )
+    }
+}

--- a/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
+++ b/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
@@ -162,7 +162,7 @@ class ImageCropperViewController: UIViewController, UIScrollViewDelegate {
         // cropping(to:) can return unequal edges since it adjusts the cropping rect to integral bounds.
         guard let croppedCGImage = image.cgImage?.cropping(to: visibleRect) else { return }
 
-        let croppedUIImage = UIImage(cgImage: croppedCGImage, scale: UIScreen.main.scale, orientation: .up)
+        let croppedUIImage = UIImage(cgImage: croppedCGImage, scale: UITraitCollection.current.displayScale, orientation: .up)
 
         guard let result = croppedUIImage.square(maxLength: Constants.maxOutputImageSizeInPixels) else { return }
         onCompletion?(result, true)
@@ -230,7 +230,7 @@ class ImageCropperViewController: UIViewController, UIScrollViewDelegate {
 extension UIImage {
     // Resize the UIImage fitting within a specified maximum size.
     func square(maxLength maxLengthInPixels: CGFloat) -> UIImage? {
-        let scale = UIScreen.main.scale
+        let scale = UITraitCollection.current.displayScale
         let smallerEgde = min(size.width * scale, size.height * scale)
         let squareEdge = floor(min(maxLengthInPixels, smallerEgde))
         return downsize(to: squareEdge)
@@ -238,7 +238,7 @@ extension UIImage {
 
     // Downsize to targetSquareEdgeInPixels
     private func downsize(to targetSquareEdgeInPixels: CGFloat) -> UIImage? {
-        let scale = UIScreen.main.scale
+        let scale = UITraitCollection.current.displayScale
         let currentSizeInPixels: CGSize = .init(width: size.width * scale, height: size.height * scale)
         // Downsize if this is not a square (to fix the unequal edges produced by cropping(to:) )
         // OR if size is bigger than target.

--- a/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
+++ b/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
@@ -179,6 +179,8 @@ class ImageCropperViewController: UIViewController, UIScrollViewDelegate {
         // Update the scrollViewFrame in the overlay view when the layout changes
         let scrollViewFrameInSuperview = scrollView.convert(scrollView.bounds, to: view)
         cropFrameView.scrollViewFrame = scrollViewFrameInSuperview
+
+        centerScrollViewContent()
     }
 
     // MARK: - UIScrollViewDelegate Methods

--- a/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
+++ b/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
@@ -3,10 +3,8 @@ import UIKit
 
 class ImageCropperViewController: UIViewController, UIScrollViewDelegate {
     private enum Constants {
-        static let overlayColor = UIColor.black.withAlphaComponent(0.2)
         static let backgroundColor = UIColor.black
-        static let scrollViewHorizontalPadding: CGFloat = .DS.Padding.medium
-        static let cropSize: CGFloat = 320
+        static let croperFrameSize: CGFloat = 320
         static let maxOutputImageSizeInPixels: CGFloat = 2048
     }
 
@@ -86,7 +84,7 @@ class ImageCropperViewController: UIViewController, UIScrollViewDelegate {
     }
 
     private func configureConstraints() {
-        let scrollViewWidthConstraint = scrollView.widthAnchor.constraint(equalToConstant: Constants.cropSize)
+        let scrollViewWidthConstraint = scrollView.widthAnchor.constraint(equalToConstant: Constants.croperFrameSize)
         scrollViewWidthConstraint.priority = .defaultLow
 
         NSLayoutConstraint.activate([
@@ -162,7 +160,7 @@ class ImageCropperViewController: UIViewController, UIScrollViewDelegate {
             height: cropFrame.height / zoomScale
         )
 
-        // cropping(to:) can return inequal edges since it adjusts the cropping rect to integral bounds.
+        // cropping(to:) can return unequal edges since it adjusts the cropping rect to integral bounds.
         guard let croppedCGImage = image.cgImage?.cropping(to: visibleRect) else { return }
 
         let croppedUIImage = UIImage(cgImage: croppedCGImage, scale: UIScreen.main.scale, orientation: .up)
@@ -240,7 +238,7 @@ extension UIImage {
     private func downsize(to targetSizeInPixels: CGSize) -> UIImage? {
         let scale = UIScreen.main.scale
         let currentSizeInPixels: CGSize = .init(width: size.width * scale, height: size.height * scale)
-        // Downsize if this is not a square (to fix the inequal edges produced by cropping(to:) )
+        // Downsize if this is not a square (to fix the unequal edges produced by cropping(to:) )
         // OR if size is bigger than target.
         guard currentSizeInPixels.width != currentSizeInPixels.height ||
             targetSizeInPixels.width < currentSizeInPixels.width ||
@@ -257,7 +255,7 @@ extension UIImage {
         return resizedImage
     }
 
-    /// A UIImage instance with corrected orientation.If the instance's orientation is already `.up`, it simply returns the original.
+    /// A UIImage instance with corrected orientation. If the instance's orientation is already `.up`, it simply returns the original.
     fileprivate var correctlyOriented: UIImage? {
         if imageOrientation == .up { return self }
 

--- a/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
+++ b/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
@@ -1,4 +1,3 @@
-import CoreGraphics
 import UIKit
 
 class ImageCropperViewController: UIViewController, UIScrollViewDelegate {

--- a/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
+++ b/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
@@ -7,7 +7,7 @@ class ImageCropperViewController: UIViewController, UIScrollViewDelegate {
         static let backgroundColor = UIColor.black
         static let scrollViewHorizontalPadding: CGFloat = .DS.Padding.medium
         static let cropSize: CGFloat = 320
-        static let maxOutputImageSizeInPixels: CGFloat = 1024
+        static let maxOutputImageSizeInPixels: CGFloat = 2048
     }
 
     // ScrollView for zooming and panning

--- a/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
+++ b/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
@@ -227,25 +227,25 @@ class ImageCropperViewController: UIViewController, UIScrollViewDelegate {
 
 @MainActor
 extension UIImage {
-    fileprivate func square(maxLength maxLengthInPixels: CGFloat) -> UIImage? {
+    // Resize the UIImage fitting within a specified maximum size.
+    func square(maxLength maxLengthInPixels: CGFloat) -> UIImage? {
         let scale = UIScreen.main.scale
         let smallerEgde = min(size.width * scale, size.height * scale)
-        let squareEdge = min(maxLengthInPixels, smallerEgde)
-        return downsize(to: .init(width: squareEdge, height: squareEdge))
+        let squareEdge = floor(min(maxLengthInPixels, smallerEgde))
+        return downsize(to: squareEdge)
     }
 
-    // Resize the UIImage fitting within a specified maximum size.
-    private func downsize(to targetSizeInPixels: CGSize) -> UIImage? {
+    // Downsize to targetSquareEdgeInPixels
+    private func downsize(to targetSquareEdgeInPixels: CGFloat) -> UIImage? {
         let scale = UIScreen.main.scale
         let currentSizeInPixels: CGSize = .init(width: size.width * scale, height: size.height * scale)
         // Downsize if this is not a square (to fix the unequal edges produced by cropping(to:) )
         // OR if size is bigger than target.
         guard currentSizeInPixels.width != currentSizeInPixels.height ||
-            targetSizeInPixels.width < currentSizeInPixels.width ||
-            targetSizeInPixels.height < currentSizeInPixels.height
+            targetSquareEdgeInPixels < currentSizeInPixels.width ||
+            targetSquareEdgeInPixels < currentSizeInPixels.height
         else { return self }
-        let newLenght = floor(min(targetSizeInPixels.width, targetSizeInPixels.height))
-        let newSize = CGSize(width: newLenght, height: newLenght)
+        let newSize = CGSize(width: targetSquareEdgeInPixels, height: targetSquareEdgeInPixels)
         let format = UIGraphicsImageRendererFormat()
         format.scale = 1
         let renderer = UIGraphicsImageRenderer(size: newSize, format: format)

--- a/Tests/GravatarUITests/UIImageAdditionsTests.swift
+++ b/Tests/GravatarUITests/UIImageAdditionsTests.swift
@@ -1,0 +1,53 @@
+@testable import GravatarUI
+import XCTest
+
+final class UIImageAdditionsTests: XCTestCase {
+    @MainActor
+    func testSquareUnequalEdgesSmallerThanMax() throws {
+        let image = try XCTUnwrap(createImage(size: .init(width: 96.1, height: 96.0)))
+        let squareImage = try XCTUnwrap(image.square(maxLength: 1024))
+        let targetLength = min(image.size.width * image.scale, image.size.height * image.scale)
+        XCTAssertEqual(squareImage.size.width, squareImage.size.height)
+        XCTAssertEqual(squareImage.size.width * squareImage.scale, targetLength)
+        XCTAssertEqual(squareImage.size.height * squareImage.scale, targetLength)
+    }
+
+    @MainActor
+    func testSquareUnequalEdgesBiggerThanMax() throws {
+        let maxLength: CGFloat = 50.0
+        let image = try XCTUnwrap(createImage(size: .init(width: 96.1, height: 96.0)))
+        let squareImage = try XCTUnwrap(image.square(maxLength: maxLength))
+        XCTAssertEqual(squareImage.size.width, squareImage.size.height)
+        XCTAssertEqual(squareImage.size.width * squareImage.scale, maxLength)
+        XCTAssertEqual(squareImage.size.height * squareImage.scale, maxLength)
+    }
+
+    @MainActor
+    func testSquareEqualEdgesBiggerThanMax() throws {
+        let maxLength: CGFloat = 50.0
+        let image = try XCTUnwrap(createImage(size: .init(width: 96.0, height: 96.0)))
+        let squareImage = try XCTUnwrap(image.square(maxLength: maxLength))
+        XCTAssertEqual(squareImage.size.width, squareImage.size.height)
+        XCTAssertEqual(squareImage.size.width * squareImage.scale, maxLength)
+        XCTAssertEqual(squareImage.size.height * squareImage.scale, maxLength)
+    }
+
+    @MainActor
+    func testSquareEqualEdgesSmallerThanMax() throws {
+        let image = try XCTUnwrap(createImage(size: .init(width: 96.1, height: 96.1)))
+        let squareImage = try XCTUnwrap(image.square(maxLength: 1024))
+        let targetLength = min(image.size.width * image.scale, image.size.height * image.scale)
+        XCTAssertEqual(squareImage.size.width, squareImage.size.height)
+        XCTAssertEqual(squareImage.size.width * squareImage.scale, targetLength)
+        XCTAssertEqual(squareImage.size.height * squareImage.scale, targetLength)
+    }
+
+    private func createImage(color: UIColor = .blue, size: CGSize) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        color.setFill()
+        UIRectFill(CGRectMake(0, 0, size.width, size.height))
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image
+    }
+}


### PR DESCRIPTION
Closes part of https://github.com/Automattic/Gravatar-SDK-iOS/issues/381 . This is necessary to be able to use PHPickerViewController. 

### Description

Adding an image cropper to be used with PHPhotoPicker since it doesn't give us a cropper out of the box.

- Uses UIScrollView to zoom and traverse the image.
- Generates perfectly square images.
- Downsizes the images to the given limit (2024 x 2024 pixels for now). The max limit can be adjusted once tested with the real upload flow. 

https://github.com/user-attachments/assets/11765ec2-4796-47de-8b3c-faf3dcd17596

### Testing Steps

- UIKit Demo app > Image cropper (Only visible in DEBUG mode since the cropper is not public.)
