### PR TITLE
Add common headers for Platform, SDK version, Source app

### DIFF
--- a/Gravatar.podspec
+++ b/Gravatar.podspec
@@ -23,6 +23,9 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = ios_deployment_target
 
   s.source_files = 'Sources/Gravatar/**/*.swift'
+  s.resource_bundles = {
+    'Gravatar' => ['Sources/Gravatar/Resources/*.plist']
+  }
 
   # Using the `package` access level for types requires us to pass `-package-name`
   # as a swift flag, with the same name for each module/pod

--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,7 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "Gravatar",
+            resources: [.process("Resources")],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency")
             ],

--- a/Sources/Gravatar/Bundle+ResourceBundle.swift
+++ b/Sources/Gravatar/Bundle+ResourceBundle.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+#if !SWIFT_PACKAGE
+private class BundleFinder: NSObject {}
+extension Bundle {
+    static var module: Bundle {
+        let defaultBundle = Bundle(for: BundleFinder.self)
+        // If installed with CocoaPods, resources will be in GravatarUI.bundle
+        if let bundleURL = defaultBundle.resourceURL,
+           let resourceBundle = Bundle(url: bundleURL.appendingPathComponent("Gravatar.bundle"))
+        {
+            return resourceBundle
+        }
+        // Otherwise, the default bundle is used for resources
+        return defaultBundle
+    }
+}
+#endif

--- a/Sources/Gravatar/Bundle+ResourceBundle.swift
+++ b/Sources/Gravatar/Bundle+ResourceBundle.swift
@@ -5,7 +5,10 @@ private class BundleFinder: NSObject {}
 extension Bundle {
     static var module: Bundle {
         let defaultBundle = Bundle(for: BundleFinder.self)
-        // If installed with CocoaPods, resources will be in GravatarUI.bundle
+        // If installed with CocoaPods, resources will be in Gravatar.bundle
+        // The name of the bundle "Gravatar.bundle" (without the .bundle file extension)
+        // needs to match the key in the respective Gravatar.podspec:
+        // `s.resource_bundles = { 'Gravatar' => ['Sources/Gravatar/Resources/*.plist'] }`
         if let bundleURL = defaultBundle.resourceURL,
            let resourceBundle = Bundle(url: bundleURL.appendingPathComponent("Gravatar.bundle"))
         {

--- a/Sources/Gravatar/BundleInfo.swift
+++ b/Sources/Gravatar/BundleInfo.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct BundleInfo {
+enum BundleInfo {
     public static var sdkVersion: String? {
         getInfoValue(forKey: "CFBundleShortVersionString") as? String
     }

--- a/Sources/Gravatar/BundleInfo.swift
+++ b/Sources/Gravatar/BundleInfo.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Info {
+struct BundleInfo {
     public static var sdkVersion: String? {
         getInfoValue(forKey: "CFBundleShortVersionString") as? String
     }

--- a/Sources/Gravatar/Info.swift
+++ b/Sources/Gravatar/Info.swift
@@ -1,8 +1,22 @@
-//
-//  File.swift
-//  
-//
-//  Created by Pinar Olguc on 3.10.2024.
-//
-
 import Foundation
+
+struct Info {
+    public static var sdkVersion: String? {
+        getInfoValue(forKey: "CFBundleShortVersionString") as? String
+    }
+
+    public static var appName: String? {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
+    }
+
+    private static func getInfoValue(forKey key: String) -> Any? {
+        // Access the SDKInfo.plist using Bundle.module
+        guard let url = Bundle.module.url(forResource: "SDKInfo", withExtension: "plist"),
+              let data = try? Data(contentsOf: url),
+              let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any]
+        else {
+            return nil
+        }
+        return plist[key]
+    }
+}

--- a/Sources/Gravatar/Info.swift
+++ b/Sources/Gravatar/Info.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Pinar Olguc on 3.10.2024.
+//
+
+import Foundation

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -47,7 +47,7 @@ public struct AvatarService: Sendable {
     @discardableResult
     @available(*, deprecated, renamed: "upload(_:accessToken:)")
     public func upload(_ image: UIImage, email: Email, accessToken: String) async throws -> URLResponse {
-        try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: [(name: "Client-Type", value: "ios")]).response
+        try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: nil).response
     }
 
     /// Uploads an image to be used as the user's Gravatar profile image, and returns the `URLResponse` of the network tasks asynchronously. Throws
@@ -59,7 +59,7 @@ public struct AvatarService: Sendable {
     @discardableResult
     public func upload(_ image: UIImage, accessToken: String) async throws -> Avatar {
         do {
-            let (data, _) = try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: [(name: "Client-Type", value: "ios")])
+            let (data, _) = try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: nil)
             return try data.decode()
         } catch let error as ImageUploadError {
             throw error

--- a/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
+++ b/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
@@ -15,8 +15,8 @@ struct URLSessionHTTPClient: HTTPClient {
         configuration.httpAdditionalHeaders = [
             "Accept": "application/json",
             "X-Platform": "ios",
-            "X-SDK-Version": Info.sdkVersion ?? "",
-            "X-Source": Info.appName ?? "",
+            "X-SDK-Version": BundleInfo.sdkVersion ?? "",
+            "X-Source": BundleInfo.appName ?? "",
         ]
         self.urlSession = urlSession ?? URLSession(configuration: configuration)
     }

--- a/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
+++ b/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
@@ -14,6 +14,9 @@ struct URLSessionHTTPClient: HTTPClient {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = [
             "Accept": "application/json",
+            "X-Platform": "ios",
+            "X-SDK-Version": Info.sdkVersion ?? "",
+            "X-Source": Info.appName ?? "",
         ]
         self.urlSession = urlSession ?? URLSession(configuration: configuration)
     }

--- a/Sources/Gravatar/Resources/SDKInfo.plist
+++ b/Sources/Gravatar/Resources/SDKInfo.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleShortVersionString</key>
+	<string>2.1.1</string>
+</dict>
+</plist>

--- a/Tests/GravatarTests/AvatarServiceTests.swift
+++ b/Tests/GravatarTests/AvatarServiceTests.swift
@@ -35,7 +35,6 @@ final class AvatarServiceTests: XCTestCase {
         XCTAssertTrue(request?.value(forHTTPHeaderField: "Authorization")?.hasPrefix("Bearer ") ?? false)
         XCTAssertNotNil(request?.value(forHTTPHeaderField: "Content-Type"))
         XCTAssertTrue(request?.value(forHTTPHeaderField: "Content-Type")?.hasPrefix("multipart/form-data; boundary=") ?? false)
-        XCTAssertTrue(request?.value(forHTTPHeaderField: "Client-Type") == "ios")
     }
 
     func testUploadImageError() async throws {


### PR DESCRIPTION
Closes https://github.com/Automattic/Gravatar-SDK-iOS/issues/451

### Description

Adding headers:

`X-Platform: ios`
`X-SDK-Version: <version>`
`X-Source: <app bundle name>`

I created a follow-up issue to find a better way about injecting the SDK version into the iOS runtime. https://github.com/Automattic/Gravatar-SDK-iOS/issues/456

### Testing Steps

SwiftUI demo app > QE 
Check with a tool like proxyman and confirm the headers are added.