### PR TITLE
Updating open-api specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ generate: $(OUTPUT_DIRECTORY) # Generates the open-api model
 	cp "$(OPENAPI_YAML_PATH)" "$(OPENAPI_GENERATOR_CLONE_DIR)"/openapi.yaml
 	mkdir -p "$(OPENAPI_GENERATOR_CLONE_DIR)"/templates
 	cp "$(MODEL_TEMPLATE_PATH)"/*.mustache "$(OPENAPI_GENERATOR_CLONE_DIR)"/templates/
+	rm -rf "$(OPENAPI_GENERATOR_CLONE_DIR)"/generated/OpenAPIClient/Classes/OpenAPIs/Models/*
 	"$(OPENAPI_GENERATOR_CLONE_DIR)"/run-in-docker.sh generate -i openapi.yaml \
     --global-property models \
     -t templates \

--- a/Sources/Gravatar/Network/Services/CheckTokenAuthorizationService.swift
+++ b/Sources/Gravatar/Network/Services/CheckTokenAuthorizationService.swift
@@ -28,7 +28,7 @@ package struct CheckTokenAuthorizationService: Sendable {
         request.httpMethod = "GET"
         do {
             let (data, _) = try await client.fetchData(with: request)
-            let result: AssociatedEmail200Response = try data.decode()
+            let result: AssociatedResponse = try data.decode()
             return result.associated
         } catch {
             throw error.apiError()

--- a/Sources/Gravatar/OpenApi/Generated/AssociatedResponse.swift
+++ b/Sources/Gravatar/OpenApi/Generated/AssociatedResponse.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public struct AssociatedEmail200Response: Codable, Hashable, Sendable {
-    /// Whether the email is associated with a Gravatar account.
+public struct AssociatedResponse: Codable, Hashable, Sendable {
+    /// Whether the entity is associated with the account.
     public private(set) var associated: Bool
 
     @available(*, deprecated, message: "init will become internal on the next release")

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -449,6 +449,16 @@ components:
           pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
           examples:
             - '2021-10-01T12:00:00Z'
+    AssociatedResponse:
+      type: object
+      required:
+        - associated
+      properties:
+        associated:
+          type: boolean
+          description: Whether the entity is associated with the account.
+          examples:
+            - true
     Error:
       type: object
       description: An error response from the API.
@@ -555,14 +565,7 @@ paths:
             application/json:
               schema:
                 type: object
-                required:
-                  - associated
-                properties:
-                  associated:
-                    type: boolean
-                    description: Whether the email is associated with a Gravatar account.
-                    examples:
-                      - true
+                $ref: '#/components/schemas/AssociatedResponse'
   /me/avatars:
     get:
       summary: List avatars


### PR DESCRIPTION
Closes #

### Description

Updating to the latest specs

### Testing Steps

The change could affect the `CheckTokenAuthorizationService`. To test, follow the steps from: https://github.com/Automattic/Gravatar-SDK-iOS/pull/427 

