### PR TITLE
Show upload fail error dialog

### DIFF
--- a/Sources/Gravatar/Network/APIErrorPayload.swift
+++ b/Sources/Gravatar/Network/APIErrorPayload.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Error payload for the REST API calls.
+public protocol APIErrorPayload: Sendable {
+    /// A business error code that identifies this error. (This is not the HTTP status code.)
+    var code: String { get }
+    /// Error message that comes from the REST API.
+    var message: String? { get }
+}
+
+extension ModelError: APIErrorPayload {
+    public var message: String? {
+        error
+    }
+}

--- a/Sources/Gravatar/Network/Errors.swift
+++ b/Sources/Gravatar/Network/Errors.swift
@@ -6,13 +6,10 @@ public enum ResponseErrorReason: Sendable {
     case URLSessionError(error: Error)
 
     /// The response contains an invalid HTTP status code. By default, status code >= 400 is recognized as invalid.
-    case invalidHTTPStatusCode(response: HTTPURLResponse, data: Data)
+    case invalidHTTPStatusCode(response: HTTPURLResponse, errorPayload: APIErrorPayload? = nil)
 
     /// The response is not a `HTTPURLResponse`.
     case invalidURLResponse(response: URLResponse)
-
-    ///
-    case invalidRequest(error: ModelError)
 
     /// An unexpected error has occurred.
     case unexpected(Error)
@@ -33,9 +30,9 @@ public enum ResponseErrorReason: Sendable {
         return nil
     }
 
-    public var errorData: Data? {
-        if case .invalidHTTPStatusCode(_, let data) = self {
-            return data
+    public var errorPayload: APIErrorPayload? {
+        if case .invalidHTTPStatusCode(_, let payload) = self {
+            return payload
         }
         return nil
     }

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -61,18 +61,10 @@ public struct AvatarService: Sendable {
         do {
             let (data, _) = try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: [(name: "Client-Type", value: "ios")])
             return try data.decode()
-
-        } catch ImageUploadError.responseError(reason: let reason) where reason.httpStatusCode == 400 {
-            guard let data = reason.errorData, let error: ModelError = try? data.decode() else {
-                throw ImageUploadError.responseError(reason: reason)
-            }
+        } catch let error as ImageUploadError {
             throw error
-        } catch let error as DecodingError {
-            throw ImageUploadError.responseError(reason: .unexpected(error))
         } catch {
-            throw error
+            throw ImageUploadError.responseError(reason: .unexpected(error))
         }
     }
 }
-
-extension ModelError: Error {}

--- a/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
+++ b/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
@@ -65,13 +65,8 @@ extension HTTPClientError {
             return .URLSessionError(error: error)
         case .invalidHTTPStatusCodeError(let response, let data):
             if response.statusCode == 400 {
-                do {
-                    let error: ModelError = try data.decode()
-                    return .invalidHTTPStatusCode(response: response, errorPayload: error)
-                } catch {
-                    // if parsing the error fails then return invalidHTTPStatusCode without the payload.
-                    return .invalidHTTPStatusCode(response: response)
-                }
+                let error: ModelError? = try? data.decode()
+                return .invalidHTTPStatusCode(response: response, errorPayload: error)
             } else {
                 return .invalidHTTPStatusCode(response: response)
             }

--- a/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
+++ b/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
@@ -62,11 +62,21 @@ extension HTTPClientError {
     func map() -> ResponseErrorReason {
         switch self {
         case .URLSessionError(let error):
-            .URLSessionError(error: error)
+            return .URLSessionError(error: error)
         case .invalidHTTPStatusCodeError(let response, let data):
-            .invalidHTTPStatusCode(response: response, data: data)
+            if response.statusCode == 400 {
+                do {
+                    let error: ModelError = try data.decode()
+                    return .invalidHTTPStatusCode(response: response, errorPayload: error)
+                } catch {
+                    // if parsing the error fails then return invalidHTTPStatusCode without the payload.
+                    return .invalidHTTPStatusCode(response: response)
+                }
+            } else {
+                return .invalidHTTPStatusCode(response: response)
+            }
         case .invalidURLResponseError(let response):
-            .invalidURLResponse(response: response)
+            return .invalidURLResponse(response: response)
         }
     }
 }

--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -40,8 +40,8 @@
 /* Title of a button that will take you to your Gravatar profile, with an arrow indicating that this action will cause you to leave this view */
 "AvatarPickerProfile.Button.ViewProfile.title" = "View profile →";
 
-/* An message that will appear in a small 'toast' message overlaying the current view */
-"AvatarPickerViewModel.Toast.Error.message" = "Oops, there was an error uploading the image.";
+/* A generic error message to show on an error dialog when the upload fails. */
+"AvatarPickerViewModel.Upload.Error.message" = "Oops, there was an error uploading the image.";
 
 /* Text on a sample Gravatar profile, appearing in the place where a Gravatar profile would display your short biography. */
 "ClaimProfile.Label.AboutMe" = "Tell the world who you are. Your avatar and bio that follows you across the web.";
@@ -70,3 +70,14 @@
 /* An option in a menu that display the user's Photo Library and allow them to choose a photo from it */
 "SystemImagePickerView.Source.PhotoLibrary.title" = "Choose a Photo";
 
+/* The title of the upload error dialog. */
+"AvatarPicker.Upload.Error.title" = "Upload has failed.";
+
+/* The title of the remove button on the upload error dialog. */
+"AvatarPicker.Upload.Error.Remove.title" = "Remove";
+
+/* The title of the retry button on the upload error dialog. */
+"AvatarPicker.Upload.Error.Retry.title" = "Retry";
+
+/* The title of the dismiss button on the upload error dialog. */
+"AvatarPicker.Upload.Error.Dismiss.title" = "Dismiss";

--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -79,5 +79,5 @@
 /* The title of the retry button on the upload error dialog. */
 "AvatarPicker.Upload.Error.Retry.title" = "Retry";
 
-/* The title of the dismiss button on the upload error dialog. */
-"AvatarPicker.Upload.Error.Dismiss.title" = "Dismiss";
+/* The title of the dismiss button on a confirmation dialog. */
+"AvatarPicker.Dismiss.title" = "Dismiss";

--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -71,7 +71,7 @@
 "SystemImagePickerView.Source.PhotoLibrary.title" = "Choose a Photo";
 
 /* The title of the upload error dialog. */
-"AvatarPicker.Upload.Error.title" = "Upload has failed.";
+"AvatarPicker.Upload.Error.title" = "Upload has failed";
 
 /* The title of the remove button on the upload error dialog. */
 "AvatarPicker.Upload.Error.Remove.title" = "Remove";

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarGridModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarGridModel.swift
@@ -60,7 +60,7 @@ class AvatarGridModel: ObservableObject {
         }
     }
 
-    func deleteModel(_ avatar: AvatarImageModel) {
-        avatars.removeAll { $0 == avatar }
+    func deleteModel(_ id: String) {
+        avatars.removeAll { $0.id == id }
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarImageModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarImageModel.swift
@@ -7,11 +7,10 @@ struct AvatarImageModel: Hashable, Identifiable, Sendable {
         case local(image: UIImage)
     }
 
-    enum State {
+    enum State: Equatable, Hashable {
         case loaded
         case loading
-        case retry
-        case error
+        case error(supportsRetry: Bool, errorMessage: String)
     }
 
     let id: String

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -340,7 +340,7 @@ private enum AvatarPicker {
     enum Localized {
         static let uploadErrorTitle = SDKLocalizedString(
             "AvatarPicker.Upload.Error.title",
-            value: "Upload has failed.",
+            value: "Upload has failed",
             comment: "The title of the upload error dialog."
         )
         static let removeButtonTitle = SDKLocalizedString(

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -354,9 +354,9 @@ private enum AvatarPicker {
             comment: "The title of the retry button on the upload error dialog."
         )
         static let dismissButtonTitle = SDKLocalizedString(
-            "AvatarPicker.Upload.Error.Dismiss.title",
+            "AvatarPicker.Dismiss.title",
             value: "Dismiss",
-            comment: "The title of the dismiss button on the upload error dialog."
+            comment: "The title of the dismiss button on a confirmation dialog."
         )
         static let buttonUploadImage = SDKLocalizedString(
             "AvatarPicker.ContentLoading.Success.ctaButtonTitle",

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -13,6 +13,8 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
     @State private var safariURL: URL?
     @Environment(\.verticalSizeClass) var verticalSizeClass
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @State private var uploadError: FailedUploadInfo?
+    @State private var isUploadErrorDialogPresented: Bool = false
     var customImageEditor: ImageEditorBlock<ImageEditor>?
     var tokenErrorHandler: (() -> Void)?
 
@@ -38,6 +40,28 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
                 }
                 .task {
                     model.refresh()
+                }
+                .confirmationDialog(
+                    Localized.uploadErrorTitle,
+                    isPresented: $isUploadErrorDialogPresented,
+                    titleVisibility: .visible,
+                    presenting: uploadError
+                ) { error in
+                    Button(role: .destructive) {
+                        deleteFailedUpload(error.avatarLocalID)
+                    } label: {
+                        Label(Localized.removeButtonTitle, systemImage: "trash")
+                    }
+                    if error.supportsRetry {
+                        Button {
+                            retryUpload(error.avatarLocalID)
+                        } label: {
+                            Label(Localized.retryButtonTitle, systemImage: "arrow.clockwise")
+                        }
+                    }
+                    Button(Localized.dismissButtonTitle, role: .cancel) {}
+                } message: { error in
+                    Text(error.errorMessage)
                 }
             }
 
@@ -180,15 +204,15 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
         }
     }
 
-    private func retryUpload(_ avatar: AvatarImageModel) {
+    private func retryUpload(_ id: String) {
         Task {
-            await model.retryUpload(of: avatar.id)
+            await model.retryUpload(of: id)
         }
     }
 
-    private func deleteFailedUpload(_ avatar: AvatarImageModel) {
+    private func deleteFailedUpload(_ id: String) {
         withAnimation {
-            model.deleteFailed(avatar)
+            model.deleteFailed(id)
         }
     }
 
@@ -206,11 +230,9 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
                 onImagePickerDidPickImage: { image in
                     uploadImage(image)
                 },
-                onRetryUpload: { avatar in
-                    retryUpload(avatar)
-                },
-                onDeleteFailed: { avatar in
-                    deleteFailedUpload(avatar)
+                onFailedUploadTapped: { failedUploadInfo in
+                    uploadError = failedUploadInfo
+                    isUploadErrorDialogPresented = true
                 }
             )
             .padding(.horizontal, Constants.horizontalPadding)
@@ -221,11 +243,9 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
                 onAvatarTap: { avatar in
                     model.selectAvatar(with: avatar.id)
                 },
-                onRetryUpload: { avatar in
-                    retryUpload(avatar)
-                },
-                onDeleteFailed: { avatar in
-                    deleteFailedUpload(avatar)
+                onFailedUploadTapped: { failedUploadInfo in
+                    uploadError = failedUploadInfo
+                    isUploadErrorDialogPresented = true
                 }
             )
             .padding(.top, .DS.Padding.medium)
@@ -318,6 +338,26 @@ private enum AvatarPicker {
     }
 
     enum Localized {
+        static let uploadErrorTitle = SDKLocalizedString(
+            "AvatarPicker.Upload.Error.title",
+            value: "Upload has failed.",
+            comment: "The title of the upload error dialog."
+        )
+        static let removeButtonTitle = SDKLocalizedString(
+            "AvatarPicker.Upload.Error.Remove.title",
+            value: "Remove",
+            comment: "The title of the remove button on the upload error dialog."
+        )
+        static let retryButtonTitle = SDKLocalizedString(
+            "AvatarPicker.Upload.Error.Retry.title",
+            value: "Retry",
+            comment: "The title of the retry button on the upload error dialog."
+        )
+        static let dismissButtonTitle = SDKLocalizedString(
+            "AvatarPicker.Upload.Error.Dismiss.title",
+            value: "Dismiss",
+            comment: "The title of the dismiss button on the upload error dialog."
+        )
         static let buttonUploadImage = SDKLocalizedString(
             "AvatarPicker.ContentLoading.Success.ctaButtonTitle",
             value: "Upload image",
@@ -454,8 +494,8 @@ private enum AvatarPicker {
             .init(id: "4", source: .remote(url: "https://gravatar.com/userimage/110207384/fbbd335e57862e19267679f19b4f9db8.jpeg?size=256")),
             .init(id: "5", source: .remote(url: "https://gravatar.com/userimage/110207384/96c6950d6d8ce8dd1177a77fe738101e.jpeg?size=256")),
             .init(id: "6", source: .remote(url: "https://gravatar.com/userimage/110207384/4a4f9385b0a6fa5c00342557a098f480.jpeg?size=256")),
-            .init(id: "7", source: .local(image: UIImage()), state: .retry),
-            .init(id: "8", source: .local(image: UIImage()), state: .error),
+            .init(id: "7", source: .local(image: UIImage()), state: .error(supportsRetry: true, errorMessage: "Something went wrong.")),
+            .init(id: "8", source: .local(image: UIImage()), state: .error(supportsRetry: false, errorMessage: "Something went wrong.")),
         ],
         selectedImageID: "5",
         profileModel: PreviewModel()

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -177,7 +177,7 @@ class AvatarPickerViewModel: ObservableObject {
             let newModel = AvatarImageModel(id: avatar.id, source: .remote(url: avatar.url))
             grid.replaceModel(withID: localID, with: newModel)
         } catch ImageUploadError.responseError(reason: let .invalidHTTPStatusCode(response, errorPayload)) where response.statusCode == 400 {
-            // If the status code is 400 then it means we got a validation error about this image and the operation is not retriable.
+            // If the status code is 400 then it means we got a validation error about this image and the operation is not suitable for retrying.
             handleUploadError(
                 imageID: localID,
                 squareImage: squareImage,

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarGrid.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarGrid.swift
@@ -22,8 +22,7 @@ struct AvatarGrid<ImageEditor: ImageEditorView>: View {
     var customImageEditor: ImageEditorBlock<ImageEditor>?
     let onAvatarTap: (AvatarImageModel) -> Void
     let onImagePickerDidPickImage: (UIImage) -> Void
-    let onRetryUpload: (AvatarImageModel) -> Void
-    let onDeleteFailed: (AvatarImageModel) -> Void
+    let onFailedUploadTapped: (FailedUploadInfo) -> Void
 
     var body: some View {
         LazyVGrid(columns: gridItems, spacing: AvatarGridConstants.avatarSpacing) {
@@ -46,8 +45,7 @@ struct AvatarGrid<ImageEditor: ImageEditorView>: View {
                         grid.selectedAvatar?.id == avatar.id
                     },
                     onAvatarTap: onAvatarTap,
-                    onRetryUpload: onRetryUpload,
-                    onDeleteFailed: onDeleteFailed
+                    onFailedUploadTapped: onFailedUploadTapped
                 )
             }
         }
@@ -68,9 +66,7 @@ struct AvatarGrid<ImageEditor: ImageEditorView>: View {
             grid.selectAvatar(withID: avatar.id)
         } onImagePickerDidPickImage: { image in
             grid.append(newAvatarModel(image))
-        } onRetryUpload: { _ in
-            // No op. inside the preview.
-        } onDeleteFailed: { _ in
+        } onFailedUploadTapped: { _ in
             // No op. inside the preview.
         }
         .padding()

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
@@ -1,13 +1,18 @@
 import SwiftUI
 
+struct FailedUploadInfo {
+    let avatarLocalID: String
+    let supportsRetry: Bool
+    let errorMessage: String
+}
+
 struct AvatarPickerAvatarView: View {
     let avatar: AvatarImageModel
     let maxLength: CGFloat
     let minLength: CGFloat
     let shouldSelect: () -> Bool
     let onAvatarTap: (AvatarImageModel) -> Void
-    let onRetryUpload: (AvatarImageModel) -> Void
-    let onDeleteFailed: (AvatarImageModel) -> Void
+    let onFailedUploadTapped: (FailedUploadInfo) -> Void
 
     var body: some View {
         AvatarView(
@@ -33,19 +38,23 @@ struct AvatarPickerAvatarView: View {
             borderWidth: shouldSelect() ? AvatarGridConstants.selectedBorderWidth : 0
         )
         .overlay {
-            if avatar.state == .loading {
+            switch avatar.state {
+            case .loading:
                 DimmingActivityIndicator()
                     .cornerRadius(AvatarGridConstants.avatarCornerRadius)
-            } else if avatar.state == .retry {
-                DimmingRetryButton {
-                    onRetryUpload(avatar)
-                }
-                .cornerRadius(AvatarGridConstants.avatarCornerRadius)
-            } else if avatar.state == .error {
+            case .error(let supportsRetry, let errorMessage):
                 DimmingErrorButton {
-                    onDeleteFailed(avatar)
+                    onFailedUploadTapped(
+                        .init(
+                            avatarLocalID: avatar.id,
+                            supportsRetry: supportsRetry,
+                            errorMessage: errorMessage
+                        )
+                    )
                 }
                 .cornerRadius(AvatarGridConstants.avatarCornerRadius)
+            case .loaded:
+                EmptyView()
             }
         }.onTapGesture {
             onAvatarTap(avatar)
@@ -58,7 +67,6 @@ struct AvatarPickerAvatarView: View {
     return AvatarPickerAvatarView(avatar: avatar, maxLength: AvatarGridConstants.maxAvatarWidth, minLength: AvatarGridConstants.minAvatarWidth) {
         false
     } onAvatarTap: { _ in
-    } onRetryUpload: { _ in
-    } onDeleteFailed: { _ in
+    } onFailedUploadTapped: { _ in
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/DimmingButton.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/DimmingButton.swift
@@ -23,27 +23,17 @@ struct DimmingButton: View {
     }
 }
 
-/// Dims the parent and puts a retry button on it.
-struct DimmingRetryButton: View {
-    let action: () -> Void
-
-    var body: some View {
-        DimmingButton(imageName: "arrow.clockwise", action: action)
-    }
-}
-
-/// Dims the parent and puts a retry button on it.
+/// Dims the parent and puts an exclamation mark on it.
 struct DimmingErrorButton: View {
     let action: () -> Void
 
     var body: some View {
-        DimmingButton(imageName: "xmark", action: action)
+        DimmingButton(imageName: "exclamationmark.triangle.fill", action: action)
     }
 }
 
 #Preview {
     VStack {
-        DimmingRetryButton {}.frame(width: 100, height: 100)
         DimmingErrorButton {}.frame(width: 100, height: 100)
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/HorizontalAvatarGrid.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/HorizontalAvatarGrid.swift
@@ -8,8 +8,7 @@ struct HorizontalAvatarGrid: View {
     @ObservedObject var grid: AvatarGridModel
 
     let onAvatarTap: (AvatarImageModel) -> Void
-    let onRetryUpload: (AvatarImageModel) -> Void
-    let onDeleteFailed: (AvatarImageModel) -> Void
+    let onFailedUploadTapped: (FailedUploadInfo) -> Void
 
     var body: some View {
         ScrollView(.horizontal) {
@@ -23,8 +22,7 @@ struct HorizontalAvatarGrid: View {
                             grid.selectedAvatar?.id == avatar.id
                         },
                         onAvatarTap: onAvatarTap,
-                        onRetryUpload: onRetryUpload,
-                        onDeleteFailed: onDeleteFailed
+                        onFailedUploadTapped: onFailedUploadTapped
                     )
                 }
             }
@@ -48,9 +46,7 @@ struct HorizontalAvatarGrid: View {
 
     return HorizontalAvatarGrid(grid: grid) { avatar in
         grid.selectAvatar(withID: avatar.id)
-    } onRetryUpload: { _ in
-        // No op. Inside the preview.
-    } onDeleteFailed: { _ in
+    } onFailedUploadTapped: { _ in
         // No op. Inside the preview.
     }
 }

--- a/Tests/GravatarUITests/TestImageFetcher.swift
+++ b/Tests/GravatarUITests/TestImageFetcher.swift
@@ -19,7 +19,7 @@ actor TestImageFetcher: ImageDownloader {
             switch result {
             case .fail:
                 let response = HTTPURLResponse(url: url, statusCode: 404, httpVersion: nil, headerFields: nil)!
-                throw ImageFetchingError.responseError(reason: .invalidHTTPStatusCode(response: response, data: "".data(using: .utf8)!))
+                throw ImageFetchingError.responseError(reason: .invalidHTTPStatusCode(response: response))
             case .success:
                 return ImageDownloadResult(image: ImageHelper.testImage, sourceURL: URL(string: url.absoluteString)!)
             }


### PR DESCRIPTION
Closes https://github.com/Automattic/Gravatar-SDK-iOS/issues/373

### Description

Adds upload fail dialog. 

Some errors are not suitable for retrying, so we don't show the retry option for them. These are the HTTP 400 errors for now. We know from REST API specs that these are validation errors about the image. Maybe we should make this assumption for all 4XX errors. I feel like it is better to show the Retry option in a false positive situation than not show it when it is actually needed.

<img width=300 src="https://github.com/user-attachments/assets/146daa6a-10de-4852-a694-b682cf8e0478" />

Others look like this:

<img src="https://github.com/user-attachments/assets/01123c6b-1246-4ac4-9b87-1acaf9940695" width=300/>

### Testing Steps

SwiftUI demo app > Avatar Picker View
- Try for both horizontal and vertical layouts
- Try uploading an image when you are offline.
- Observe: The error dialog appears with "Remove" and "Retry" options.

(It is a bit difficult to generate HTTP 400 errors, i had to comment out some image cropping code to get that not-square error ☝️. )