### PR TITLE
Adding a configuration for the global quick editor experience

### DIFF
--- a/Demo/Demo/Gravatar-SwiftUI-Demo/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/DemoProfileEditorView.swift
@@ -33,8 +33,7 @@ struct DemoProfileEditorView: View {
             .gravatarQuickEditorSheet(
                 isPresented: $isPresentingPicker,
                 email: email,
-                scope: .avatarPicker,
-                contentLayout: contentLayoutOptions.contentLayout,
+                scope: .avatarPicker(.init(contentLayout: contentLayoutOptions.contentLayout)),
                 onDismiss: {
                     updateHasSession(with: email)
                 }

--- a/Demo/Demo/Gravatar-SwiftUI-Demo/QELayoutOptions.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/QELayoutOptions.swift
@@ -9,7 +9,7 @@ enum QELayoutOptions: String, Identifiable, CaseIterable {
     case verticalExpandablePrioritizeScrolling = "vertical - expandable - prioritize scrolling"
     case horizontal = "horizontal"
     
-    var contentLayout: AvatarPickerContentLayoutWithPresentation {
+    var contentLayout: AvatarPickerContentLayout {
         switch self {
         case .verticalLarge:
                 .vertical(presentationStyle: .large)

--- a/Demo/Demo/Gravatar-UIKit-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/DemoQuickEditorViewController.swift
@@ -88,6 +88,25 @@ final class DemoQuickEditorViewController: UIViewController {
         present(sheet, animated: true)
     }
 
+    lazy var colorSchemeLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "Prefered color scheme:"
+        return label
+    }()
+
+    lazy var schemeToggle: UISegmentedControl = {
+        let control = UISegmentedControl(items: [
+            UIAction.init(title: "System") { _ in self.customColorScheme = .unspecified },
+            UIAction.init(title: "Light") { _ in self.customColorScheme = .light },
+            UIAction.init(title: "Dark") { _ in self.customColorScheme = .dark },
+        ])
+        control.selectedSegmentIndex = 0
+        return control
+    }()
+
+    var customColorScheme: UIUserInterfaceStyle = .unspecified
+
     lazy var logoutButton: UIButton = {
         let button = UIButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -124,7 +143,15 @@ final class DemoQuickEditorViewController: UIViewController {
     }()
 
     lazy var rootStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [emailField, tokenField, layoutButton, logoutButton, showButton])
+        let stackView = UIStackView(arrangedSubviews: [
+            emailField,
+            tokenField,
+            colorSchemeLabel,
+            schemeToggle,
+            layoutButton,
+            logoutButton,
+            showButton
+        ])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
         stackView.spacing = 12
@@ -150,9 +177,11 @@ final class DemoQuickEditorViewController: UIViewController {
         let presenter = QuickEditorPresenter(
             email: Email(email),
             scope: .avatarPicker,
-            avatarPickerConfiguration: AvatarPickerConfiguration(contentLayout: selectedLayout.contentLayout),
-            token: token
-        )
+            configuration: .init(
+                interfaceStyle: customColorScheme,
+                avatarPickerConfiguration: AvatarPickerConfiguration(contentLayout: selectedLayout.contentLayout)
+            ),
+            token: token)
 
         presenter.present(in: self, onDismiss: { [weak self] in
             self?.updateLogoutButton()

--- a/Demo/Demo/Gravatar-UIKit-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/DemoQuickEditorViewController.swift
@@ -176,13 +176,12 @@ final class DemoQuickEditorViewController: UIViewController {
         savedEmail = email
         let presenter = QuickEditorPresenter(
             email: Email(email),
-            scope: .avatarPicker,
+            scope: .avatarPicker(AvatarPickerConfiguration(contentLayout: selectedLayout.contentLayout)),
             configuration: .init(
-                interfaceStyle: customColorScheme,
-                avatarPickerConfiguration: AvatarPickerConfiguration(contentLayout: selectedLayout.contentLayout)
+                interfaceStyle: customColorScheme
             ),
-            token: token)
-
+            token: token
+        )
         presenter.present(in: self, onDismiss: { [weak self] in
             self?.updateLogoutButton()
         })

--- a/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
@@ -2,24 +2,21 @@ import UIKit
 
 public class QuickEditorConfiguration {
     let interfaceStyle: UIUserInterfaceStyle
-    let avatarPickerConfiguration: AvatarPickerConfiguration
 
     static var `default`: QuickEditorConfiguration { .init() }
 
     public init(
-        interfaceStyle: UIUserInterfaceStyle? = nil,
-        avatarPickerConfiguration: AvatarPickerConfiguration? = nil
+        interfaceStyle: UIUserInterfaceStyle? = nil
     ) {
         self.interfaceStyle = interfaceStyle ?? .unspecified
-        self.avatarPickerConfiguration = avatarPickerConfiguration ?? .default
     }
 }
 
 /// Configuration which will be applied to the avatar picker screen.
 public struct AvatarPickerConfiguration: Sendable {
-    let contentLayout: AvatarPickerContentLayoutWithPresentation
+    let contentLayout: AvatarPickerContentLayout
 
-    public init(contentLayout: AvatarPickerContentLayoutWithPresentation) {
+    public init(contentLayout: AvatarPickerContentLayout) {
         self.contentLayout = contentLayout
     }
 

--- a/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
@@ -1,0 +1,29 @@
+import UIKit
+
+public class QuickEditorConfiguration {
+    let interfaceStyle: UIUserInterfaceStyle
+    let avatarPickerConfiguration: AvatarPickerConfiguration
+
+    static var `default`: QuickEditorConfiguration { .init() }
+
+    public init(
+        interfaceStyle: UIUserInterfaceStyle? = nil,
+        avatarPickerConfiguration: AvatarPickerConfiguration? = nil
+    ) {
+        self.interfaceStyle = interfaceStyle ?? .unspecified
+        self.avatarPickerConfiguration = avatarPickerConfiguration ?? .default
+    }
+}
+
+/// Configuration which will be applied to the avatar picker screen.
+public struct AvatarPickerConfiguration: Sendable {
+    let contentLayout: AvatarPickerContentLayoutWithPresentation
+
+    public init(contentLayout: AvatarPickerContentLayoutWithPresentation) {
+        self.contentLayout = contentLayout
+    }
+
+    static let `default` = AvatarPickerConfiguration(
+        contentLayout: .horizontal(presentationStyle: .intrinsicHeight)
+    )
+}

--- a/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
@@ -21,13 +21,16 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
 
     var verticalSizeClass: UserInterfaceSizeClass?
     var sheetHeight: CGFloat = QEModalPresentationConstants.bottomSheetEstimatedHeight
-    var contentLayoutWithPresentation: AvatarPickerContentLayoutWithPresentation {
-        configuration.avatarPickerConfiguration.contentLayout
+    var contentLayoutWithPresentation: AvatarPickerContentLayout {
+        switch scope {
+        case .avatarPicker(let config):
+            config.contentLayout
+        }
     }
 
     private lazy var quickEditor: InnerHeightUIHostingController = .init(rootView: QuickEditor(
         email: email,
-        scope: scope,
+        scope: scope.scopeType,
         token: token,
         isPresented: isPresented,
         customImageEditor: nil as NoCustomEditorBlock?,

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerContentLayout.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerContentLayout.swift
@@ -24,7 +24,7 @@ public enum HorizontalContentPresentationStyle: String, Sendable, Equatable {
 }
 
 /// Content layout to use iOS 16.0 +.
-public enum AvatarPickerContentLayoutWithPresentation: AvatarPickerContentLayoutProviding, Equatable {
+public enum AvatarPickerContentLayout: AvatarPickerContentLayoutProviding, Equatable {
     /// Displays avatars in a vertcally scrolling grid with the given presentation style. See: ``VerticalContentPresentationStyle``
     case vertical(presentationStyle: VerticalContentPresentationStyle = .large)
 
@@ -34,7 +34,7 @@ public enum AvatarPickerContentLayoutWithPresentation: AvatarPickerContentLayout
 
     // MARK: AvatarPickerContentLayoutProviding
 
-    var contentLayout: AvatarPickerContentLayout {
+    var contentLayout: AvatarPickerContentLayoutType {
         switch self {
         case .horizontal:
             .horizontal
@@ -54,8 +54,8 @@ public enum AvatarPickerContentLayoutWithPresentation: AvatarPickerContentLayout
 }
 
 /// Content layout to use pre iOS 16.0 where the system don't offer different presentation styles for SwiftUI.
-/// Use ``AvatarPickerContentLayoutWithPresentation`` for iOS 16.0 +.
-enum AvatarPickerContentLayout: String, CaseIterable, Identifiable, AvatarPickerContentLayoutProviding {
+/// Use ``AvatarPickerContentLayout`` for iOS 16.0 +.
+enum AvatarPickerContentLayoutType: String, CaseIterable, Identifiable, AvatarPickerContentLayoutProviding {
     var id: Self { self }
 
     /// Displays avatars in a vertcally scrolling grid.
@@ -65,11 +65,11 @@ enum AvatarPickerContentLayout: String, CaseIterable, Identifiable, AvatarPicker
 
     // MARK: AvatarPickerContentLayoutProviding
 
-    var contentLayout: AvatarPickerContentLayout { self }
+    var contentLayout: AvatarPickerContentLayoutType { self }
 }
 
-/// Internal type. This is an abstraction over `AvatarPickerContentLayout` and `AvatarPickerContentLayoutWithPresentation`
+/// Internal type. This is an abstraction over `AvatarPickerContentLayoutType` and `AvatarPickerContentLayout`
 /// to use when all we are interested is to find out if the content is horizontial or vertical.
 protocol AvatarPickerContentLayoutProviding: Sendable {
-    var contentLayout: AvatarPickerContentLayout { get }
+    var contentLayout: AvatarPickerContentLayoutType { get }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -17,7 +17,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
     @State private var uploadError: FailedUploadInfo?
     @State private var isUploadErrorDialogPresented: Bool = false
 
-    var contentLayoutProvider: AvatarPickerContentLayoutProviding = AvatarPickerContentLayout.vertical
+    var contentLayoutProvider: AvatarPickerContentLayoutProviding = AvatarPickerContentLayoutType.vertical
     var customImageEditor: ImageEditorBlock<ImageEditor>?
     var tokenErrorHandler: (() -> Void)?
 
@@ -506,7 +506,7 @@ private enum AvatarPicker {
         profileModel: PreviewModel()
     )
 
-    return AvatarPickerView<NoCustomEditor>(model: model, isPresented: .constant(true), contentLayoutProvider: AvatarPickerContentLayout.horizontal)
+    return AvatarPickerView<NoCustomEditor>(model: model, isPresented: .constant(true), contentLayoutProvider: AvatarPickerContentLayoutType.horizontal)
 }
 
 #Preview("Empty elements") {

--- a/Sources/GravatarUI/SwiftUI/AvatarPickerModalPresentationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPickerModalPresentationModifier.swift
@@ -24,9 +24,9 @@ struct AvatarPickerModalPresentationModifier<ModalView: View>: ViewModifier, Mod
     @State private var prioritizeScrollOverResize: Bool = false
     let onDismiss: (() -> Void)?
     let modalView: ModalView
-    var contentLayoutWithPresentation: AvatarPickerContentLayoutWithPresentation
+    var contentLayoutWithPresentation: AvatarPickerContentLayout
 
-    init(isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, modalView: ModalView, contentLayout: AvatarPickerContentLayoutWithPresentation) {
+    init(isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, modalView: ModalView, contentLayout: AvatarPickerContentLayout) {
         self._isPresented = isPresented
         self.isPresentedInner = isPresented.wrappedValue
         self.onDismiss = onDismiss
@@ -89,7 +89,7 @@ struct AvatarPickerModalPresentationModifier<ModalView: View>: ViewModifier, Mod
 
 @MainActor
 protocol ModalPresentationWithIntrinsicSize {
-    var contentLayoutWithPresentation: AvatarPickerContentLayoutWithPresentation { get }
+    var contentLayoutWithPresentation: AvatarPickerContentLayout { get }
     var verticalSizeClass: UserInterfaceSizeClass? { get }
 }
 

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -1,7 +1,18 @@
 import SwiftUI
 
-public enum QuickEditorScope: Sendable {
+public enum QuickEditorScopeType: Sendable {
     case avatarPicker
+}
+
+public enum QuickEditorScope: Sendable {
+    case avatarPicker(AvatarPickerConfiguration)
+    
+    var scopeType: QuickEditorScopeType {
+        switch self {
+        case .avatarPicker(_):
+            .avatarPicker
+        }
+    }
 }
 
 private enum QuickEditorConstants {
@@ -13,7 +24,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
 
     @Environment(\.oauthSession) private var oauthSession
     @State var hasSession: Bool = false
-    @State var scope: QuickEditorScope
+    @State var scope: QuickEditorScopeType
     @State var isAuthenticating: Bool = true
     @State var oauthError: OAuthError?
     @Binding var isPresented: Bool
@@ -24,11 +35,11 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
 
     init(
         email: Email,
-        scope: QuickEditorScope,
+        scope: QuickEditorScopeType,
         token: String? = nil,
         isPresented: Binding<Bool>,
         customImageEditor: ImageEditorBlock<ImageEditor>? = nil,
-        contentLayoutProvider: AvatarPickerContentLayoutProviding = AvatarPickerContentLayout.vertical
+        contentLayoutProvider: AvatarPickerContentLayoutProviding = AvatarPickerContentLayoutType.vertical
     ) {
         self.email = email
         self.scope = scope
@@ -196,6 +207,6 @@ extension QuickEditorConstants {
         email: .init(""),
         scope: .avatarPicker,
         isPresented: .constant(true),
-        contentLayoutProvider: AvatarPickerContentLayoutWithPresentation.vertical(presentationStyle: .large)
+        contentLayoutProvider: AvatarPickerContentLayout.vertical(presentationStyle: .large)
     )
 }

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@available(iOS, deprecated: 16.0, renamed: "QuickEditorScope")
 public enum QuickEditorScopeType: Sendable {
     case avatarPicker
 }

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -7,10 +7,10 @@ public enum QuickEditorScopeType: Sendable {
 
 public enum QuickEditorScope: Sendable {
     case avatarPicker(AvatarPickerConfiguration)
-    
+
     var scopeType: QuickEditorScopeType {
         switch self {
-        case .avatarPicker(_):
+        case .avatarPicker:
             .avatarPicker
         }
     }

--- a/Sources/GravatarUI/SwiftUI/QEDetent.swift
+++ b/Sources/GravatarUI/SwiftUI/QEDetent.swift
@@ -9,7 +9,7 @@ enum QEDetent {
     case height(CGFloat)
 
     static func detents(
-        for presentation: AvatarPickerContentLayoutWithPresentation,
+        for presentation: AvatarPickerContentLayout,
         intrinsicHeight: CGFloat,
         verticalSizeClass: UserInterfaceSizeClass?
     ) -> [QEDetent] {

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -11,7 +11,7 @@ extension View {
             )
     }
 
-    @available(iOS, deprecated: 16.0, message: "Use the new method that takes in `AvatarPickerContentLayoutWithPresentation` for `contentLayout`.")
+    @available(iOS, deprecated: 16.0, message: "Use the new method that takes in `AvatarPickerContentLayout` for `contentLayout`.")
     public func avatarPickerSheet(
         isPresented: Binding<Bool>,
         email: String,
@@ -21,7 +21,7 @@ extension View {
         let avatarPickerView = AvatarPickerView(
             model: AvatarPickerViewModel(email: Email(email), authToken: authToken),
             isPresented: isPresented,
-            contentLayoutProvider: AvatarPickerContentLayout.vertical,
+            contentLayoutProvider: AvatarPickerContentLayoutType.vertical,
             customImageEditor: customImageEditor
         )
         let navigationWrapped = NavigationView { avatarPickerView }
@@ -33,7 +33,7 @@ extension View {
         isPresented: Binding<Bool>,
         email: String,
         authToken: String,
-        contentLayout: AvatarPickerContentLayoutWithPresentation,
+        contentLayout: AvatarPickerContentLayout,
         customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?
     ) -> some View {
         let avatarPickerView = AvatarPickerView(
@@ -56,11 +56,11 @@ extension View {
             .padding(.vertical, borderWidth) // to prevent borders from getting clipped
     }
 
-    @available(iOS, deprecated: 16.0, message: "Use the new method that takes in `AvatarPickerContentLayoutWithPresentation` for `contentLayout`.")
+    @available(iOS, deprecated: 16.0, message: "Use the new method that takes in `QuickEditorScope`.")
     public func gravatarQuickEditorSheet(
         isPresented: Binding<Bool>,
         email: String,
-        scope: QuickEditorScope,
+        scope: QuickEditorScopeType,
         customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
@@ -69,7 +69,7 @@ extension View {
             scope: scope,
             isPresented: isPresented,
             customImageEditor: customImageEditor,
-            contentLayoutProvider: AvatarPickerContentLayout.vertical
+            contentLayoutProvider: AvatarPickerContentLayoutType.vertical
         )
         return modifier(ModalPresentationModifier(isPresented: isPresented, onDismiss: onDismiss, modalView: editor))
     }
@@ -80,22 +80,24 @@ extension View {
         email: String,
         scope: QuickEditorScope,
         customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?,
-        contentLayout: AvatarPickerContentLayoutWithPresentation,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
-        let editor = QuickEditor(
-            email: .init(email),
-            scope: scope,
-            isPresented: isPresented,
-            customImageEditor: customImageEditor,
-            contentLayoutProvider: contentLayout
-        )
-        return modifier(AvatarPickerModalPresentationModifier(
-            isPresented: isPresented,
-            onDismiss: onDismiss,
-            modalView: editor,
-            contentLayout: contentLayout
-        ))
+        switch scope {
+        case .avatarPicker(let config):
+            let editor = QuickEditor(
+                email: .init(email),
+                scope: scope.scopeType,
+                isPresented: isPresented,
+                customImageEditor: customImageEditor,
+                contentLayoutProvider: config.contentLayout
+            )
+            return modifier(AvatarPickerModalPresentationModifier(
+                isPresented: isPresented,
+                onDismiss: onDismiss,
+                modalView: editor,
+                contentLayout: config.contentLayout
+            ))
+        }
     }
 
     func presentationContentInteraction(shouldPrioritizeScrolling: Bool) -> some View {


### PR DESCRIPTION
Closes #

### Description

Adding a configuration for the global quick editor experience
So far we are only applying a configuration to override the system color scheme

<img src="https://github.com/user-attachments/assets/32457183-3551-4423-b053-7575786a1f51" width="40%">

### Testing Steps

- Run the UIKit demo app
- Chose the Quick Editor demo screen
- Select a different color scheme from the current system 
- Open the Quick Editor
  - Check that the Quick Editor respect the selected color scheme. 