### PR TITLE
Set "Accept : application/json" header

### DIFF
--- a/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
+++ b/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
@@ -13,7 +13,7 @@ struct URLSessionHTTPClient: HTTPClient {
     init(urlSession: URLSessionProtocol? = nil) {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = [
-            "Accept" : "application/json"
+            "Accept": "application/json",
         ]
         self.urlSession = urlSession ?? URLSession(configuration: configuration)
     }

--- a/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
+++ b/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
@@ -10,8 +10,12 @@ enum HTTPClientError: Error {
 struct URLSessionHTTPClient: HTTPClient {
     private let urlSession: URLSessionProtocol
 
-    init(urlSession: URLSessionProtocol = URLSession(configuration: .default)) {
-        self.urlSession = urlSession
+    init(urlSession: URLSessionProtocol? = nil) {
+        let configuration = URLSessionConfiguration.default
+        configuration.httpAdditionalHeaders = [
+            "Accept" : "application/json"
+        ]
+        self.urlSession = urlSession ?? URLSession(configuration: configuration)
     }
 
     func fetchData(with request: URLRequest) async throws -> (Data, HTTPURLResponse) {


### PR DESCRIPTION
Closes #422 

### Description

Sets the `Accept=application/json` header on the URLSessionConfiguration. This value can be overridden at the URLRequest level so our image download request also works fine. 

### Testing Steps

Check with a tool like proxyman and observe the header.