### PR TITLE
Concurrency Improvements in ImageDownloadService

### DIFF
--- a/Demo/Demo/Gravatar-UIKit-Demo/DemoUIImageViewExtensionViewController.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/DemoUIImageViewExtensionViewController.swift
@@ -18,6 +18,7 @@ class DemoUIImageViewExtensionViewController: UIViewController {
         textField.placeholder = "Enter Gravatar email"
         textField.autocapitalizationType = .none
         textField.keyboardType = .emailAddress
+        textField.text = "p8914704@gmail.com"
         return textField
     }()
     
@@ -135,11 +136,12 @@ class DemoUIImageViewExtensionViewController: UIViewController {
 
         present(controller, animated: true)
     }
+    var task: Task<Void, Never>?
 
     @objc private func fetchAvatarButtonHandler() {
         let options = setupOptions()
         let placeholderImage: UIImage? = showPlaceholderSwitchWithLabel.isOn ? UIImage(named: "placeholder") : nil
-        Task {
+        task = Task {
             do {
                 let result = try await avatarImageView.gravatar.setImage(
                     avatarID: .email(emailInputField.text ?? ""),
@@ -150,7 +152,6 @@ class DemoUIImageViewExtensionViewController: UIViewController {
                 print("success!")
                 print("result url: \(result.sourceURL)")
                 print("retrived Image point size: \(result.image.size)")
-                
             } catch {
                 print(error)
             }
@@ -158,9 +159,7 @@ class DemoUIImageViewExtensionViewController: UIViewController {
     }
     
     @objc private func cancelOngoingButtonHandler() {
-        Task {
-            await avatarImageView.gravatar.cancelImageDownload()
-        }
+        task?.cancel()
     }
     
     private func setupOptions() -> [ImageSettingOption] {

--- a/Demo/Demo/Gravatar-UIKit-Demo/DemoUIImageViewExtensionViewController.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/DemoUIImageViewExtensionViewController.swift
@@ -18,7 +18,6 @@ class DemoUIImageViewExtensionViewController: UIViewController {
         textField.placeholder = "Enter Gravatar email"
         textField.autocapitalizationType = .none
         textField.keyboardType = .emailAddress
-        textField.text = "p8914704@gmail.com"
         return textField
     }()
     

--- a/Sources/Gravatar/Network/Services/ImageDownloadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageDownloadService.swift
@@ -4,7 +4,7 @@ import UIKit
 ///
 /// This is the default type which implements ``ImageDownloader``..
 /// Unless specified otherwise, `ImageDownloadService` will use a `URLSession` based `HTTPClient`, and a in-memory image cache.
-public struct ImageDownloadService: ImageDownloader, Sendable {
+public actor ImageDownloadService: ImageDownloader, Sendable {
     private let client: HTTPClient
     let imageCache: ImageCaching
 

--- a/Sources/Gravatar/Network/Services/ImageDownloadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageDownloadService.swift
@@ -83,10 +83,7 @@ public actor ImageDownloadService: ImageDownloader, Sendable {
 
 extension URLRequest {
     fileprivate static func imageRequest(url: URL, forceRefresh: Bool) -> URLRequest {
-        var request = forceRefresh ? URLRequest(url: url, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData) : URLRequest(url: url)
-        if forceRefresh {
-            request.setValue("no-cache, no-store, max-age=0", forHTTPHeaderField: "Cache-Control")
-        }
+        var request = forceRefresh ? URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData) : URLRequest(url: url)
         request.httpShouldHandleCookies = false
         request.addValue("image/*", forHTTPHeaderField: "Accept")
         return request

--- a/Sources/Gravatar/Network/Services/ImageDownloader.swift
+++ b/Sources/Gravatar/Network/Services/ImageDownloader.swift
@@ -14,8 +14,4 @@ public protocol ImageDownloader: Sendable {
         forceRefresh: Bool,
         processingMethod: ImageProcessingMethod
     ) async throws -> ImageDownloadResult
-
-    /// Cancels the download task for the given `URL`.
-    /// - Parameter url: `URL` of the download task.
-    func cancelTask(for url: URL)
 }

--- a/Sources/GravatarUI/GravatarCompatibleUI/UIImageView+Gravatar.swift
+++ b/Sources/GravatarUI/GravatarCompatibleUI/UIImageView+Gravatar.swift
@@ -124,12 +124,6 @@ extension GravatarWrapper where Component: UIImageView {
         }
     }
 
-    public func cancelImageDownload() {
-        if let sourceURL {
-            imageDownloader?.cancelTask(for: sourceURL)
-        }
-    }
-
     /// Downloads the Gravatar profile image and sets it to this UIImageView. Throws ``ImageFetchingComponentError``.
     ///
     /// - Parameters:

--- a/Sources/TestHelpers/TestImageCache.swift
+++ b/Sources/TestHelpers/TestImageCache.swift
@@ -54,4 +54,10 @@ package final class TestImageCache: ImageCaching, @unchecked Sendable {
             cacheMessages.filter { $0.operation == type }.count
         }
     }
+
+    package func messageCount(type: CacheMessageType, forKey key: String) -> Int {
+        accessQueue.sync {
+            cacheMessages.filter { $0.operation == type && $0.key == key }.count
+        }
+    }
 }

--- a/Sources/TestHelpers/TestImageCache.swift
+++ b/Sources/TestHelpers/TestImageCache.swift
@@ -4,28 +4,57 @@ import UIKit
 package class TestImageCache: ImageCaching, @unchecked Sendable {
     let imageCache = ImageCache()
 
+    package typealias CacheMessage = (operation: CacheMessageType, key: String)
+    private var cacheMessages = [CacheMessage]()
+
+    package enum CacheMessageType {
+        case setToNil
+        case inProgress
+        case ready
+        case get
+    }
+
     package private(set) var getImageCallsCount = 0
     package private(set) var setImageCallsCount = 0
     package private(set) var setTaskCallsCount = 0
 
+    // Serial queue to synchronize access to shared mutable state
+    private let accessQueue = DispatchQueue(label: "com.testImageCache.accessQueue")
+
     package init() {}
 
     package func setEntry(_ entry: Gravatar.CacheEntry?, for key: String) {
-        guard let entry else {
-            imageCache.setEntry(nil, for: key)
-            return
+        accessQueue.sync {
+            var message: CacheMessage
+            defer { cacheMessages.append(message) }
+            guard let entry else {
+                imageCache.setEntry(nil, for: key)
+                message = (operation: .setToNil, key: key)
+                return
+            }
+            switch entry {
+            case .inProgress:
+                setTaskCallsCount += 1
+                message = (operation: .inProgress, key: key)
+            case .ready:
+                setImageCallsCount += 1
+                message = (operation: .ready, key: key)
+            }
+            imageCache.setEntry(entry, for: key)
         }
-        switch entry {
-        case .inProgress:
-            setTaskCallsCount += 1
-        case .ready:
-            setImageCallsCount += 1
-        }
-        imageCache.setEntry(entry, for: key)
     }
 
     package func getEntry(with key: String) -> Gravatar.CacheEntry? {
-        getImageCallsCount += 1
-        return imageCache.getEntry(with: key)
+        accessQueue.sync {
+            getImageCallsCount += 1
+            cacheMessages.append(CacheMessage(operation: .get, key: key))
+            return imageCache.getEntry(with: key)
+        }
+    }
+
+    package func messageCount(type: CacheMessageType) -> Int {
+        accessQueue.sync {
+            cacheMessages.filter { $0.operation == type }.count
+        }
     }
 }

--- a/Sources/TestHelpers/TestImageCache.swift
+++ b/Sources/TestHelpers/TestImageCache.swift
@@ -14,9 +14,9 @@ package class TestImageCache: ImageCaching, @unchecked Sendable {
         case get
     }
 
-    package private(set) var getImageCallsCount = 0
-    package private(set) var setImageCallsCount = 0
-    package private(set) var setTaskCallsCount = 0
+    package var getImageCallsCount: Int { messageCount(type: .get) }
+    package var setImageCallsCount: Int { messageCount(type: .ready) }
+    package var setTaskCallsCount: Int { messageCount(type: .inProgress) }
 
     // Serial queue to synchronize access to shared mutable state
     private let accessQueue = DispatchQueue(label: "com.testImageCache.accessQueue")
@@ -34,10 +34,8 @@ package class TestImageCache: ImageCaching, @unchecked Sendable {
             }
             switch entry {
             case .inProgress:
-                setTaskCallsCount += 1
                 message = (operation: .inProgress, key: key)
             case .ready:
-                setImageCallsCount += 1
                 message = (operation: .ready, key: key)
             }
             imageCache.setEntry(entry, for: key)
@@ -46,7 +44,6 @@ package class TestImageCache: ImageCaching, @unchecked Sendable {
 
     package func getEntry(with key: String) -> Gravatar.CacheEntry? {
         accessQueue.sync {
-            getImageCallsCount += 1
             cacheMessages.append(CacheMessage(operation: .get, key: key))
             return imageCache.getEntry(with: key)
         }

--- a/Sources/TestHelpers/TestImageCache.swift
+++ b/Sources/TestHelpers/TestImageCache.swift
@@ -1,7 +1,7 @@
 import Gravatar
 import UIKit
 
-package class TestImageCache: ImageCaching, @unchecked Sendable {
+package final class TestImageCache: ImageCaching, @unchecked Sendable {
     let imageCache = ImageCache()
 
     package typealias CacheMessage = (operation: CacheMessageType, key: String)

--- a/Sources/TestHelpers/URLSessionMock.swift
+++ b/Sources/TestHelpers/URLSessionMock.swift
@@ -11,7 +11,7 @@ package actor URLSessionMock: URLSessionProtocol {
 
     let returnData: Data
     let response: HTTPURLResponse
-    let error: NSError?
+    private(set) var error: NSError?
     private(set) var isCancellable: Bool = false
     private(set) var maxDurationSeconds: Double = 2
     package private(set) var callsCount = 0
@@ -61,6 +61,10 @@ package actor URLSessionMock: URLSessionProtocol {
 
     func update(request: URLRequest) async {
         self.request = request
+    }
+
+    package func update(error: NSError?) async {
+        self.error = error
     }
 
     package func update(isCancellable: Bool) async {

--- a/Tests/GravatarTests/ImageDownloadServiceTests.swift
+++ b/Tests/GravatarTests/ImageDownloadServiceTests.swift
@@ -116,6 +116,44 @@ final class ImageDownloadServiceTests: XCTestCase {
         XCTAssertEqual(request?.url?.absoluteString, "https://gravatar.com/avatar/HASH")
         XCTAssertNotNil(imageResponse.image)
     }
+
+    func testSimultaneousFetchShouldOnlyTriggerOneNetworkRequest() async throws {
+        let imageURL = URL(string: "https://example.com/image.png")!
+
+        let response = HTTPURLResponse.successResponse(with: imageURL)
+
+        let mockImageData = UIImage(systemName: "iphone.gen2")!.pngData()!
+        let sessionMock = URLSessionMock(returnData: mockImageData, response: response)
+        let cache = TestImageCache()
+        let service = imageDownloadService(with: sessionMock, cache: cache)
+
+        let expectation = XCTestExpectation(description: "First image fetch should complete.")
+
+        // When
+        // Start two simultaneous fetches
+        let fetchTask1 = Task { try await service.fetchImage(with: imageURL, forceRefresh: false) }
+        let fetchTask2 = Task { try await service.fetchImage(with: imageURL, forceRefresh: false) }
+
+        // Then
+        let result1 = try await fetchTask1.value
+        let result2 = try await fetchTask2.value
+
+        expectation.fulfill()
+        await fulfillment(of: [expectation], timeout: 0.5)
+
+        // Assert that both fetches return the same image
+        XCTAssertEqual(result1.image.pngData(), mockImageData)
+        XCTAssertEqual(result2.image.pngData(), mockImageData)
+
+        // Assert that the image was returned twice
+        XCTAssertEqual(cache.messageCount(type: .get), 2)
+
+        // Assert that only one fetch set an `.inProgress` CacheEntry
+        XCTAssertEqual(cache.messageCount(type: .inProgress), 1)
+
+        // Assert that only one fetch set an `.ready` CacheEntry
+        XCTAssertEqual(cache.messageCount(type: .ready), 1)
+    }
 }
 
 private func imageDownloadService(with session: URLSessionProtocol, cache: ImageCaching? = nil) -> ImageDownloadService {

--- a/Tests/GravatarTests/ImageDownloadServiceTests.swift
+++ b/Tests/GravatarTests/ImageDownloadServiceTests.swift
@@ -104,6 +104,90 @@ final class ImageDownloadServiceTests: XCTestCase {
         // Assert that only one fetch set an `.ready` CacheEntry
         XCTAssertEqual(cache.messageCount(type: .ready, forKey: imageURL.absoluteString), 1)
     }
+
+    func testSimultaneousFetchShouldOnlyTriggerOneNetworkRequestPerUrl() async throws {
+        let imageURL1 = URL(string: "https://example.com/image1.png")!
+        let imageURL2 = URL(string: "https://example.com/image2.png")!
+
+        let mockImageData = UIImage(systemName: "iphone.gen2")!.pngData()!
+
+        let sessionMock = URLSessionMock(
+            returnData: mockImageData,
+            response: HTTPURLResponse()
+        )
+
+        let cache = TestImageCache()
+        let service = imageDownloadService(with: sessionMock, cache: cache)
+
+        let expectation = XCTestExpectation(description: "Image fetches should complete")
+
+        // When
+        // Start simultaneous fetches
+        let fetchTask1 = Task { try await service.fetchImage(with: imageURL1, forceRefresh: false) }
+        let fetchTask2 = Task { try await service.fetchImage(with: imageURL2, forceRefresh: false) }
+        let fetchTask3 = Task { try await service.fetchImage(with: imageURL1, forceRefresh: false) }
+        let fetchTask4 = Task { try await service.fetchImage(with: imageURL2, forceRefresh: false) }
+        let fetchTask5 = Task { try await service.fetchImage(with: imageURL1, forceRefresh: false) }
+        let fetchTask6 = Task { try await service.fetchImage(with: imageURL2, forceRefresh: false) }
+
+        // Then
+        let result1 = try await fetchTask1.value
+        let result2 = try await fetchTask2.value
+        let result3 = try await fetchTask3.value
+        let result4 = try await fetchTask4.value
+        let result5 = try await fetchTask5.value
+        let result6 = try await fetchTask6.value
+
+        expectation.fulfill()
+        await fulfillment(of: [expectation], timeout: 0.5)
+
+        // Assert that all fetches return the same image
+        XCTAssertEqual(result1.image.pngData(), mockImageData)
+        XCTAssertEqual(result2.image.pngData(), mockImageData)
+        XCTAssertEqual(result3.image.pngData(), mockImageData)
+        XCTAssertEqual(result4.image.pngData(), mockImageData)
+        XCTAssertEqual(result5.image.pngData(), mockImageData)
+        XCTAssertEqual(result6.image.pngData(), mockImageData)
+
+        // Assert that all fetches attempted to read from the cache
+        XCTAssertEqual(
+            cache.messageCount(type: .get),
+            6,
+            "All fetches should have attempted to read from the cache"
+        )
+        XCTAssertEqual(
+            cache.messageCount(type: .get, forKey: imageURL1.absoluteString), 3,
+            "All fetches for '\(imageURL1)' should have attempted to read from the cache"
+        )
+        XCTAssertEqual(
+            cache.messageCount(type: .get, forKey: imageURL2.absoluteString), 3,
+            "All fetches for '\(imageURL2)' should have attempted to read from the cache"
+        )
+
+        // Assert that only one fetch set an `.inProgress` CacheEntry
+        XCTAssertEqual(
+            cache.messageCount(type: .inProgress, forKey: imageURL1.absoluteString),
+            1,
+            "Only one fetch for '\(imageURL1)' should have set an `.inProgress` CacheEntry"
+        )
+        XCTAssertEqual(
+            cache.messageCount(type: .inProgress, forKey: imageURL2.absoluteString),
+            1,
+            "Only one fetch for '\(imageURL2)' should have set an `.inProgress` CacheEntry"
+        )
+
+        // Assert that only one fetch set an `.ready` CacheEntry
+        XCTAssertEqual(
+            cache.messageCount(type: .ready, forKey: imageURL1.absoluteString),
+            1,
+            "Only one fetch for '\(imageURL1)' should have set a `.ready` CacheEntry"
+        )
+        XCTAssertEqual(
+            cache.messageCount(type: .ready, forKey: imageURL2.absoluteString),
+            1,
+            "Only one fetch for '\(imageURL2)' should have set a `.ready` CacheEntry"
+        )
+    }
 }
 
 private func imageDownloadService(with session: URLSessionProtocol, cache: ImageCaching? = nil) -> ImageDownloadService {

--- a/Tests/GravatarTests/ImageDownloadServiceTests.swift
+++ b/Tests/GravatarTests/ImageDownloadServiceTests.swift
@@ -15,46 +15,6 @@ final class ImageDownloadServiceTests: XCTestCase {
         XCTAssertNotNil(imageResponse.image)
     }
 
-    func testImageProcessingError() async throws {
-        let imageURL = try XCTUnwrap(URL(string: "https://gravatar.com/avatar/HASH"))
-        let response = HTTPURLResponse.successResponse(with: imageURL)
-        let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
-        let cache = TestImageCache()
-        let service = imageDownloadService(with: sessionMock, cache: cache)
-
-        do {
-            _ = try await service.fetchImage(with: imageURL, processingMethod: .custom(processor: FailingImageProcessor()))
-            XCTFail()
-        } catch ImageFetchingError.imageProcessorFailed {
-            // success
-        } catch {
-            XCTFail()
-        }
-    }
-
-    func testFetchCatchedImageWithURL() async throws {
-        let imageURL = "https://gravatar.com/avatar/HASH"
-        let response = HTTPURLResponse.successResponse(with: URL(string: imageURL)!)
-        let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
-        let cache = TestImageCache()
-        let service = imageDownloadService(with: sessionMock, cache: cache)
-
-        _ = try await service.fetchImage(with: URL(string: imageURL)!)
-        _ = try await service.fetchImage(with: URL(string: imageURL)!)
-        let imageResponse = try await service.fetchImage(with: URL(string: imageURL)!)
-        let setImageCallsCount = cache.setImageCallsCount
-        let setTaskCallCount = cache.setTaskCallsCount
-        let getImageCallsCount = cache.getImageCallsCount
-        let request = await sessionMock.request
-        let callsCount = await sessionMock.callsCount
-        XCTAssertEqual(setImageCallsCount, 1)
-        XCTAssertEqual(setTaskCallCount, 1)
-        XCTAssertEqual(getImageCallsCount, 3)
-        XCTAssertEqual(callsCount, 1)
-        XCTAssertEqual(request?.url?.absoluteString, "https://gravatar.com/avatar/HASH")
-        XCTAssertNotNil(imageResponse.image)
-    }
-
     func testFetchImageCancel() async throws {
         let imageURL = try XCTUnwrap(URL(string: "https://gravatar.com/avatar/HASH"))
         let response = HTTPURLResponse.successResponse(with: imageURL)
@@ -106,6 +66,46 @@ final class ImageDownloadServiceTests: XCTestCase {
         await sessionMock.update(error: nil)
         let result = try await service.fetchImage(with: imageURL)
         XCTAssertNotNil(result.image)
+    }
+
+    func testImageProcessingError() async throws {
+        let imageURL = try XCTUnwrap(URL(string: "https://gravatar.com/avatar/HASH"))
+        let response = HTTPURLResponse.successResponse(with: imageURL)
+        let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
+        let cache = TestImageCache()
+        let service = imageDownloadService(with: sessionMock, cache: cache)
+
+        do {
+            _ = try await service.fetchImage(with: imageURL, processingMethod: .custom(processor: FailingImageProcessor()))
+            XCTFail()
+        } catch ImageFetchingError.imageProcessorFailed {
+            // success
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func testFetchCatchedImageWithURL() async throws {
+        let imageURL = "https://gravatar.com/avatar/HASH"
+        let response = HTTPURLResponse.successResponse(with: URL(string: imageURL)!)
+        let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
+        let cache = TestImageCache()
+        let service = imageDownloadService(with: sessionMock, cache: cache)
+
+        _ = try await service.fetchImage(with: URL(string: imageURL)!)
+        _ = try await service.fetchImage(with: URL(string: imageURL)!)
+        let imageResponse = try await service.fetchImage(with: URL(string: imageURL)!)
+        let setImageCallsCount = cache.setImageCallsCount
+        let setTaskCallCount = cache.setTaskCallsCount
+        let getImageCallsCount = cache.getImageCallsCount
+        let request = await sessionMock.request
+        let callsCount = await sessionMock.callsCount
+        XCTAssertEqual(setImageCallsCount, 1)
+        XCTAssertEqual(setTaskCallCount, 1)
+        XCTAssertEqual(getImageCallsCount, 3)
+        XCTAssertEqual(callsCount, 1)
+        XCTAssertEqual(request?.url?.absoluteString, "https://gravatar.com/avatar/HASH")
+        XCTAssertNotNil(imageResponse.image)
     }
 
     func testSimultaneousFetchShouldOnlyTriggerOneNetworkRequest() async throws {

--- a/Tests/GravatarTests/ImageDownloadServiceTests.swift
+++ b/Tests/GravatarTests/ImageDownloadServiceTests.swift
@@ -124,8 +124,6 @@ final class ImageDownloadServiceTests: XCTestCase {
         let cache = TestImageCache()
         let service = imageDownloadService(with: sessionMock, cache: cache)
 
-        let expectation = XCTestExpectation(description: "Image fetches should complete")
-
         // When
         // Start simultaneous fetches
         let fetchTask1 = Task { try await service.fetchImage(with: imageURL, forceRefresh: false) }
@@ -140,9 +138,6 @@ final class ImageDownloadServiceTests: XCTestCase {
         let result3 = try await fetchTask3.value
         let result4 = try await fetchTask4.value
         let result5 = try await fetchTask5.value
-
-        expectation.fulfill()
-        await fulfillment(of: [expectation], timeout: 0.5)
 
         // Assert that all fetches return the same image
         XCTAssertEqual(result1.image.pngData(), mockImageData)

--- a/Tests/GravatarTests/ImageDownloadServiceTests.swift
+++ b/Tests/GravatarTests/ImageDownloadServiceTests.swift
@@ -65,6 +65,9 @@ final class ImageDownloadServiceTests: XCTestCase {
             response: HTTPURLResponse.successResponse(with: imageURL)
         )
 
+        // Simulate download tasks that have a longer duration
+        await sessionMock.update(isCancellable: true)
+
         let cache = TestImageCache()
         let service = imageDownloadService(with: sessionMock, cache: cache)
 

--- a/Tests/GravatarTests/ImageDownloadServiceTests.swift
+++ b/Tests/GravatarTests/ImageDownloadServiceTests.swift
@@ -101,7 +101,7 @@ final class ImageDownloadServiceTests: XCTestCase {
 
         await task1.value
 
-        // The task is cancelled, now we retry and it should succeed.
+        // The task has failed, now we retry and it should succeed.
         await sessionMock.update(isCancellable: false)
         await sessionMock.update(error: nil)
         let result = try await service.fetchImage(with: imageURL)

--- a/Tests/GravatarTests/ImageDownloadServiceTests.swift
+++ b/Tests/GravatarTests/ImageDownloadServiceTests.swift
@@ -99,10 +99,10 @@ final class ImageDownloadServiceTests: XCTestCase {
         XCTAssertEqual(cache.messageCount(type: .get), 5)
 
         // Assert that only one fetch set an `.inProgress` CacheEntry
-        XCTAssertEqual(cache.messageCount(type: .inProgress), 1)
+        XCTAssertEqual(cache.messageCount(type: .inProgress, forKey: imageURL.absoluteString), 1)
 
         // Assert that only one fetch set an `.ready` CacheEntry
-        XCTAssertEqual(cache.messageCount(type: .ready), 1)
+        XCTAssertEqual(cache.messageCount(type: .ready, forKey: imageURL.absoluteString), 1)
     }
 }
 


### PR DESCRIPTION
Closes #397 

### Description

This updates `ImageDownloadService` to handle concurrency:
- Makes `ImageDownloadService` an actor
- Removes the ability to cancel a task by URL, since we can have multiple tasks for the same URL
- Addresses a re-entrancy issue
- Introduces unit testing for concurrent cache use
- Improves the `TestImageCache` for testing concurrent image caching

### Testing Steps

- [ ] CI (and new unit tests) should be 🟢 
- [ ] Smoke test image fetching in the Demo app