### PR TITLE
Using PHPicker

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/CameraImagePicker.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/CameraImagePicker.swift
@@ -1,0 +1,51 @@
+import PhotosUI
+import SwiftUI
+
+struct CameraImagePicker: UIViewControllerRepresentable {
+    let onImageSelected: (ImagePickerItem) -> Void
+
+    @State private var pickedImage: ImagePickerItem? {
+        didSet {
+            if let pickedImage {
+                onImageSelected(pickedImage)
+            }
+        }
+    }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let imagePicker = UIImagePickerController()
+        // Forcefully use UIImagePickerController for device camera only
+        imagePicker.sourceType = .camera
+        imagePicker.delegate = context.coordinator
+        // Use custom image cropper
+        imagePicker.allowsEditing = false
+
+        return imagePicker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {
+        // No-op
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        var parent: CameraImagePicker
+
+        init(_ parent: CameraImagePicker) {
+            self.parent = parent
+        }
+
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+            if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+                parent.pickedImage = .init(id: UUID().uuidString, image: image)
+            }
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            picker.dismiss(animated: true)
+        }
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/PhotosImagePicker.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/PhotosImagePicker.swift
@@ -1,0 +1,70 @@
+import PhotosUI
+import SwiftUI
+
+struct PhotosImagePicker: UIViewControllerRepresentable {
+    let onImageSelected: (ImagePickerItem) -> Void
+    let onCancel: () -> Void
+
+    @State private var pickedImage: ImagePickerItem? {
+        didSet {
+            if let pickedImage {
+                onImageSelected(pickedImage)
+            }
+        }
+    }
+
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var config = PHPickerConfiguration()
+        config.filter = .images
+        config.selectionLimit = 1
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {
+        // No-op
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    final class Coordinator: NSObject, PHPickerViewControllerDelegate {
+        let parent: PhotosImagePicker
+
+        init(_ parent: PhotosImagePicker) {
+            self.parent = parent
+        }
+
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            guard
+                let result = results.first,
+                result.itemProvider.canLoadObject(ofClass: UIImage.self)
+            else {
+                parent.onCancel()
+                return
+            }
+
+            Task {
+                let image = await result.itemProvider.loadUIImage()
+                let imageItem = ImagePickerItem(id: UUID().uuidString, image: image)
+                parent.pickedImage = imageItem
+            }
+        }
+    }
+}
+
+extension NSItemProvider {
+    fileprivate func loadUIImage() async -> UIImage {
+        await withCheckedContinuation { continuation in
+            loadObject(ofClass: UIImage.self) { itemReading, _ in
+                guard let image = itemReading as? UIImage else {
+                    return
+                }
+
+                continuation.resume(returning: image)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #381 

### Description

Using `PHPickerViewController` instead of `UIImagePickerController` for picking on-device photos.
`UIImagePickerController` is still used for the device camera, and both (camera and device photos) use the custom Image Cropper as photo editor.

### Testing Steps

- Run the SwiftUI demo app.
- Open the Avatar Picker demo screen .
- Present the Avatar Picker.
- Add a new image.
  - Check that both options (`Take photo` and `Choose image`) work as expected.
