### PR TITLE
Unit Tests for Canceling Fetches

### DIFF
--- a/Sources/TestHelpers/URLSessionMock.swift
+++ b/Sources/TestHelpers/URLSessionMock.swift
@@ -11,7 +11,7 @@ package actor URLSessionMock: URLSessionProtocol {
 
     let returnData: Data
     let response: HTTPURLResponse
-    let error: NSError?
+    private(set) var error: NSError?
     private(set) var isCancellable: Bool = false
     private(set) var maxDurationSeconds: Double = 2
     package private(set) var callsCount = 0
@@ -61,6 +61,10 @@ package actor URLSessionMock: URLSessionProtocol {
 
     func update(request: URLRequest) async {
         self.request = request
+    }
+
+    package func update(error: NSError?) async {
+        self.error = error
     }
 
     package func update(isCancellable: Bool) async {

--- a/Tests/GravatarTests/ImageDownloadServiceTests.swift
+++ b/Tests/GravatarTests/ImageDownloadServiceTests.swift
@@ -15,46 +15,6 @@ final class ImageDownloadServiceTests: XCTestCase {
         XCTAssertNotNil(imageResponse.image)
     }
 
-    func testImageProcessingError() async throws {
-        let imageURL = try XCTUnwrap(URL(string: "https://gravatar.com/avatar/HASH"))
-        let response = HTTPURLResponse.successResponse(with: imageURL)
-        let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
-        let cache = TestImageCache()
-        let service = imageDownloadService(with: sessionMock, cache: cache)
-
-        do {
-            _ = try await service.fetchImage(with: imageURL, processingMethod: .custom(processor: FailingImageProcessor()))
-            XCTFail()
-        } catch ImageFetchingError.imageProcessorFailed {
-            // success
-        } catch {
-            XCTFail()
-        }
-    }
-
-    func testFetchCatchedImageWithURL() async throws {
-        let imageURL = "https://gravatar.com/avatar/HASH"
-        let response = HTTPURLResponse.successResponse(with: URL(string: imageURL)!)
-        let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
-        let cache = TestImageCache()
-        let service = imageDownloadService(with: sessionMock, cache: cache)
-
-        _ = try await service.fetchImage(with: URL(string: imageURL)!)
-        _ = try await service.fetchImage(with: URL(string: imageURL)!)
-        let imageResponse = try await service.fetchImage(with: URL(string: imageURL)!)
-        let setImageCallsCount = cache.setImageCallsCount
-        let setTaskCallCount = cache.setTaskCallsCount
-        let getImageCallsCount = cache.getImageCallsCount
-        let request = await sessionMock.request
-        let callsCount = await sessionMock.callsCount
-        XCTAssertEqual(setImageCallsCount, 1)
-        XCTAssertEqual(setTaskCallCount, 1)
-        XCTAssertEqual(getImageCallsCount, 3)
-        XCTAssertEqual(callsCount, 1)
-        XCTAssertEqual(request?.url?.absoluteString, "https://gravatar.com/avatar/HASH")
-        XCTAssertNotNil(imageResponse.image)
-    }
-
     func testFetchImageCancel() async throws {
         let imageURL = try XCTUnwrap(URL(string: "https://gravatar.com/avatar/HASH"))
         let response = HTTPURLResponse.successResponse(with: imageURL)
@@ -106,6 +66,46 @@ final class ImageDownloadServiceTests: XCTestCase {
         await sessionMock.update(error: nil)
         let result = try await service.fetchImage(with: imageURL)
         XCTAssertNotNil(result.image)
+    }
+
+    func testImageProcessingError() async throws {
+        let imageURL = try XCTUnwrap(URL(string: "https://gravatar.com/avatar/HASH"))
+        let response = HTTPURLResponse.successResponse(with: imageURL)
+        let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
+        let cache = TestImageCache()
+        let service = imageDownloadService(with: sessionMock, cache: cache)
+
+        do {
+            _ = try await service.fetchImage(with: imageURL, processingMethod: .custom(processor: FailingImageProcessor()))
+            XCTFail()
+        } catch ImageFetchingError.imageProcessorFailed {
+            // success
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func testFetchCatchedImageWithURL() async throws {
+        let imageURL = "https://gravatar.com/avatar/HASH"
+        let response = HTTPURLResponse.successResponse(with: URL(string: imageURL)!)
+        let sessionMock = URLSessionMock(returnData: ImageHelper.testImageData, response: response)
+        let cache = TestImageCache()
+        let service = imageDownloadService(with: sessionMock, cache: cache)
+
+        _ = try await service.fetchImage(with: URL(string: imageURL)!)
+        _ = try await service.fetchImage(with: URL(string: imageURL)!)
+        let imageResponse = try await service.fetchImage(with: URL(string: imageURL)!)
+        let setImageCallsCount = cache.setImageCallsCount
+        let setTaskCallCount = cache.setTaskCallsCount
+        let getImageCallsCount = cache.getImageCallsCount
+        let request = await sessionMock.request
+        let callsCount = await sessionMock.callsCount
+        XCTAssertEqual(setImageCallsCount, 1)
+        XCTAssertEqual(setTaskCallCount, 1)
+        XCTAssertEqual(getImageCallsCount, 3)
+        XCTAssertEqual(callsCount, 1)
+        XCTAssertEqual(request?.url?.absoluteString, "https://gravatar.com/avatar/HASH")
+        XCTAssertNotNil(imageResponse.image)
     }
 
     func testSimultaneousFetchShouldOnlyTriggerOneNetworkRequest() async throws {

--- a/Tests/GravatarTests/ImageDownloadServiceTests.swift
+++ b/Tests/GravatarTests/ImageDownloadServiceTests.swift
@@ -101,7 +101,7 @@ final class ImageDownloadServiceTests: XCTestCase {
 
         await task1.value
 
-        // The task is cancelled, now we retry and it should succeed.
+        // The task has failed, now we retry and it should succeed.
         await sessionMock.update(isCancellable: false)
         await sessionMock.update(error: nil)
         let result = try await service.fetchImage(with: imageURL)


### PR DESCRIPTION
Closes #

### Description

Re-introduces tests for canceling fetches in the ImageDownloadService

### Testing Steps

- CI is 🟢 