### PR TITLE
Properly encode literal `+` characters in `URLQueryItem`s

### DIFF
--- a/Sources/Gravatar/AvatarURL.swift
+++ b/Sources/Gravatar/AvatarURL.swift
@@ -55,7 +55,7 @@ extension URL {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
             return nil
         }
-        components.queryItems = options.queryItems
+        components.setQueryItems(options.queryItems)
 
         if components.queryItems?.isEmpty == true {
             components.queryItems = nil

--- a/Sources/Gravatar/AvatarURL.swift
+++ b/Sources/Gravatar/AvatarURL.swift
@@ -11,12 +11,15 @@ public struct AvatarURL {
     public init?(url: URL, options: AvatarQueryOptions = AvatarQueryOptions()) {
         guard
             Self.isAvatarURL(url),
-            let components = URLComponents(url: url, resolvingAgainstBaseURL: false)?.sanitizingComponents(),
-            let sanitizedURL = components.url,
-            let url = sanitizedURL.addQueryItems(from: options)
+            let sanitizedComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)?.sanitizingComponents(),
+            let sanitizedURL = sanitizedComponents.url
         else {
             return nil
         }
+
+        let components = sanitizedComponents.settingQueryItems(options.queryItems, shouldEncodePlusChar: true)
+
+        guard let url = components.url else { return nil }
 
         self.canonicalURL = sanitizedURL
         self.components = components
@@ -48,21 +51,6 @@ extension AvatarURL: Equatable {
 extension String {
     fileprivate static let scheme = "https"
     fileprivate static let baseURL = "https://gravatar.com/avatar/"
-}
-
-extension URL {
-    fileprivate func addQueryItems(from options: AvatarQueryOptions) -> URL? {
-        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
-            return nil
-        }
-        components.setQueryItems(options.queryItems)
-
-        if components.queryItems?.isEmpty == true {
-            components.queryItems = nil
-        }
-
-        return components.url
-    }
 }
 
 extension URLComponents {

--- a/Sources/Gravatar/URLComponents+Additions.swift
+++ b/Sources/Gravatar/URLComponents+Additions.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension URLComponents {
+    package mutating func setQueryItems(_ queryItems: [URLQueryItem], shouldEncodePlusChar: Bool = true) {
+        self.queryItems = queryItems
+
+        if shouldEncodePlusChar {
+            self.percentEncodedQuery = self.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
+        }
+    }
+}

--- a/Sources/Gravatar/URLComponents+Additions.swift
+++ b/Sources/Gravatar/URLComponents+Additions.swift
@@ -1,11 +1,26 @@
 import Foundation
 
 extension URLComponents {
-    package mutating func setQueryItems(_ queryItems: [URLQueryItem], shouldEncodePlusChar: Bool = true) {
-        self.queryItems = queryItems
+    /// Returns a `URLComponents` object with its `.queryItems` property set
+    /// - Parameters:
+    ///   - queryItems: an array of `URLQueryItem`.  If empty, the `.queryItems` property will be set to `nil`
+    ///   - shouldEncodePlusChar: whether to encode `+` characters.  The default matches the default behavior of `URLComponents`,
+    ///   which does not encode `+` characters.
+    /// - Returns: a `URLComponents` object with its `.queryItems` property set
+    package func settingQueryItems(_ queryItems: [URLQueryItem], shouldEncodePlusChar: Bool = false) -> URLComponents {
+        var copy = self
+
+        guard !queryItems.isEmpty else {
+            copy.queryItems = nil
+            return copy
+        }
+
+        copy.queryItems = queryItems
 
         if shouldEncodePlusChar {
-            self.percentEncodedQuery = self.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
+            copy.percentEncodedQuery = copy.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
         }
+
+        return copy
     }
 }

--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
@@ -74,7 +74,7 @@ public struct OAuthSession: Sendable {
         let params = OAuthURLParams(email: email, secrets: secrets)
         var urlComponents = URLComponents(string: "https://public-api.wordpress.com/oauth2/authorize")!
         do {
-            urlComponents.queryItems = try params.queryItems
+            try urlComponents.setQueryItems(params.queryItems)
             guard let finalURL = urlComponents.url else {
                 assertionFailure(
                     "Error encoding oauth secrets. Check the config in `Configuration.shared.configure(with:oauthSecrets:)` and try again"

--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
@@ -74,7 +74,7 @@ public struct OAuthSession: Sendable {
         let params = OAuthURLParams(email: email, secrets: secrets)
         var urlComponents = URLComponents(string: "https://public-api.wordpress.com/oauth2/authorize")!
         do {
-            try urlComponents.setQueryItems(params.queryItems)
+            urlComponents = try urlComponents.settingQueryItems(params.queryItems, shouldEncodePlusChar: true)
             guard let finalURL = urlComponents.url else {
                 assertionFailure(
                     "Error encoding oauth secrets. Check the config in `Configuration.shared.configure(with:oauthSecrets:)` and try again"

--- a/Tests/GravatarTests/URLComponentsTests.swift
+++ b/Tests/GravatarTests/URLComponentsTests.swift
@@ -14,8 +14,8 @@ final class URLComponentsTests: XCTestCase {
             TestQueryItem(
                 name: "plus_signs",
                 value: "value+with+plus+signs",
-                plusEncodedQueryString: "plus_signs=value%2Bwith%2Bplus%2Bsigns",
-                defaultEncodedQueryString: "plus_signs=value+with+plus+signs"
+                plusEncodedQueryString: "plus_signs=value%2Bwith%2Bplus%2Bsigns", // `+` should be encoded as `%2B`
+                defaultEncodedQueryString: "plus_signs=value+with+plus+signs" // `+` should not be encoded
             ),
             TestQueryItem(
                 name: "non_reserved_chars",
@@ -26,14 +26,14 @@ final class URLComponentsTests: XCTestCase {
             TestQueryItem(
                 name: "reserved_chars",
                 value: "!*'();:@&=+$,/?%#[]",
-                plusEncodedQueryString: "reserved_chars=!*'();:@%26%3D%2B$,/?%25%23%5B%5D",
-                defaultEncodedQueryString: "reserved_chars=!*'();:@%26%3D+$,/?%25%23%5B%5D"
+                plusEncodedQueryString: "reserved_chars=!*'();:@%26%3D%2B$,/?%25%23%5B%5D", // `+` should be encoded as `%2B`
+                defaultEncodedQueryString: "reserved_chars=!*'();:@%26%3D+$,/?%25%23%5B%5D" // `+` should not be encoded
             ),
             TestQueryItem(
                 name: "!*'();:@&=+$,/?%#[] ",
                 value: "name_uses_reserved_chars",
-                plusEncodedQueryString: "!*'();:@%26%3D%2B$,/?%25%23%5B%5D%20=name_uses_reserved_chars",
-                defaultEncodedQueryString: "!*'();:@%26%3D+$,/?%25%23%5B%5D%20=name_uses_reserved_chars"
+                plusEncodedQueryString: "!*'();:@%26%3D%2B$,/?%25%23%5B%5D%20=name_uses_reserved_chars", // `+` should be encoded as `%2B`
+                defaultEncodedQueryString: "!*'();:@%26%3D+$,/?%25%23%5B%5D%20=name_uses_reserved_chars" // `+` should not be encoded
             ),
             TestQueryItem(
                 name: "non_ascii_chars",

--- a/Tests/GravatarTests/URLComponentsTests.swift
+++ b/Tests/GravatarTests/URLComponentsTests.swift
@@ -49,23 +49,32 @@ final class URLComponentsTests: XCTestCase {
 
     func testUrlComponentsEncodesPlusCharInQueryItems() {
         var components = URLComponents(string: Self.urlString)
-        components?.setQueryItems(queryItems, shouldEncodePlusChar: true)
+        components = components?.settingQueryItems(queryItems, shouldEncodePlusChar: true)
 
         XCTAssertEqual(components?.url, PlusCharEncodedQuery.url)
     }
 
     func testUrlComponentsDoesNotEncodePlusCharInQueryItems() {
         var components = URLComponents(string: Self.urlString)
-        components?.setQueryItems(queryItems, shouldEncodePlusChar: false)
+        components = components?.settingQueryItems(queryItems, shouldEncodePlusChar: false)
 
         XCTAssertEqual(components?.url, DefaultEncodedQuery.url)
     }
 
     func testEncodingPlusCharDoesNotAlterQueryItems() {
         var components = URLComponents(string: Self.urlString)
-        components?.setQueryItems(queryItems, shouldEncodePlusChar: true)
+        components = components?.settingQueryItems(queryItems, shouldEncodePlusChar: true)
 
         XCTAssertNotNil(components?.queryItems)
         XCTAssertEqual(components?.queryItems, queryItems)
+    }
+
+    func testAddingEmptyQueryItemsArrayReturnsQueryItemsSetToNil() {
+        let baseComponents = URLComponents(string: Self.urlString)
+        let componentsWithQueryItems = baseComponents?.settingQueryItems(queryItems, shouldEncodePlusChar: true)
+        XCTAssertNotNil(componentsWithQueryItems?.queryItems, "URLComponents object should contain array of URLQueryItems")
+
+        let componentsWithoutQueryItems = componentsWithQueryItems?.settingQueryItems([], shouldEncodePlusChar: true)
+        XCTAssertNil(componentsWithoutQueryItems?.queryItems, "QueryItems should be nil")
     }
 }

--- a/Tests/GravatarTests/URLComponentsTests.swift
+++ b/Tests/GravatarTests/URLComponentsTests.swift
@@ -1,80 +1,118 @@
 import XCTest
 
 final class URLComponentsTests: XCTestCase {
-    private let queryItems = [
-        URLQueryItem(name: "spaces", value: "value with spaces"),
-        URLQueryItem(name: "plus_signs", value: "value+with+plus+signs"),
-        URLQueryItem(
-            name: "non_reserved_chars",
-            value: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"
-        ),
-        URLQueryItem(name: "reserved_chars", value: "!*'();:@&=+$,/?%#[]"),
-        URLQueryItem(name: "!*'();:@&=+$,/?%#[] ", value: "name_uses_reserved_chars"),
-        URLQueryItem(name: "non_ascii_chars", value: "नमस्ते दुनिया 👋🌍 ∑(n=1)^∞ (1/2)^n = 1"),
-    ]
-
     private static let urlString = "https://example.com"
 
-    private enum PlusCharEncodedQuery {
-        static let spacesQuery = "spaces=value%20with%20spaces"
-        static let plusSignQuery = "plus_signs=value%2Bwith%2Bplus%2Bsigns"
-        static let nonReservedChars = "non_reserved_chars=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"
-        static let reservedChars = "reserved_chars=!*'();:@%26%3D%2B$,/?%25%23%5B%5D"
-        static let nameUsesReservedChars = "!*'();:@%26%3D%2B$,/?%25%23%5B%5D%20=name_uses_reserved_chars"
-        static let nonASCIIChars =
-            "non_ascii_chars=%E0%A4%A8%E0%A4%AE%E0%A4%B8%E0%A5%8D%E0%A4%A4%E0%A5%87%20%E0%A4%A6%E0%A5%81%E0%A4%A8%E0%A4%BF%E0%A4%AF%E0%A4%BE%20%F0%9F%91%8B%F0%9F%8C%8D%20%E2%88%91(n%3D1)%5E%E2%88%9E%20(1/2)%5En%20%3D%201"
-
-        static var queryString: String {
-            "\(spacesQuery)&\(plusSignQuery)&\(nonReservedChars)&\(reservedChars)&\(nameUsesReservedChars)&\(nonASCIIChars)"
-        }
-
-        static var url: URL { URL(string: "\(urlString)?\(queryString)")! }
-    }
-
-    private enum DefaultEncodedQuery {
-        static let spacesQuery = "spaces=value%20with%20spaces"
-        static let plusSignQuery = "plus_signs=value+with+plus+signs"
-        static let nonReservedChars = "non_reserved_chars=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"
-        static let reservedChars = "reserved_chars=!*'();:@%26%3D+$,/?%25%23%5B%5D"
-        static let nameUsesReservedChars = "!*'();:@%26%3D+$,/?%25%23%5B%5D%20=name_uses_reserved_chars"
-        static let nonASCIIChars =
-            "non_ascii_chars=%E0%A4%A8%E0%A4%AE%E0%A4%B8%E0%A5%8D%E0%A4%A4%E0%A5%87%20%E0%A4%A6%E0%A5%81%E0%A4%A8%E0%A4%BF%E0%A4%AF%E0%A4%BE%20%F0%9F%91%8B%F0%9F%8C%8D%20%E2%88%91(n%3D1)%5E%E2%88%9E%20(1/2)%5En%20%3D%201"
-
-        static var queryString: String {
-            "\(spacesQuery)&\(plusSignQuery)&\(nonReservedChars)&\(reservedChars)&\(nameUsesReservedChars)&\(nonASCIIChars)"
-        }
-
-        static var url: URL { URL(string: "\(urlString)?\(queryString)")! }
-    }
+    private let testQueryItems: TestQueryItems = .init(
+        [
+            TestQueryItem(
+                name: "spaces",
+                value: "value with spaces",
+                plusEncodedQueryString: "spaces=value%20with%20spaces",
+                defaultEncodedQueryString: "spaces=value%20with%20spaces"
+            ),
+            TestQueryItem(
+                name: "plus_signs",
+                value: "value+with+plus+signs",
+                plusEncodedQueryString: "plus_signs=value%2Bwith%2Bplus%2Bsigns",
+                defaultEncodedQueryString: "plus_signs=value+with+plus+signs"
+            ),
+            TestQueryItem(
+                name: "non_reserved_chars",
+                value: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~",
+                plusEncodedQueryString: "non_reserved_chars=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~",
+                defaultEncodedQueryString: "non_reserved_chars=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"
+            ),
+            TestQueryItem(
+                name: "reserved_chars",
+                value: "!*'();:@&=+$,/?%#[]",
+                plusEncodedQueryString: "reserved_chars=!*'();:@%26%3D%2B$,/?%25%23%5B%5D",
+                defaultEncodedQueryString: "reserved_chars=!*'();:@%26%3D+$,/?%25%23%5B%5D"
+            ),
+            TestQueryItem(
+                name: "!*'();:@&=+$,/?%#[] ",
+                value: "name_uses_reserved_chars",
+                plusEncodedQueryString: "!*'();:@%26%3D%2B$,/?%25%23%5B%5D%20=name_uses_reserved_chars",
+                defaultEncodedQueryString: "!*'();:@%26%3D+$,/?%25%23%5B%5D%20=name_uses_reserved_chars"
+            ),
+            TestQueryItem(
+                name: "non_ascii_chars",
+                value: "नमस्ते दुनिया 👋🌍 ∑(n=1)^∞ (1/2)^n = 1",
+                plusEncodedQueryString: "non_ascii_chars=%E0%A4%A8%E0%A4%AE%E0%A4%B8%E0%A5%8D%E0%A4%A4%E0%A5%87%20%E0%A4%A6%E0%A5%81%E0%A4%A8%E0%A4%BF%E0%A4%AF%E0%A4%BE%20%F0%9F%91%8B%F0%9F%8C%8D%20%E2%88%91(n%3D1)%5E%E2%88%9E%20(1/2)%5En%20%3D%201",
+                defaultEncodedQueryString: "non_ascii_chars=%E0%A4%A8%E0%A4%AE%E0%A4%B8%E0%A5%8D%E0%A4%A4%E0%A5%87%20%E0%A4%A6%E0%A5%81%E0%A4%A8%E0%A4%BF%E0%A4%AF%E0%A4%BE%20%F0%9F%91%8B%F0%9F%8C%8D%20%E2%88%91(n%3D1)%5E%E2%88%9E%20(1/2)%5En%20%3D%201"
+            ),
+        ]
+    )
 
     func testUrlComponentsEncodesPlusCharInQueryItems() {
         var components = URLComponents(string: Self.urlString)
-        components = components?.settingQueryItems(queryItems, shouldEncodePlusChar: true)
+        components = components?.settingQueryItems(testQueryItems.queryItems, shouldEncodePlusChar: true)
 
-        XCTAssertEqual(components?.url, PlusCharEncodedQuery.url)
+        XCTAssertEqual(components?.url, testQueryItems.plusEncodedURL)
     }
 
     func testUrlComponentsDoesNotEncodePlusCharInQueryItems() {
         var components = URLComponents(string: Self.urlString)
-        components = components?.settingQueryItems(queryItems, shouldEncodePlusChar: false)
+        components = components?.settingQueryItems(testQueryItems.queryItems, shouldEncodePlusChar: false)
 
-        XCTAssertEqual(components?.url, DefaultEncodedQuery.url)
+        XCTAssertEqual(components?.url, testQueryItems.defaultEncodedURL)
     }
 
     func testEncodingPlusCharDoesNotAlterQueryItems() {
         var components = URLComponents(string: Self.urlString)
-        components = components?.settingQueryItems(queryItems, shouldEncodePlusChar: true)
+        components = components?.settingQueryItems(testQueryItems.queryItems, shouldEncodePlusChar: true)
 
         XCTAssertNotNil(components?.queryItems)
-        XCTAssertEqual(components?.queryItems, queryItems)
+        XCTAssertEqual(components?.queryItems, testQueryItems.queryItems)
     }
 
     func testAddingEmptyQueryItemsArrayReturnsQueryItemsSetToNil() {
         let baseComponents = URLComponents(string: Self.urlString)
-        let componentsWithQueryItems = baseComponents?.settingQueryItems(queryItems, shouldEncodePlusChar: true)
+        let componentsWithQueryItems = baseComponents?.settingQueryItems(testQueryItems.queryItems, shouldEncodePlusChar: true)
         XCTAssertNotNil(componentsWithQueryItems?.queryItems, "URLComponents object should contain array of URLQueryItems")
 
         let componentsWithoutQueryItems = componentsWithQueryItems?.settingQueryItems([], shouldEncodePlusChar: true)
         XCTAssertNil(componentsWithoutQueryItems?.queryItems, "QueryItems should be nil")
+    }
+}
+
+private struct TestQueryItems {
+    let items: [TestQueryItem]
+
+    var queryItems: [URLQueryItem] {
+        items.map(\.queryItem)
+    }
+
+    var plusEncodedQueryString: String {
+        items.map(\.plusEncodedQueryString).joined(separator: "&")
+    }
+
+    var defaultEncodedQueryString: String {
+        items.map(\.defaultEncodedQueryString).joined(separator: "&")
+    }
+
+    var plusEncodedURL: URL? {
+        URL(string: "\(TestQueryItem.urlString)?\(plusEncodedQueryString)")
+    }
+
+    var defaultEncodedURL: URL? {
+        URL(string: "\(TestQueryItem.urlString)?\(defaultEncodedQueryString)")
+    }
+
+    init(_ items: [TestQueryItem]) {
+        self.items = items
+    }
+}
+
+private struct TestQueryItem {
+    static let urlString = "https://example.com"
+
+    let name: String
+    let value: String
+    let plusEncodedQueryString: String
+    let defaultEncodedQueryString: String
+
+    var queryItem: URLQueryItem {
+        URLQueryItem(name: name, value: value)
     }
 }

--- a/Tests/GravatarTests/URLComponentsTests.swift
+++ b/Tests/GravatarTests/URLComponentsTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+
+final class URLComponentsTests: XCTestCase {
+    private let queryItems = [
+        URLQueryItem(name: "spaces", value: "value with spaces"),
+        URLQueryItem(name: "plus_signs", value: "value+with+plus+signs"),
+        URLQueryItem(
+            name: "non_reserved_chars",
+            value: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"
+        ),
+        URLQueryItem(name: "reserved_chars", value: "!*'();:@&=+$,/?%#[]"),
+        URLQueryItem(name: "!*'();:@&=+$,/?%#[] ", value: "name_uses_reserved_chars"),
+        URLQueryItem(name: "non_ascii_chars", value: "नमस्ते दुनिया 👋🌍 ∑(n=1)^∞ (1/2)^n = 1"),
+    ]
+
+    private static let urlString = "https://example.com"
+
+    private enum PlusCharEncodedQuery {
+        static let spacesQuery = "spaces=value%20with%20spaces"
+        static let plusSignQuery = "plus_signs=value%2Bwith%2Bplus%2Bsigns"
+        static let nonReservedChars = "non_reserved_chars=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"
+        static let reservedChars = "reserved_chars=!*'();:@%26%3D%2B$,/?%25%23%5B%5D"
+        static let nameUsesReservedChars = "!*'();:@%26%3D%2B$,/?%25%23%5B%5D%20=name_uses_reserved_chars"
+        static let nonASCIIChars =
+            "non_ascii_chars=%E0%A4%A8%E0%A4%AE%E0%A4%B8%E0%A5%8D%E0%A4%A4%E0%A5%87%20%E0%A4%A6%E0%A5%81%E0%A4%A8%E0%A4%BF%E0%A4%AF%E0%A4%BE%20%F0%9F%91%8B%F0%9F%8C%8D%20%E2%88%91(n%3D1)%5E%E2%88%9E%20(1/2)%5En%20%3D%201"
+
+        static var queryString: String {
+            "\(spacesQuery)&\(plusSignQuery)&\(nonReservedChars)&\(reservedChars)&\(nameUsesReservedChars)&\(nonASCIIChars)"
+        }
+
+        static var url: URL { URL(string: "\(urlString)?\(queryString)")! }
+    }
+
+    private enum DefaultEncodedQuery {
+        static let spacesQuery = "spaces=value%20with%20spaces"
+        static let plusSignQuery = "plus_signs=value+with+plus+signs"
+        static let nonReservedChars = "non_reserved_chars=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"
+        static let reservedChars = "reserved_chars=!*'();:@%26%3D+$,/?%25%23%5B%5D"
+        static let nameUsesReservedChars = "!*'();:@%26%3D+$,/?%25%23%5B%5D%20=name_uses_reserved_chars"
+        static let nonASCIIChars =
+            "non_ascii_chars=%E0%A4%A8%E0%A4%AE%E0%A4%B8%E0%A5%8D%E0%A4%A4%E0%A5%87%20%E0%A4%A6%E0%A5%81%E0%A4%A8%E0%A4%BF%E0%A4%AF%E0%A4%BE%20%F0%9F%91%8B%F0%9F%8C%8D%20%E2%88%91(n%3D1)%5E%E2%88%9E%20(1/2)%5En%20%3D%201"
+
+        static var queryString: String {
+            "\(spacesQuery)&\(plusSignQuery)&\(nonReservedChars)&\(reservedChars)&\(nameUsesReservedChars)&\(nonASCIIChars)"
+        }
+
+        static var url: URL { URL(string: "\(urlString)?\(queryString)")! }
+    }
+
+    func testUrlComponentsEncodesPlusCharInQueryItems() {
+        var components = URLComponents(string: Self.urlString)
+        components?.setQueryItems(queryItems, shouldEncodePlusChar: true)
+
+        XCTAssertEqual(components?.url, PlusCharEncodedQuery.url)
+    }
+
+    func testUrlComponentsDoesNotEncodePlusCharInQueryItems() {
+        var components = URLComponents(string: Self.urlString)
+        components?.setQueryItems(queryItems, shouldEncodePlusChar: false)
+
+        XCTAssertEqual(components?.url, DefaultEncodedQuery.url)
+    }
+
+    func testEncodingPlusCharDoesNotAlterQueryItems() {
+        var components = URLComponents(string: Self.urlString)
+        components?.setQueryItems(queryItems, shouldEncodePlusChar: true)
+
+        XCTAssertNotNil(components?.queryItems)
+        XCTAssertEqual(components?.queryItems, queryItems)
+    }
+}


### PR DESCRIPTION
Closes #404 

This PR is meant to replace #406.  See that PR for a detailed discussion of why this PR exists.

### Description

This introduces a method for adding `URLQueryItem`'s to a `URLComponents` object, and encapsulates the encoding of `+` literal characters.

This is a simplified approach.  See #406 for a more comprehensive, and more fragile, solution.

### Testing Steps

See #404 for details

- [ ] All unit tests should pass
- [ ] Smoke test avatars
- [ ] Try `Profile editor with oauth` in the `SwiftUI` demo app.  Enter an email address that contains a `+` character, and observe that the auto-populated email address in the OAuth web view contains that character (and not a space).