### PR TITLE
QE OAuth: Ignore the cancelled error so it doesn't override our current error

### DIFF
--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
@@ -80,7 +80,7 @@ enum OAuthError: Error {
     case notConfigured
     case couldNotCreateOAuthURLWithGivenSecrets
     case couldNotParseAccessCode(String)
-    case oauthResponseError(String)
+    case oauthResponseError(String, ASWebAuthenticationSessionError.Code?)
     case unknown(Error)
     case couldNotStoreToken(Error)
     case decodingError(Error)
@@ -99,7 +99,7 @@ extension OAuthError {
             return OAuthError.decodingError(error)
         case let error as NSError:
             if error.domain == ASWebAuthenticationSessionErrorDomain {
-                return .oauthResponseError(error.localizedDescription)
+                return .oauthResponseError(error.localizedDescription, ASWebAuthenticationSessionError.Code(rawValue: error.code))
             }
             return .unknown(error)
         default:

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -107,14 +107,16 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
     func performAuthentication() {
         Task {
             isAuthenticating = true
-            oauthError = nil
             if !oauthSession.hasSession(with: email) {
                 do {
                     _ = try await oauthSession.retrieveAccessToken(with: email)
+                    oauthError = nil
+                } catch OAuthError.oauthResponseError(_, let code) where code == .canceledLogin {
+                    // ignore the error if the user has cancelled the operation.
                 } catch let error as OAuthError {
                     oauthError = error
                 } catch {
-                    // No op.
+                    oauthError = nil
                 }
             }
             hasSession = oauthSession.hasSession(with: email)


### PR DESCRIPTION
Closes https://github.com/Automattic/Gravatar-SDK-iOS/issues/431

### Description

We start to detect if the user has cancelled the oauth flow and treat it just like a dismissal of the OAuth flow so we ignore the error and the previous state remains same. 

### Testing Steps

SwiftUI Demo app > Profile editor with OAuth
Follow the steps here https://github.com/Automattic/Gravatar-SDK-iOS/pull/427 to see the wrong email error
Restart the oauth flow but this time tap cancel
Observe: The same wrong email error remains

cc: @hamorillo 