### PR TITLE
Avatar selected callback

### DIFF
--- a/Demo/Demo/Gravatar-SwiftUI-Demo/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/DemoProfileEditorView.swift
@@ -74,7 +74,6 @@ struct DemoProfileEditorView: View {
         Task {
             let service = ProfileService()
             let profile = try await service.fetch(with: .email(email))
-            print("Profile found")
             self.profileModel = profile
             self.avatarID = profile.avatarIdentifier
         }

--- a/Demo/Demo/Gravatar-UIKit-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/DemoQuickEditorViewController.swift
@@ -74,7 +74,6 @@ final class DemoQuickEditorViewController: UIViewController {
         let view = ProfileSummaryView(frame: .zero, paletteType: .system, profileButtonStyle: .edit)
         view.translatesAutoresizingMaskIntoConstraints = false
         view.avatarActivityIndicatorType = .activity
-//        view.delegate = self
         return view
     }()
 

--- a/Demo/Demo/Gravatar-UIKit-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/DemoQuickEditorViewController.swift
@@ -171,7 +171,7 @@ final class DemoQuickEditorViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
+        view.backgroundColor = .secondarySystemBackground
         view.addSubview(rootStackView)
         NSLayoutConstraint.activate([
             rootStackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
@@ -194,8 +194,8 @@ final class DemoQuickEditorViewController: UIViewController {
             ),
             token: token
         )
-        presenter.present(in: self, onAvatarUpdated: { [weak self] avatar in
-            self?.profileSummaryView.loadAvatar(avatar)
+        presenter.present(in: self, onAvatarUpdated: { [weak self] in
+            self?.profileSummaryView.loadAvatar(with: .email(email), options: [.forceRefresh])
         } , onDismiss: { [weak self] in
             self?.updateLogoutButton()
         })

--- a/Sources/GravatarUI/ProfileView/BaseProfileView.swift
+++ b/Sources/GravatarUI/ProfileView/BaseProfileView.swift
@@ -320,29 +320,6 @@ open class BaseProfileView: UIView, UIContentView {
         }
     }
 
-    public func loadAvatar(
-        _ avatar: Avatar,
-        placeholder: UIImage? = nil,
-        rating: Rating? = nil,
-        defaultAvatarOption: DefaultAvatarOption? = nil,
-        options: [ImageSettingOption]? = nil
-    ) {
-        guard let avatarURL = URL(string: avatar.url) else {
-            avatarProvider.setImage(placeholder)
-            return
-        }
-        let pointsSize: ImageSize = .points(avatarLength)
-        let downloadOptions = ImageSettingOptions(options: options).deriveDownloadOptions(
-            garavatarRating: rating,
-            preferredSize: pointsSize,
-            defaultAvatarOption: defaultAvatarOption
-        )
-
-        Task {
-            try await avatarProvider.setImage(with: avatarURL, placeholder: placeholder, options: options)
-        }
-    }
-
     func refresh(with paletteType: PaletteType) {
         avatarProvider.refresh(with: paletteType)
         backgroundColor = paletteType.palette.background.primary

--- a/Sources/GravatarUI/ProfileView/BaseProfileView.swift
+++ b/Sources/GravatarUI/ProfileView/BaseProfileView.swift
@@ -320,6 +320,29 @@ open class BaseProfileView: UIView, UIContentView {
         }
     }
 
+    public func loadAvatar(
+        _ avatar: Avatar,
+        placeholder: UIImage? = nil,
+        rating: Rating? = nil,
+        defaultAvatarOption: DefaultAvatarOption? = nil,
+        options: [ImageSettingOption]? = nil
+    ) {
+        guard let avatarURL = URL(string: avatar.url) else {
+            avatarProvider.setImage(placeholder)
+            return
+        }
+        let pointsSize: ImageSize = .points(avatarLength)
+        let downloadOptions = ImageSettingOptions(options: options).deriveDownloadOptions(
+            garavatarRating: rating,
+            preferredSize: pointsSize,
+            defaultAvatarOption: defaultAvatarOption
+        )
+
+        Task {
+            try await avatarProvider.setImage(with: avatarURL, placeholder: placeholder, options: options)
+        }
+    }
+
     func refresh(with paletteType: PaletteType) {
         avatarProvider.refresh(with: paletteType)
         backgroundColor = paletteType.palette.background.primary

--- a/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
@@ -6,7 +6,7 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
     let scope: QuickEditorScope
     let token: String?
     let configuration: QuickEditorConfiguration
-    let onAvatarUpdated: ((Avatar) -> Void)?
+    let onAvatarUpdated: (() -> Void)?
     let onDismiss: (() -> Void)?
 
     private lazy var isPresented: Binding<Bool> = Binding {
@@ -53,7 +53,7 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
         scope: QuickEditorScope,
         configuration: QuickEditorConfiguration? = nil,
         token: String? = nil,
-        onAvatarUpdated: ((Avatar) -> Void)? = nil,
+        onAvatarUpdated: (() -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) {
         self.email = email
@@ -167,7 +167,7 @@ public struct QuickEditorPresenter {
         in parent: UIViewController,
         animated: Bool = true,
         completion: (() -> Void)? = nil,
-        onAvatarUpdated: ((Avatar) -> Void)? = nil,
+        onAvatarUpdated: (() -> Void)? = nil,
         onDismiss: @escaping () -> Void
     ) {
         let quickEditor = QuickEditorViewController(

--- a/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
@@ -6,8 +6,8 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
     let scope: QuickEditorScope
     let token: String?
     let configuration: QuickEditorConfiguration
-
-    var onDismiss: (() -> Void)? = nil
+    let onAvatarUpdated: ((Avatar) -> Void)?
+    let onDismiss: (() -> Void)?
 
     private lazy var isPresented: Binding<Bool> = Binding {
         true
@@ -34,7 +34,8 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
         token: token,
         isPresented: isPresented,
         customImageEditor: nil as NoCustomEditorBlock?,
-        contentLayoutProvider: contentLayoutWithPresentation
+        contentLayoutProvider: contentLayoutWithPresentation,
+        avatarUpdatedHandler: onAvatarUpdated
     ), onHeightChange: { [weak self] newHeight in
         guard let self else { return }
         if self.shouldAcceptHeight(newHeight) {
@@ -52,6 +53,7 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
         scope: QuickEditorScope,
         configuration: QuickEditorConfiguration? = nil,
         token: String? = nil,
+        onAvatarUpdated: ((Avatar) -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) {
         self.email = email
@@ -59,6 +61,7 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
         self.configuration = configuration ?? .default
         self.token = token
         self.onDismiss = onDismiss
+        self.onAvatarUpdated = onAvatarUpdated
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -164,6 +167,7 @@ public struct QuickEditorPresenter {
         in parent: UIViewController,
         animated: Bool = true,
         completion: (() -> Void)? = nil,
+        onAvatarUpdated: ((Avatar) -> Void)? = nil,
         onDismiss: @escaping () -> Void
     ) {
         let quickEditor = QuickEditorViewController(
@@ -171,11 +175,11 @@ public struct QuickEditorPresenter {
             scope: scope,
             configuration: configuration,
             token: token,
+            onAvatarUpdated: onAvatarUpdated,
             onDismiss: onDismiss
         )
 
         quickEditor.overrideUserInterfaceStyle = configuration.interfaceStyle
-        quickEditor.onDismiss = onDismiss
         parent.present(quickEditor, animated: animated, completion: completion)
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -20,7 +20,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
     var contentLayoutProvider: AvatarPickerContentLayoutProviding = AvatarPickerContentLayoutType.vertical
     var customImageEditor: ImageEditorBlock<ImageEditor>?
     var tokenErrorHandler: (() -> Void)?
-    var avatarUpdatedHandler: ((Avatar) -> Void)?
+    var avatarUpdatedHandler: (() -> Void)?
 
     public var body: some View {
         ZStack {
@@ -264,8 +264,8 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
 
     func selectAvatar(with id: String) {
         Task {
-            if let avatar = await model.selectAvatar(with: id) {
-                avatarUpdatedHandler?(avatar)
+            if await model.selectAvatar(with: id) != nil {
+                avatarUpdatedHandler?()
             }
         }
     }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -20,6 +20,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
     var contentLayoutProvider: AvatarPickerContentLayoutProviding = AvatarPickerContentLayoutType.vertical
     var customImageEditor: ImageEditorBlock<ImageEditor>?
     var tokenErrorHandler: (() -> Void)?
+    var avatarUpdatedHandler: ((Avatar) -> Void)?
 
     public var body: some View {
         ZStack {
@@ -228,7 +229,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
                 grid: model.grid,
                 customImageEditor: customImageEditor,
                 onAvatarTap: { avatar in
-                    model.selectAvatar(with: avatar.id)
+                    selectAvatar(with: avatar.id)
                 },
                 onImagePickerDidPickImage: { image in
                     uploadImage(image)
@@ -244,7 +245,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
             HorizontalAvatarGrid(
                 grid: model.grid,
                 onAvatarTap: { avatar in
-                    model.selectAvatar(with: avatar.id)
+                    selectAvatar(with: avatar.id)
                 },
                 onFailedUploadTapped: { failedUploadInfo in
                     uploadError = failedUploadInfo
@@ -258,6 +259,14 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
             }
             .padding(.horizontal, Constants.horizontalPadding)
             .padding(.bottom, .DS.Padding.medium)
+        }
+    }
+
+    func selectAvatar(with id: String) {
+        Task {
+            if let avatar = await model.selectAvatar(with: id) {
+                avatarUpdatedHandler?(avatar)
+            }
         }
     }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -102,7 +102,6 @@ class AvatarPickerViewModel: ObservableObject {
         do {
             let response = try await profileService.selectAvatar(token: authToken, profileID: identifier, avatarID: avatarID)
 
-
             toastManager.showToast("Avatar updated! It may take a few minutes to appear everywhere.", type: .info)
 
             selectedAvatarResult = .success(response.imageId)

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -33,7 +33,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
     let token: String?
     var customImageEditor: ImageEditorBlock<ImageEditor>?
     var contentLayoutProvider: AvatarPickerContentLayoutProviding
-    var avatarUpdatedHandler: ((Avatar) -> Void)?
+    var avatarUpdatedHandler: (() -> Void)?
 
     init(
         email: Email,
@@ -42,7 +42,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
         isPresented: Binding<Bool>,
         customImageEditor: ImageEditorBlock<ImageEditor>? = nil,
         contentLayoutProvider: AvatarPickerContentLayoutProviding = AvatarPickerContentLayoutType.vertical,
-        avatarUpdatedHandler: ((Avatar) -> Void)? = nil
+        avatarUpdatedHandler: (() -> Void)? = nil
     ) {
         self.email = email
         self.scope = scope

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -33,6 +33,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
     let token: String?
     var customImageEditor: ImageEditorBlock<ImageEditor>?
     var contentLayoutProvider: AvatarPickerContentLayoutProviding
+    var avatarUpdatedHandler: ((Avatar) -> Void)?
 
     init(
         email: Email,
@@ -40,7 +41,8 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
         token: String? = nil,
         isPresented: Binding<Bool>,
         customImageEditor: ImageEditorBlock<ImageEditor>? = nil,
-        contentLayoutProvider: AvatarPickerContentLayoutProviding = AvatarPickerContentLayoutType.vertical
+        contentLayoutProvider: AvatarPickerContentLayoutProviding = AvatarPickerContentLayoutType.vertical,
+        avatarUpdatedHandler: ((Avatar) -> Void)? = nil
     ) {
         self.email = email
         self.scope = scope
@@ -48,6 +50,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
         self.customImageEditor = customImageEditor
         self.contentLayoutProvider = contentLayoutProvider
         self.token = token
+        self.avatarUpdatedHandler = avatarUpdatedHandler
     }
 
     var body: some View {
@@ -75,7 +78,8 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
                 tokenErrorHandler: {
                     oauthSession.deleteSession(with: email)
                     performAuthentication()
-                }
+                },
+                avatarUpdatedHandler: avatarUpdatedHandler
             )
         }
     }

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -17,7 +17,7 @@ extension View {
         email: String,
         authToken: String,
         customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?,
-        avatarUpdatedHandler: ((Avatar) -> Void)? = nil
+        avatarUpdatedHandler: (() -> Void)? = nil
     ) -> some View {
         let avatarPickerView = AvatarPickerView(
             model: AvatarPickerViewModel(email: Email(email), authToken: authToken),
@@ -37,7 +37,7 @@ extension View {
         authToken: String,
         contentLayout: AvatarPickerContentLayout,
         customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?,
-        avatarUpdatedHandler: ((Avatar) -> Void)? = nil
+        avatarUpdatedHandler: (() -> Void)? = nil
     ) -> some View {
         let avatarPickerView = AvatarPickerView(
             model: AvatarPickerViewModel(email: Email(email), authToken: authToken),
@@ -66,7 +66,7 @@ extension View {
         email: String,
         scope: QuickEditorScopeType,
         customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?,
-        avatarUpdatedHandler: ((Avatar) -> Void)? = nil,
+        avatarUpdatedHandler: (() -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
         let editor = QuickEditor(
@@ -86,7 +86,7 @@ extension View {
         email: String,
         scope: QuickEditorScope,
         customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?,
-        avatarUpdatedHandler: ((Avatar) -> Void)? = nil,
+        avatarUpdatedHandler: (() -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
         switch scope {

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -16,13 +16,15 @@ extension View {
         isPresented: Binding<Bool>,
         email: String,
         authToken: String,
-        customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?
+        customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?,
+        avatarUpdatedHandler: ((Avatar) -> Void)? = nil
     ) -> some View {
         let avatarPickerView = AvatarPickerView(
             model: AvatarPickerViewModel(email: Email(email), authToken: authToken),
             isPresented: isPresented,
             contentLayoutProvider: AvatarPickerContentLayoutType.vertical,
-            customImageEditor: customImageEditor
+            customImageEditor: customImageEditor,
+            avatarUpdatedHandler: avatarUpdatedHandler
         )
         let navigationWrapped = NavigationView { avatarPickerView }
         return modifier(ModalPresentationModifier(isPresented: isPresented, modalView: navigationWrapped))
@@ -34,13 +36,15 @@ extension View {
         email: String,
         authToken: String,
         contentLayout: AvatarPickerContentLayout,
-        customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?
+        customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?,
+        avatarUpdatedHandler: ((Avatar) -> Void)? = nil
     ) -> some View {
         let avatarPickerView = AvatarPickerView(
             model: AvatarPickerViewModel(email: Email(email), authToken: authToken),
             isPresented: isPresented,
             contentLayoutProvider: contentLayout,
-            customImageEditor: customImageEditor
+            customImageEditor: customImageEditor,
+            avatarUpdatedHandler: avatarUpdatedHandler
         )
         let navigationWrapped = NavigationView { avatarPickerView }
         return modifier(AvatarPickerModalPresentationModifier(isPresented: isPresented, modalView: navigationWrapped, contentLayout: contentLayout))
@@ -62,6 +66,7 @@ extension View {
         email: String,
         scope: QuickEditorScopeType,
         customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?,
+        avatarUpdatedHandler: ((Avatar) -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
         let editor = QuickEditor(
@@ -69,7 +74,8 @@ extension View {
             scope: scope,
             isPresented: isPresented,
             customImageEditor: customImageEditor,
-            contentLayoutProvider: AvatarPickerContentLayoutType.vertical
+            contentLayoutProvider: AvatarPickerContentLayoutType.vertical,
+            avatarUpdatedHandler: avatarUpdatedHandler
         )
         return modifier(ModalPresentationModifier(isPresented: isPresented, onDismiss: onDismiss, modalView: editor))
     }
@@ -80,6 +86,7 @@ extension View {
         email: String,
         scope: QuickEditorScope,
         customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?,
+        avatarUpdatedHandler: ((Avatar) -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
         switch scope {
@@ -89,7 +96,8 @@ extension View {
                 scope: scope.scopeType,
                 isPresented: isPresented,
                 customImageEditor: customImageEditor,
-                contentLayoutProvider: config.contentLayout
+                contentLayoutProvider: config.contentLayout,
+                avatarUpdatedHandler: avatarUpdatedHandler
             )
             return modifier(AvatarPickerModalPresentationModifier(
                 isPresented: isPresented,


### PR DESCRIPTION
Closes #

### Description

This PR adds a callback to signal the parent app of a new avatar selection by the user.

### Testing Steps

#### UIKit:
- Go to Quick Editor example page
- Open the Avatar Picker and select a different avatar
  - Check that the avatar on the demo screen updates acordingly

#### SwiftUI:
- Go to Profile Editor with OAuth
- Open the Avatar Picker and select a different avatar
  - Check that the avatar on the demo screen updates acordingly
