### PR TITLE
Add color scheme picker to the SwiftUI demo app

### DIFF
--- a/Demo/Demo/Gravatar-SwiftUI-Demo/DemoAvatarPickerView.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/DemoAvatarPickerView.swift
@@ -10,7 +10,7 @@ struct DemoAvatarPickerView: View {
     // You can make this `true` by default to easily test the picker
     @State private var isPresentingPicker: Bool = false
     @State var enableCustomImageCropper: Bool = false
-    @State private var selectedScheme: ColorScheme? = nil // nil means it will use the system default
+    @State private var selectedScheme: UIUserInterfaceStyle = .unspecified
 
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
@@ -56,7 +56,7 @@ struct DemoAvatarPickerView: View {
             }
             .padding(.horizontal)
         }
-        .preferredColorScheme(selectedScheme)
+        .preferredColorScheme(ColorScheme(selectedScheme))
     }
     
     func customImageEditor() -> ImageEditorBlock<TestImageCropper>? {

--- a/Demo/Demo/Gravatar-SwiftUI-Demo/DemoAvatarPickerView.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/DemoAvatarPickerView.swift
@@ -10,6 +10,7 @@ struct DemoAvatarPickerView: View {
     // You can make this `true` by default to easily test the picker
     @State private var isPresentingPicker: Bool = false
     @State var enableCustomImageCropper: Bool = false
+    @State private var selectedScheme: ColorScheme? = nil // nil means it will use the system default
 
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
@@ -32,7 +33,12 @@ struct DemoAvatarPickerView: View {
                     }
                 }
                 Divider()
+
                 QEContentLayoutPickerRow(contentLayoutOptions: $contentLayoutOptions)
+                Divider()
+
+                QEColorSchemePickerRow(selectedScheme: $selectedScheme)
+                Divider()
 
                 Toggle("Custom image cropper", isOn: $enableCustomImageCropper)
                 Spacer()
@@ -50,6 +56,7 @@ struct DemoAvatarPickerView: View {
             }
             .padding(.horizontal)
         }
+        .preferredColorScheme(selectedScheme)
     }
     
     func customImageEditor() -> ImageEditorBlock<TestImageCropper>? {

--- a/Demo/Demo/Gravatar-SwiftUI-Demo/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/DemoProfileEditorView.swift
@@ -8,7 +8,7 @@ struct DemoProfileEditorView: View {
     // You can make this `true` by default to easily test the picker
     @State private var isPresentingPicker: Bool = false
     @State private var hasSession: Bool = false
-    @State private var selectedScheme: ColorScheme? = nil // nil means it will use the system default
+    @State private var selectedScheme: UIUserInterfaceStyle = .unspecified
     @Environment(\.oauthSession) var oauthSession
 
     var body: some View {
@@ -39,6 +39,7 @@ struct DemoProfileEditorView: View {
                     updateHasSession(with: email)
                 }
             )
+            .preferredColorScheme(ColorScheme(selectedScheme))
             if hasSession {
                 Button("Log out") {
                     oauthSession.deleteSession(with: .init(email))
@@ -54,7 +55,6 @@ struct DemoProfileEditorView: View {
         .onChange(of: email) { _, newValue in
             updateHasSession(with: newValue)
         }
-        .preferredColorScheme(selectedScheme)
     }
 
     func updateHasSession(with email: String) {

--- a/Demo/Demo/Gravatar-SwiftUI-Demo/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/DemoProfileEditorView.swift
@@ -8,6 +8,7 @@ struct DemoProfileEditorView: View {
     // You can make this `true` by default to easily test the picker
     @State private var isPresentingPicker: Bool = false
     @State private var hasSession: Bool = false
+    @State private var selectedScheme: ColorScheme? = nil // nil means it will use the system default
     @Environment(\.oauthSession) var oauthSession
 
     var body: some View {
@@ -18,9 +19,12 @@ struct DemoProfileEditorView: View {
                     .textInputAutocapitalization(.never)
                     .keyboardType(.emailAddress)
                     .disableAutocorrection(true)
-
                 Divider()
+
                 QEContentLayoutPickerRow(contentLayoutOptions: $contentLayoutOptions)
+                Divider()
+
+                QEColorSchemePickerRow(selectedScheme: $selectedScheme)
             }
             .padding(.horizontal)
             Button("Open Profile Editor with OAuth flow") {
@@ -43,12 +47,14 @@ struct DemoProfileEditorView: View {
             }
 
             Spacer()
-        }.onAppear() {
+        }
+        .onAppear() {
             updateHasSession(with: email)
         }
         .onChange(of: email) { _, newValue in
             updateHasSession(with: newValue)
         }
+        .preferredColorScheme(selectedScheme)
     }
 
     func updateHasSession(with email: String) {

--- a/Demo/Demo/Gravatar-SwiftUI-Demo/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/DemoProfileEditorView.swift
@@ -39,7 +39,6 @@ struct DemoProfileEditorView: View {
                     updateHasSession(with: email)
                 }
             )
-            .preferredColorScheme(ColorScheme(selectedScheme))
             if hasSession {
                 Button("Log out") {
                     oauthSession.deleteSession(with: .init(email))
@@ -55,6 +54,7 @@ struct DemoProfileEditorView: View {
         .onChange(of: email) { _, newValue in
             updateHasSession(with: newValue)
         }
+        .preferredColorScheme(ColorScheme(selectedScheme))
     }
 
     func updateHasSession(with email: String) {

--- a/Demo/Demo/Gravatar-SwiftUI-Demo/QEColorSchemePickerRow.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/QEColorSchemePickerRow.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct QEColorSchemePickerRow: View {
+    enum Options: String, CaseIterable, Identifiable {
+        var id: String {
+            rawValue
+        }
+        
+        case light
+        case dark
+        case system
+        
+        var colorScheme: ColorScheme? {
+            switch self {
+            case .light:
+                .light
+            case .dark:
+                .dark
+            case .system:
+                nil
+            }
+        }
+    }
+    
+    @Binding var selectedScheme: ColorScheme?
+    @State private var options: Options = .system
+    
+    var body: some View {
+        HStack {
+            Text("Color Scheme")
+            Spacer()
+            Picker("Color Scheme", selection: $options) {
+                ForEach(Options.allCases) { option in
+                    Text(option.rawValue).tag(option)
+                }
+            }
+            .pickerStyle(MenuPickerStyle())
+            .onChange(of: options) { oldValue, newValue in
+                self.selectedScheme = newValue.colorScheme
+            }
+        }
+
+    }
+}
+
+#Preview {
+    QEColorSchemePickerRow(selectedScheme: .constant(nil))
+}

--- a/Demo/Demo/Gravatar-SwiftUI-Demo/QEColorSchemePickerRow.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/QEColorSchemePickerRow.swift
@@ -10,19 +10,19 @@ struct QEColorSchemePickerRow: View {
         case dark
         case system
         
-        var colorScheme: ColorScheme? {
+        var colorScheme: UIUserInterfaceStyle {
             switch self {
             case .light:
                 .light
             case .dark:
                 .dark
             case .system:
-                nil
+                .unspecified
             }
         }
     }
-    
-    @Binding var selectedScheme: ColorScheme?
+
+    @Binding var selectedScheme: UIUserInterfaceStyle
     @State private var options: Options = .system
     
     var body: some View {
@@ -44,5 +44,5 @@ struct QEColorSchemePickerRow: View {
 }
 
 #Preview {
-    QEColorSchemePickerRow(selectedScheme: .constant(nil))
+    QEColorSchemePickerRow(selectedScheme: .constant(.unspecified))
 }

--- a/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		917DEEC92C7F639F00E43774 /* TestImageCropper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917DEEC82C7F619100E43774 /* TestImageCropper.swift */; };
 		91956A522B6793AF00BF3CF0 /* SwitchWithLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91956A512B6793AF00BF3CF0 /* SwitchWithLabel.swift */; };
 		91956A542B67943A00BF3CF0 /* DemoUIImageViewExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91956A532B67943A00BF3CF0 /* DemoUIImageViewExtensionViewController.swift */; };
+		919C70572CAAF28E0036B03C /* QEColorSchemePickerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919C70562CAAF28E0036B03C /* QEColorSchemePickerRow.swift */; };
 		91B73B372C404F6E00E7D325 /* DemoAvatarPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B73B362C404F6E00E7D325 /* DemoAvatarPickerView.swift */; };
 		91E2FB042BC0276E00265E8E /* DemoProfileViewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E2FB032BC0276E00265E8E /* DemoProfileViewsViewController.swift */; };
 		91F0B3DD2B62815F0025C4F8 /* MainTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F0B3DB2B62815F0025C4F8 /* MainTableViewController.swift */; };
@@ -128,6 +129,7 @@
 		917DEEC82C7F619100E43774 /* TestImageCropper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImageCropper.swift; sourceTree = "<group>"; };
 		91956A512B6793AF00BF3CF0 /* SwitchWithLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchWithLabel.swift; sourceTree = "<group>"; };
 		91956A532B67943A00BF3CF0 /* DemoUIImageViewExtensionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoUIImageViewExtensionViewController.swift; sourceTree = "<group>"; };
+		919C70562CAAF28E0036B03C /* QEColorSchemePickerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QEColorSchemePickerRow.swift; sourceTree = "<group>"; };
 		91B73B362C404F6E00E7D325 /* DemoAvatarPickerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoAvatarPickerView.swift; sourceTree = "<group>"; };
 		91E2FB032BC0276E00265E8E /* DemoProfileViewsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoProfileViewsViewController.swift; sourceTree = "<group>"; };
 		91F0B3DB2B62815F0025C4F8 /* MainTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainTableViewController.swift; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 				3FD478222C51D7E20071B8B9 /* Gravatar-SwiftUI-Demo.Release.xcconfig */,
 				9133DF1A2CA54D1B0028196F /* QELayoutOptions.swift */,
 				9133DF1D2CA54E080028196F /* QEContentLayoutPickerRow.swift */,
+				919C70562CAAF28E0036B03C /* QEColorSchemePickerRow.swift */,
 				917DEEC82C7F619100E43774 /* TestImageCropper.swift */,
 			);
 			path = "Gravatar-SwiftUI-Demo";
@@ -464,6 +467,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9133DF1C2CA54D7A0028196F /* QELayoutOptions.swift in Sources */,
+				919C70572CAAF28E0036B03C /* QEColorSchemePickerRow.swift in Sources */,
 				49C5D6102B5B33E20067C2A8 /* ContentView.swift in Sources */,
 				1E3FA2402C74B8CC002901F2 /* Secrets.swift in Sources */,
 				9146A7AE2C3BD8F000E07C63 /* DemoAvatarView.swift in Sources */,


### PR DESCRIPTION
Closes #

### Description

Just wanted to add a color scheme option to the QE demo pages for easier testing.

### Testing Steps

SwiftUI demo app, these pages now have color scheme options:

- Avatar Picker View
- Profile editor with oauth