### PR TITLE
Image Download: Add cache buster if forceRefresh == true

### DIFF
--- a/Sources/Gravatar/Network/Services/ImageDownloadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageDownloadService.swift
@@ -95,7 +95,15 @@ public struct ImageDownloadService: ImageDownloader, Sendable {
 
 extension URLRequest {
     fileprivate static func imageRequest(url: URL, forceRefresh: Bool) -> URLRequest {
-        var request = forceRefresh ? URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData) : URLRequest(url: url)
+        var request = forceRefresh ? URLRequest(url: url, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData) : URLRequest(url: url)
+        if forceRefresh, let url = request.url, url.isGravatarURL {
+            var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            // Gravatar doesn't support cache control headers. So we add a random query parameter to
+            // bypass the backend cache and get the latest image.
+            // Remove this if Gravatar starts to support cache control headers.
+            urlComponents?.queryItems?.append(.init(name: "_", value: "\(NSDate().timeIntervalSince1970)"))
+            request.url = urlComponents?.url
+        }
         request.httpShouldHandleCookies = false
         request.addValue("image/*", forHTTPHeaderField: "Accept")
         return request


### PR DESCRIPTION
Closes #366 

### Description

Unfortunately Gravatar doesn't support cache-control headers. So i am adding a cache buster query parameter if `forceRefresh == true`. I also updated the cache policy to `.reloadIgnoringLocalAndRemoteCacheData` if `forceRefresh == true`, it doesn't work yet and ignored by the backend. But there's a systems request about it and if the server side starts respecting it, all we need to do will be to remove the cache buster param.

### Testing Steps

UIKit demo app > UIImageViewExtension
Switch on "Ignore Cache"
Change your avatar else where
Tap on "Fetch Avatar" on the UIKit demo app
It should fetch the most up to date avatar
