### PR TITLE
Add logic for re-generating specific models with `notPublicAPI=true`

### DIFF
--- a/Sources/Gravatar/Network/Services/ProfileService.swift
+++ b/Sources/Gravatar/Network/Services/ProfileService.swift
@@ -104,15 +104,7 @@ package struct ProfileIdentity: Decodable, Sendable {
     package let imageUrl: String
 }
 
-public struct Avatar: Decodable, Sendable {
-    private let imageId: String
-    private let imageUrl: String
-
-    package init(id: String, url: String) {
-        self.imageId = id
-        self.imageUrl = url
-    }
-
+extension Avatar {
     public var id: String {
         imageId
     }

--- a/Sources/Gravatar/OpenApi/Generated/Avatar.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Avatar.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// An avatar that the user has already uploaded to their Gravatar account.
+///
+public struct Avatar: Codable, Hashable, Sendable {
+    public enum Rating: String, Codable, CaseIterable, Sendable {
+        case g = "G"
+        case pg = "PG"
+        case r = "R"
+        case x = "X"
+    }
+
+    // THIS IS EDITED
+
+    /// Unique identifier for the image.
+    public private(set) var imageId: String
+    /// Image URL
+    public private(set) var imageUrl: String
+    /// Rating associated with the image.
+    public private(set) var rating: Rating
+    /// Date and time when the image was last updated.
+    public private(set) var updatedDate: Date
+    /// Alternative text description of the image.
+    public private(set) var altText: String
+    /// Whether the image is currently selected as the provided selected email's avatar.
+    public private(set) var selected: Bool?
+
+    @available(*, deprecated, message: "init will become internal on the next release")
+    public init(imageId: String, imageUrl: String, rating: Rating, updatedDate: Date, altText: String, selected: Bool? = nil) {
+        self.imageId = imageId
+        self.imageUrl = imageUrl
+        self.rating = rating
+        self.updatedDate = updatedDate
+        self.altText = altText
+        self.selected = selected
+    }
+
+    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case imageId = "image_id"
+        case imageUrl = "image_url"
+        case rating
+        case updatedDate = "updated_date"
+        case altText = "alt_text"
+        case selected
+    }
+
+    enum InternalCodingKeys: String, CodingKey, CaseIterable {
+        case imageId = "image_id"
+        case imageUrl = "image_url"
+        case rating
+        case updatedDate = "updated_date"
+        case altText = "alt_text"
+        case selected
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        try container.encode(imageId, forKey: .imageId)
+        try container.encode(imageUrl, forKey: .imageUrl)
+        try container.encode(rating, forKey: .rating)
+        try container.encode(updatedDate, forKey: .updatedDate)
+        try container.encode(altText, forKey: .altText)
+        try container.encodeIfPresent(selected, forKey: .selected)
+    }
+
+    // Decodable protocol methods
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
+
+        imageId = try container.decode(String.self, forKey: .imageId)
+        imageUrl = try container.decode(String.self, forKey: .imageUrl)
+        rating = try container.decode(Rating.self, forKey: .rating)
+        updatedDate = try container.decode(Date.self, forKey: .updatedDate)
+        altText = try container.decode(String.self, forKey: .altText)
+        selected = try container.decodeIfPresent(Bool.self, forKey: .selected)
+    }
+}

--- a/Sources/Gravatar/OpenApi/Generated/ModelError.swift
+++ b/Sources/Gravatar/OpenApi/Generated/ModelError.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public struct ModelError: Codable, Hashable, Sendable {
+    /// The error message
+    public private(set) var error: String?
+    /// The error code for the error message
+    public private(set) var code: String?
+
+    @available(*, deprecated, message: "init will become internal on the next release")
+    public init(error: String? = nil, code: String? = nil) {
+        self.error = error
+        self.code = code
+    }
+
+    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case error
+        case code
+    }
+
+    enum InternalCodingKeys: String, CodingKey, CaseIterable {
+        case error
+        case code
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        try container.encodeIfPresent(error, forKey: .error)
+        try container.encodeIfPresent(code, forKey: .code)
+    }
+
+    // Decodable protocol methods
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
+
+        error = try container.decodeIfPresent(String.self, forKey: .error)
+        code = try container.decodeIfPresent(String.self, forKey: .code)
+    }
+}

--- a/Sources/Gravatar/OpenApi/Generated/Profile.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Profile.swift
@@ -27,6 +27,16 @@ public struct Profile: Codable, Hashable, Sendable {
     public private(set) var pronunciation: String
     /// The pronouns the user uses.
     public private(set) var pronouns: String
+    /// The timezone the user has. This is only provided in authenticated API requests.
+    public private(set) var timezone: String?
+    /// The languages the user knows. This is only provided in authenticated API requests.
+    public private(set) var languages: [String]?
+    /// User's first name. This is only provided in authenticated API requests.
+    public private(set) var firstName: String?
+    /// User's last name. This is only provided in authenticated API requests.
+    public private(set) var lastName: String?
+    /// Whether user is an organization. This is only provided in authenticated API requests.
+    public private(set) var isOrganization: Bool?
     /// A list of links the user has added to their profile. This is only provided in authenticated API requests.
     public private(set) var links: [Link]?
     /// A list of interests the user has added to their profile. This is only provided in authenticated API requests.
@@ -87,7 +97,7 @@ public struct Profile: Codable, Hashable, Sendable {
     }
 
     // NOTE: This init is maintained manually.
-    // Avoid deleting this init until the deprecation of is applied.
+    // Avoid deleting this init until the deprecation is applied.
     init(
         hash: String,
         displayName: String,
@@ -101,6 +111,11 @@ public struct Profile: Codable, Hashable, Sendable {
         verifiedAccounts: [VerifiedAccount],
         pronunciation: String,
         pronouns: String,
+        timezone: String? = nil,
+        languages: [String]? = nil,
+        firstName: String? = nil,
+        lastName: String? = nil,
+        isOrganization: Bool? = nil,
         links: [Link]? = nil,
         interests: [Interest]? = nil,
         payments: ProfilePayments? = nil,
@@ -122,6 +137,11 @@ public struct Profile: Codable, Hashable, Sendable {
         self.verifiedAccounts = verifiedAccounts
         self.pronunciation = pronunciation
         self.pronouns = pronouns
+        self.timezone = timezone
+        self.languages = languages
+        self.firstName = firstName
+        self.lastName = lastName
+        self.isOrganization = isOrganization
         self.links = links
         self.interests = interests
         self.payments = payments
@@ -146,7 +166,13 @@ public struct Profile: Codable, Hashable, Sendable {
         case verifiedAccounts = "verified_accounts"
         case pronunciation
         case pronouns
+        case timezone
+        case languages
+        case firstName = "first_name"
+        case lastName = "last_name"
+        case isOrganization = "is_organization"
         case links
+        case interests
         case payments
         case contactInfo = "contact_info"
         case gallery
@@ -168,6 +194,11 @@ public struct Profile: Codable, Hashable, Sendable {
         case verifiedAccounts = "verified_accounts"
         case pronunciation
         case pronouns
+        case timezone
+        case languages
+        case firstName = "first_name"
+        case lastName = "last_name"
+        case isOrganization = "is_organization"
         case links
         case interests
         case payments
@@ -194,6 +225,11 @@ public struct Profile: Codable, Hashable, Sendable {
         try container.encode(verifiedAccounts, forKey: .verifiedAccounts)
         try container.encode(pronunciation, forKey: .pronunciation)
         try container.encode(pronouns, forKey: .pronouns)
+        try container.encodeIfPresent(timezone, forKey: .timezone)
+        try container.encodeIfPresent(languages, forKey: .languages)
+        try container.encodeIfPresent(firstName, forKey: .firstName)
+        try container.encodeIfPresent(lastName, forKey: .lastName)
+        try container.encodeIfPresent(isOrganization, forKey: .isOrganization)
         try container.encodeIfPresent(links, forKey: .links)
         try container.encodeIfPresent(interests, forKey: .interests)
         try container.encodeIfPresent(payments, forKey: .payments)
@@ -221,6 +257,11 @@ public struct Profile: Codable, Hashable, Sendable {
         verifiedAccounts = try container.decode([VerifiedAccount].self, forKey: .verifiedAccounts)
         pronunciation = try container.decode(String.self, forKey: .pronunciation)
         pronouns = try container.decode(String.self, forKey: .pronouns)
+        timezone = try container.decodeIfPresent(String.self, forKey: .timezone)
+        languages = try container.decodeIfPresent([String].self, forKey: .languages)
+        firstName = try container.decodeIfPresent(String.self, forKey: .firstName)
+        lastName = try container.decodeIfPresent(String.self, forKey: .lastName)
+        isOrganization = try container.decodeIfPresent(Bool.self, forKey: .isOrganization)
         links = try container.decodeIfPresent([Link].self, forKey: .links)
         interests = try container.decodeIfPresent([Interest].self, forKey: .interests)
         payments = try container.decodeIfPresent(ProfilePayments.self, forKey: .payments)

--- a/Sources/Gravatar/OpenApi/Generated/SetEmailAvatarRequest.swift
+++ b/Sources/Gravatar/OpenApi/Generated/SetEmailAvatarRequest.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct SetEmailAvatarRequest: Codable, Hashable, Sendable {
+    /// The email SHA256 hash to set the avatar for.
+    public private(set) var emailHash: String
+
+    enum InternalCodingKeys: String, CodingKey, CaseIterable {
+        case emailHash = "email_hash"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        try container.encode(emailHash, forKey: .emailHash)
+    }
+
+    // Decodable protocol methods
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
+
+        emailHash = try container.decode(String.self, forKey: .emailHash)
+    }
+}

--- a/openapi/modelInlineEnumDeclaration.mustache
+++ b/openapi/modelInlineEnumDeclaration.mustache
@@ -1,0 +1,7 @@
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum {{enumName}}: {{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}String{{/isContainer}}, {{#useVapor}}Content, Hashable{{/useVapor}}{{^useVapor}}Codable{{^isContainer}}{{^isString}}{{^isInteger}}{{^isFloat}}{{^isDouble}}, JSONEncodable{{/isDouble}}{{/isFloat}}{{/isInteger}}{{/isString}}{{/isContainer}}{{/useVapor}}, CaseIterable{{#enumUnknownDefaultCase}}{{#isInteger}}, CaseIterableDefaultsLast{{/isInteger}}{{#isFloat}}, CaseIterableDefaultsLast{{/isFloat}}{{#isDouble}}, CaseIterableDefaultsLast{{/isDouble}}{{#isString}}, CaseIterableDefaultsLast{{/isString}}{{#isContainer}}, CaseIterableDefaultsLast{{/isContainer}}{{/enumUnknownDefaultCase}}, Sendable {
+        {{#allowableValues}}
+        {{#enumVars}}
+        case {{{name}}} = {{{value}}}
+        {{/enumVars}}
+        {{/allowableValues}}
+    }

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -12,6 +12,8 @@ servers:
 tags:
   - name: profiles
     description: Operations about user profiles
+  - name: avatars
+    description: Operations about user avatars
 components:
   headers:
     X-RateLimit-Limit:
@@ -29,6 +31,56 @@ components:
       schema:
         type: integer
   schemas:
+    Avatar:
+      type: object
+      description: An avatar that the user has already uploaded to their Gravatar account.
+      required:
+        - image_id
+        - image_url
+        - rating
+        - updated_date
+        - alt_text
+      properties:
+        image_id:
+          type: string
+          description: Unique identifier for the image.
+          examples:
+            - 38be15a98a2bbc40df69172a2a8349
+        image_url:
+          type: string
+          description: Image URL
+          examples:
+            - >-
+              https://gravatar.com/userimage/252014526/d38bele5a98a2bbc40df69172a2a8348.jpeg
+        rating:
+          type: string
+          description: Rating associated with the image.
+          enum:
+            - G
+            - PG
+            - R
+            - X
+        updated_date:
+          type: string
+          format: date-time
+          description: Date and time when the image was last updated.
+          pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
+          examples:
+            - '2021-10-01T12:00:00Z'
+        alt_text:
+          type: string
+          description: Alternative text description of the image.
+          examples:
+            - >-
+              Gravatar's avatar image. Gravatar is a service for providing
+              globally unique avatars.
+        selected:
+          type: boolean
+          description: >-
+            Whether the image is currently selected as the provided selected
+            email's avatar.
+          examples:
+            - true
     Link:
       type: object
       description: A link the user has added to their profile.
@@ -216,6 +268,41 @@ components:
           description: The pronouns the user uses.
           examples:
             - She/They
+        timezone:
+          type: string
+          description: >-
+            The timezone the user has. This is only provided in authenticated
+            API requests.
+          examples:
+            - Europe/Bratislava
+        languages:
+          type: array
+          description: >-
+            The languages the user knows. This is only provided in authenticated
+            API requests.
+          items:
+            type: string
+        first_name:
+          type: string
+          description: >-
+            User's first name. This is only provided in authenticated API
+            requests.
+          examples:
+            - Alex
+        last_name:
+          type: string
+          description: >-
+            User's last name. This is only provided in authenticated API
+            requests.
+          examples:
+            - Morgan
+        is_organization:
+          type: boolean
+          description: >-
+            Whether user is an organization. This is only provided in
+            authenticated API requests.
+          examples:
+            - false
         links:
           type: array
           description: >-
@@ -330,6 +417,15 @@ components:
           pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
           examples:
             - '2021-10-01T12:00:00Z'
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+          description: The error message
+        code:
+          type: string
+          description: The error code for the error message
   securitySchemes:
     apiKey:
       type: http
@@ -337,6 +433,14 @@ components:
       description: >-
         Bearer token to authenticate the request. Full profile information is
         only available in authenticated requests.
+    oauth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://public-api.wordpress.com/oauth2/authorize
+          tokenUrl: https://public-api.wordpress.com/oauth2/token
+          scopes: {}
+      description: WordPress OAuth token to authenticate the request.
 paths:
   /profiles/{profileIdentifier}:
     get:
@@ -354,6 +458,8 @@ paths:
             slug.
           schema:
             type: string
+      security:
+        - apiKey: []
       responses:
         '200':
           description: Successful response
@@ -388,5 +494,109 @@ paths:
               $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           description: Internal server error
-security:
-  - apiKey: []
+  /me/avatars:
+    get:
+      summary: List avatars
+      description: Retrieves a list of available avatars for the authenticated user.
+      tags:
+        - avatars
+      operationId: getAvatars
+      security:
+        - oauth: []
+      parameters:
+        - name: selectedEmail
+          in: query
+          description: >-
+            The email address used to determine which avatar is selected. The
+            'selected' attribute in the avatar list will be set to 'true' for
+            the avatar associated with this email.
+          schema:
+            type: string
+            default: null
+      responses:
+        '200':
+          description: Successful retrieval of avatars
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Avatar'
+    post:
+      summary: Upload new avatar image
+      description: Uploads a new avatar image for the authenticated user.
+      tags:
+        - avatars
+      operationId: uploadAvatar
+      security:
+        - oauth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: string
+                  format: binary
+                  description: The avatar image file
+              required:
+                - data
+      responses:
+        '200':
+          description: Avatar uploaded successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Avatar'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                uncropped_image:
+                  value:
+                    error: Only square images are accepted
+                    code: uncropped_image
+                unsupported_image:
+                  value:
+                    error: Unsupported image type
+                    code: unsupported_image
+  /me/avatars/{imageId}/email:
+    put:
+      summary: Set avatar for the hashed email
+      description: Sets the avatar for the provided email hash.
+      tags:
+        - avatars
+      parameters:
+        - name: imageId
+          in: path
+          description: Image ID of the avatar to set as the provided hashed email avatar.
+          required: true
+          schema:
+            type: string
+      operationId: setEmailAvatar
+      requestBody:
+        description: Avatar selection details
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email_hash:
+                  type: string
+                  description: The email SHA256 hash to set the avatar for.
+                  examples:
+                    - >-
+                      31c5543c1734d25c7206f5fd591525d0295bec6fe84ff82f946a34fe970a1e66
+              required:
+                - email_hash
+      security:
+        - oauth: []
+      responses:
+        '204':
+          description: Avatar successfully set


### PR DESCRIPTION
Closes #

### Description

This updates the Makelfile `generate` command so that it can re-generate a list of models with `internal` access.

This approach will work only for models that are specified in the `components/schemas` of the openapi.yaml.  Some models are not defined there, though.  Responses can also define schemas.  These become "inline" models, and they cannot be specified when calling the `generate` command.

One solution would be adding generic schemas for each of these responses and referencing those schemas.

### Testing Steps

To see it work, go to the `Makefile` and update this line:
```makefile
OPENAPI_GENERATOR_INTERNAL_MODELS = # Colon separated list, no spaces. Leave empty if all models should be public
```

For example:
```
OPENAPI_GENERATOR_INTERNAL_MODELS = Error
```

The run `make generate`.  Notice two things:
1. The name of the `Error` schema becomes `ModelError` in the generated code:
```
[main] WARN  o.o.c.languages.Swift5ClientCodegen - Error (reserved word) cannot be used as model name. Renamed to ModelError
```
2. The generated `ModelError` is indeed `internal`

### Notes
Noti