### PR TITLE
Decrease the max crop size

### DIFF
--- a/Sources/Gravatar/Network/Services/ImageUploadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploadService.swift
@@ -14,7 +14,7 @@ struct ImageUploadService: ImageUploader {
 
     @discardableResult
     func uploadImage(_ image: UIImage, accessToken: String, additionalHTTPHeaders: [HTTPHeaderField]?) async throws -> (data: Data, response: HTTPURLResponse) {
-        guard let data = image.jpegData(compressionQuality: 0.9) else {
+        guard let data = image.jpegData(compressionQuality: 0.8) else {
             throw ImageUploadError.cannotConvertImageIntoData
         }
 

--- a/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
+++ b/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
@@ -4,7 +4,7 @@ class ImageCropperViewController: UIViewController, UIScrollViewDelegate {
     private enum Constants {
         static let backgroundColor = UIColor.black
         static let croperFrameSize: CGFloat = 320
-        static let maxOutputImageSizeInPixels: CGFloat = 1536
+        static let maxOutputImageSizeInPixels: CGFloat = 1280
     }
 
     // ScrollView for zooming and panning

--- a/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
+++ b/Sources/GravatarUI/ImageCropper/ImageCropperViewController.swift
@@ -4,7 +4,7 @@ class ImageCropperViewController: UIViewController, UIScrollViewDelegate {
     private enum Constants {
         static let backgroundColor = UIColor.black
         static let croperFrameSize: CGFloat = 320
-        static let maxOutputImageSizeInPixels: CGFloat = 2048
+        static let maxOutputImageSizeInPixels: CGFloat = 1536
     }
 
     // ScrollView for zooming and panning


### PR DESCRIPTION
Closes https://github.com/Automattic/Gravatar-SDK-iOS/issues/438

### Description

The existing max crop size(2048 x 2048) was selected arbitrarily. Now that i had time to test the uploads, it can take a bit long to upload such image, it seems like real device pictures can be big. I think this new value is better but let me know what you think.

### Testing Steps

You can test the "UIKit demo app > Image cropper" example page(only visible in DEBUG config) to crop an image bigger than (1536 x 1536) and observe that the cropped image is 1536 x 1536 (scale: 1).

You can also try "SwiftUI Demo app > avatar picker" to upload an image and see if the upload time feels better.