### PR TITLE
Use Implicit OAuth (token response)

### DIFF
--- a/Sources/GravatarUI/SwiftUI/OAuthSession/AccessToken.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/AccessToken.swift
@@ -1,9 +1,7 @@
 import Foundation
 
 struct AccessToken {
-    let accessToken: String
-    let expiresIn: Int?
-    let tokenType: String?
+    let token: String
 }
 
 extension AccessToken {
@@ -28,13 +26,7 @@ extension AccessToken {
         // Extract required access_token
         guard let accessToken = parameters["access_token"] else { return nil }
 
-        // Extract optional expires_in and token_type
-        let expiresIn = parameters["expires_in"].flatMap { Int($0) }
-        let tokenType = parameters["token_type"]
-
         // Initialize the AccessToken with extracted values
-        self.accessToken = accessToken
-        self.expiresIn = expiresIn
-        self.tokenType = tokenType
+        self.token = accessToken
     }
 }

--- a/Sources/GravatarUI/SwiftUI/OAuthSession/AccessToken.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/AccessToken.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+struct AccessToken {
+    let accessToken: String
+    let expiresIn: Int?
+    let tokenType: String?
+}
+
+extension AccessToken {
+    /// Initialize an AccessToken from a URL Callback
+    /// - Parameter callbackURL: the OAuth2 callback URL
+    init?(from callbackURL: URL) {
+        // Extract the fragment part of the URL
+        guard let fragment = callbackURL.fragment else { return nil }
+
+        // Convert the fragment into a valid query string by replacing `#` with `?`
+        let fragmentAsQuery = "?" + fragment
+
+        // Use URLComponents to parse the fragment as query parameters
+        guard let components = URLComponents(string: fragmentAsQuery),
+              let queryItems = components.queryItems else { return nil }
+
+        // Create a dictionary of query parameters
+        let parameters = queryItems.reduce(into: [String: String]()) { result, item in
+            result[item.name] = item.value
+        }
+
+        // Extract required access_token
+        guard let accessToken = parameters["access_token"] else { return nil }
+
+        // Extract optional expires_in and token_type
+        let expiresIn = parameters["expires_in"].flatMap { Int($0) }
+        let tokenType = parameters["token_type"]
+
+        // Initialize the AccessToken with extracted values
+        self.accessToken = accessToken
+        self.expiresIn = expiresIn
+        self.tokenType = tokenType
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/OAuthSession/AccessToken.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/AccessToken.swift
@@ -1,6 +1,8 @@
 import Foundation
 
+/// A representation of the `access_token` metadata returned from an OAuth2 'Implicit OAuth' authorization response
 struct AccessToken {
+    /// The `access_token`
     let token: String
 }
 

--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
@@ -36,7 +36,7 @@ public struct OAuthSession: Sendable {
         do {
             let url = try oauthURL(with: email, secrets: secrets)
             let callbackURL = try await authenticationSession.authenticate(using: url, callbackURLScheme: secrets.callbackScheme)
-            let token = try await tokenResponse(from: callbackURL).token
+            let token = try tokenResponse(from: callbackURL).token
             try storage.setSecret(token, for: email.rawValue)
             return token
         } catch {
@@ -44,7 +44,7 @@ public struct OAuthSession: Sendable {
         }
     }
 
-    private func tokenResponse(from callbackURL: URL) async throws -> AccessToken {
+    private func tokenResponse(from callbackURL: URL) throws -> AccessToken {
         guard let accessToken = AccessToken(from: callbackURL) else {
             throw OAuthError.couldNotParseAccessCode(callbackURL.absoluteString)
         }

--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
@@ -49,7 +49,7 @@ public struct OAuthSession: Sendable {
             throw OAuthError.couldNotParseAccessCode(callbackURL.absoluteString)
         }
 
-        return accessToken.accessToken
+        return accessToken.token
     }
 
     private func oauthURL(with email: Email, secrets: Configuration.OAuthSecrets) throws -> URL {

--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
@@ -36,7 +36,7 @@ public struct OAuthSession: Sendable {
         do {
             let url = try oauthURL(with: email, secrets: secrets)
             let callbackURL = try await authenticationSession.authenticate(using: url, callbackURLScheme: secrets.callbackScheme)
-            let token = try await getToken(from: callbackURL, secrets: secrets)
+            let token = try await tokenResponse(from: callbackURL).token
             try storage.setSecret(token, for: email.rawValue)
             return token
         } catch {
@@ -44,12 +44,12 @@ public struct OAuthSession: Sendable {
         }
     }
 
-    private func getToken(from callbackURL: URL, secrets: Configuration.OAuthSecrets) async throws -> String {
+    private func tokenResponse(from callbackURL: URL) async throws -> AccessToken {
         guard let accessToken = AccessToken(from: callbackURL) else {
             throw OAuthError.couldNotParseAccessCode(callbackURL.absoluteString)
         }
 
-        return accessToken.token
+        return accessToken
     }
 
     private func oauthURL(with email: Email, secrets: Configuration.OAuthSecrets) throws -> URL {

--- a/Tests/GravatarUITests/AccessTokenTests.swift
+++ b/Tests/GravatarUITests/AccessTokenTests.swift
@@ -4,19 +4,20 @@ import XCTest
 class AccessTokenTests: XCTestCase {
     func testValidAccessTokenWithAllParameters() {
         // Given a valid callback URL with all parameters
-        let url = url(encodedAccessToken: "abc123")
+        let token = "abc123"
+        let url = URL(string: "https://example.com/callback#access_token=\(token)")!
 
         // When initializing AccessToken from the URL
         let accessToken = AccessToken(from: url)
 
         // Then the access token should be parsed correctly
         XCTAssertNotNil(accessToken)
-        XCTAssertEqual(accessToken?.token, "abc123")
+        XCTAssertEqual(accessToken?.token, token)
     }
 
     func testInvalidAccessTokenWithMissingAccessToken() {
         // Given a callback URL missing the access_token
-        let url = url(encodedAccessToken: nil)
+        let url = URL(string: "https://example.com/callback#foo=bar&baz=qux")!
 
         // When initializing AccessToken from the URL
         let accessToken = AccessToken(from: url)
@@ -26,24 +27,19 @@ class AccessTokenTests: XCTestCase {
     }
 
     func testAccessTokenWithSpecialCharacters() {
-        // Given a callback URL with an access_token containing special characters
-        let url = url(encodedAccessToken: "abc%26123")
+        // Given a callback URL with an access_token containing the literal character `&`
+        // and additional fields separated by the special character `&`
+        let token = "abc&123"
+        let encodedToken = "abc%26123"
+        let url = URL(string: "https://example.com/callback#access_token=\(encodedToken)&baz=qux&foo=bar")!
 
         // When initializing AccessToken from the URL
         let accessToken = AccessToken(from: url)
 
         // Then access_token should correctly decode special characters
         XCTAssertNotNil(accessToken)
-        XCTAssertEqual(accessToken?.token, "abc&123") // `%26` should decode to `&`
+        XCTAssertEqual(accessToken?.token, token) // `%26` should decode to `&`
     }
 
-    private func url(encodedAccessToken: String? = nil) -> URL {
-        var urlString = "https://example.com/callback#"
-
-        if let encodedAccessToken {
-            urlString += "access_token=\(encodedAccessToken)"
-        }
-
-        return URL(string: urlString)!
-    }
+    func testUrlGenerator() {}
 }

--- a/Tests/GravatarUITests/AccessTokenTests.swift
+++ b/Tests/GravatarUITests/AccessTokenTests.swift
@@ -4,35 +4,19 @@ import XCTest
 class AccessTokenTests: XCTestCase {
     func testValidAccessTokenWithAllParameters() {
         // Given a valid callback URL with all parameters
-        let url = url(encodedAccessToken: "abc123", encodedExpiresIn: "3600", encodedTokenType: "bearer")
+        let url = url(encodedAccessToken: "abc123")
 
         // When initializing AccessToken from the URL
         let accessToken = AccessToken(from: url)
 
         // Then the access token should be parsed correctly
         XCTAssertNotNil(accessToken)
-        XCTAssertEqual(accessToken?.accessToken, "abc123")
-        XCTAssertEqual(accessToken?.expiresIn, 3600)
-        XCTAssertEqual(accessToken?.tokenType, "bearer")
-    }
-
-    func testValidAccessTokenWithMissingOptionalParameters() {
-        // Given a callback URL with only the access_token
-        let url = url(encodedAccessToken: "abc123")
-
-        // When initializing AccessToken from the URL
-        let accessToken = AccessToken(from: url)
-
-        // Then only access_token should be present, expiresIn and tokenType should be nil
-        XCTAssertNotNil(accessToken)
-        XCTAssertEqual(accessToken?.accessToken, "abc123")
-        XCTAssertNil(accessToken?.expiresIn)
-        XCTAssertNil(accessToken?.tokenType)
+        XCTAssertEqual(accessToken?.token, "abc123")
     }
 
     func testInvalidAccessTokenWithMissingAccessToken() {
         // Given a callback URL missing the access_token
-        let url = url(encodedExpiresIn: "3600", encodedTokenType: "bearer")
+        let url = url(encodedAccessToken: nil)
 
         // When initializing AccessToken from the URL
         let accessToken = AccessToken(from: url)
@@ -41,50 +25,23 @@ class AccessTokenTests: XCTestCase {
         XCTAssertNil(accessToken)
     }
 
-    func testMalformedExpiresInParameter() {
-        // Given a callback URL with a non-numeric expires_in value
-        let url = url(encodedAccessToken: "abc123", encodedExpiresIn: "notANumber", encodedTokenType: "bearer")
-
-        // When initializing AccessToken from the URL
-        let accessToken = AccessToken(from: url)
-
-        // Then accessToken should be valid, but expiresIn should be nil
-        XCTAssertNotNil(accessToken)
-        XCTAssertEqual(accessToken?.accessToken, "abc123")
-        XCTAssertNil(accessToken?.expiresIn) // expires_in should fail to convert to Int and be nil
-        XCTAssertEqual(accessToken?.tokenType, "bearer")
-    }
-
     func testAccessTokenWithSpecialCharacters() {
         // Given a callback URL with an access_token containing special characters
-        let url = url(encodedAccessToken: "abc%26123", encodedExpiresIn: "3600", encodedTokenType: "bearer")
+        let url = url(encodedAccessToken: "abc%26123")
 
         // When initializing AccessToken from the URL
         let accessToken = AccessToken(from: url)
 
         // Then access_token should correctly decode special characters
         XCTAssertNotNil(accessToken)
-        XCTAssertEqual(accessToken?.accessToken, "abc&123") // `%26` should decode to `&`
-        XCTAssertEqual(accessToken?.expiresIn, 3600)
-        XCTAssertEqual(accessToken?.tokenType, "bearer")
+        XCTAssertEqual(accessToken?.token, "abc&123") // `%26` should decode to `&`
     }
 
-    private func url(
-        encodedAccessToken: String? = nil,
-        encodedExpiresIn: String? = nil,
-        encodedTokenType: String? = nil
-    ) -> URL {
+    private func url(encodedAccessToken: String? = nil) -> URL {
         var urlString = "https://example.com/callback#"
 
         if let encodedAccessToken {
             urlString += "access_token=\(encodedAccessToken)"
-        }
-        if let encodedExpiresIn {
-            urlString += "&expires_in=\(encodedExpiresIn)"
-        }
-
-        if let encodedTokenType {
-            urlString += "&token_type=\(encodedTokenType)"
         }
 
         return URL(string: urlString)!

--- a/Tests/GravatarUITests/AccessTokenTests.swift
+++ b/Tests/GravatarUITests/AccessTokenTests.swift
@@ -1,0 +1,92 @@
+@testable import GravatarUI
+import XCTest
+
+class AccessTokenTests: XCTestCase {
+    func testValidAccessTokenWithAllParameters() {
+        // Given a valid callback URL with all parameters
+        let url = url(encodedAccessToken: "abc123", encodedExpiresIn: "3600", encodedTokenType: "bearer")
+
+        // When initializing AccessToken from the URL
+        let accessToken = AccessToken(from: url)
+
+        // Then the access token should be parsed correctly
+        XCTAssertNotNil(accessToken)
+        XCTAssertEqual(accessToken?.accessToken, "abc123")
+        XCTAssertEqual(accessToken?.expiresIn, 3600)
+        XCTAssertEqual(accessToken?.tokenType, "bearer")
+    }
+
+    func testValidAccessTokenWithMissingOptionalParameters() {
+        // Given a callback URL with only the access_token
+        let url = url(encodedAccessToken: "abc123")
+
+        // When initializing AccessToken from the URL
+        let accessToken = AccessToken(from: url)
+
+        // Then only access_token should be present, expiresIn and tokenType should be nil
+        XCTAssertNotNil(accessToken)
+        XCTAssertEqual(accessToken?.accessToken, "abc123")
+        XCTAssertNil(accessToken?.expiresIn)
+        XCTAssertNil(accessToken?.tokenType)
+    }
+
+    func testInvalidAccessTokenWithMissingAccessToken() {
+        // Given a callback URL missing the access_token
+        let url = url(encodedExpiresIn: "3600", encodedTokenType: "bearer")
+
+        // When initializing AccessToken from the URL
+        let accessToken = AccessToken(from: url)
+
+        // Then the initializer should return nil since access_token is required
+        XCTAssertNil(accessToken)
+    }
+
+    func testMalformedExpiresInParameter() {
+        // Given a callback URL with a non-numeric expires_in value
+        let url = url(encodedAccessToken: "abc123", encodedExpiresIn: "notANumber", encodedTokenType: "bearer")
+
+        // When initializing AccessToken from the URL
+        let accessToken = AccessToken(from: url)
+
+        // Then accessToken should be valid, but expiresIn should be nil
+        XCTAssertNotNil(accessToken)
+        XCTAssertEqual(accessToken?.accessToken, "abc123")
+        XCTAssertNil(accessToken?.expiresIn) // expires_in should fail to convert to Int and be nil
+        XCTAssertEqual(accessToken?.tokenType, "bearer")
+    }
+
+    func testAccessTokenWithSpecialCharacters() {
+        // Given a callback URL with an access_token containing special characters
+        let url = url(encodedAccessToken: "abc%26123", encodedExpiresIn: "3600", encodedTokenType: "bearer")
+
+        // When initializing AccessToken from the URL
+        let accessToken = AccessToken(from: url)
+
+        // Then access_token should correctly decode special characters
+        XCTAssertNotNil(accessToken)
+        XCTAssertEqual(accessToken?.accessToken, "abc&123") // `%26` should decode to `&`
+        XCTAssertEqual(accessToken?.expiresIn, 3600)
+        XCTAssertEqual(accessToken?.tokenType, "bearer")
+    }
+
+    private func url(
+        encodedAccessToken: String? = nil,
+        encodedExpiresIn: String? = nil,
+        encodedTokenType: String? = nil
+    ) -> URL {
+        var urlString = "https://example.com/callback#"
+
+        if let encodedAccessToken {
+            urlString += "access_token=\(encodedAccessToken)"
+        }
+        if let encodedExpiresIn {
+            urlString += "&expires_in=\(encodedExpiresIn)"
+        }
+
+        if let encodedTokenType {
+            urlString += "&token_type=\(encodedTokenType)"
+        }
+
+        return URL(string: urlString)!
+    }
+}


### PR DESCRIPTION
Closes #421 

### Description

This swaps the OAuth implementation from "Server Code  (requesting `code` response type) to Implicit OAuth (requesting `token` response type).

The implementation of Implicit OAuth is simpler, as the token is supplied in the URL fragment of the callback from the `authorization` endpoint.

This introduces an internal type called `AccessToken`, mostly for unit testing.  Eventually, we could update the `AccessToken` to include the `Email`, and then encapsulate the keychain operations.

### Testing Steps

- [ ] Test OAuth in the Demo app
   - Run the SwiftUI app
   - Log out if needed
   - Try to log in
   - Check that login succeeds and everything works as before