### PR TITLE
Prevent stacking of toast messages

### DIFF
--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -85,8 +85,8 @@
 /* The title of the dismiss button on a confirmation dialog. */
 "AvatarPicker.Dismiss.title" = "Dismiss";
 
-/* A success message to show when the user picks a different avatar. */
+/* This confirmation message shows when the user picks a different avatar. */
 "AvatarPickerViewModel.Update.Success" = "Avatar updated! It may take a few minutes to appear everywhere.";
 
-/* An error message to show when the user's attempt to picks a different avatar fails. */
+/* This error message shows when the user attempts to pick a different avatar and fails. */
 "AvatarPickerViewModel.Update.Fail" = "Oops, something didn't quite work out while trying to change your avatar.";

--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -84,3 +84,9 @@
 
 /* The title of the dismiss button on a confirmation dialog. */
 "AvatarPicker.Dismiss.title" = "Dismiss";
+
+/* A success message to show when the user picks a different avatar. */
+"AvatarPickerViewModel.Update.Success" = "Avatar updated! It may take a few minutes to appear everywhere.";
+
+/* An error message to show when the user's attempt to picks a different avatar fails. */
+"AvatarPickerViewModel.Update.Fail" = "Oops, something didn't quite work out while trying to change your avatar.";

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -99,12 +99,12 @@ class AvatarPickerViewModel: ObservableObject {
 
         do {
             let response = try await profileService.selectAvatar(token: authToken, profileID: identifier, avatarID: avatarID)
-            toastManager.showToast("Avatar updated! It may take a few minutes to appear everywhere.", type: .info)
+            toastManager.showToast(Localized.avatarUpdateSuccess, type: .info)
             selectedAvatarResult = .success(response.imageId)
         } catch APIError.responseError(let reason) where reason.cancelled {
             // NoOp.
         } catch {
-            toastManager.showToast("Oops, something didn't quite work out while trying to change your avatar.", type: .error)
+            toastManager.showToast(Localized.avatarUpdateSuccess, type: .error)
             grid.selectAvatar(withID: selectedAvatarResult?.value())
         }
     }
@@ -250,6 +250,16 @@ extension AvatarPickerViewModel {
             "AvatarPickerViewModel.Upload.Error.message",
             value: "Oops, there was an error uploading the image.",
             comment: "A generic error message to show on an error dialog when the upload fails."
+        )
+        static let avatarUpdateSuccess = SDKLocalizedString(
+            "AvatarPickerViewModel.Update.Success",
+            value: "Avatar updated! It may take a few minutes to appear everywhere.",
+            comment: "A success message to show when the user picks a different avatar."
+        )
+        static let avatarUpdateFail = SDKLocalizedString(
+            "AvatarPickerViewModel.Update.Fail",
+            value: "Oops, something didn't quite work out while trying to change your avatar.",
+            comment: "An error message to show when the user's attempt to picks a different avatar fails."
         )
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -254,12 +254,12 @@ extension AvatarPickerViewModel {
         static let avatarUpdateSuccess = SDKLocalizedString(
             "AvatarPickerViewModel.Update.Success",
             value: "Avatar updated! It may take a few minutes to appear everywhere.",
-            comment: "A success message to show when the user picks a different avatar."
+            comment: "This confirmation message shows when the user picks a different avatar."
         )
         static let avatarUpdateFail = SDKLocalizedString(
             "AvatarPickerViewModel.Update.Fail",
             value: "Oops, something didn't quite work out while trying to change your avatar.",
-            comment: "An error message to show when the user's attempt to picks a different avatar fails."
+            comment: "This error message shows when the user attempts to pick a different avatar and fails."
         )
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -104,7 +104,7 @@ class AvatarPickerViewModel: ObservableObject {
         } catch APIError.responseError(let reason) where reason.cancelled {
             // NoOp.
         } catch {
-            toastManager.showToast(Localized.avatarUpdateSuccess, type: .error)
+            toastManager.showToast(Localized.avatarUpdateFail, type: .error)
             grid.selectAvatar(withID: selectedAvatarResult?.value())
         }
     }

--- a/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
@@ -63,7 +63,7 @@ struct Toast: View {
     VStack {
         Toast(toast: .init(
             message: "Avatar updated! It may take a few minutes to appear everywhere.",
-            type: .info, 
+            type: .info,
             stackingBehavior: .dismissExistingWithSameMessage
         )) { _ in
         }

--- a/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
@@ -64,14 +64,14 @@ struct Toast: View {
         Toast(toast: .init(
             message: "Avatar updated! It may take a few minutes to appear everywhere.",
             type: .info,
-            stackingBehavior: .dismissExistingWithSameMessage
+            stackingBehavior: .avoidStackingWithSameMessage
         )) { _ in
         }
 
         Toast(toast: .init(
             message: "Something went wrong.",
             type: .error,
-            stackingBehavior: .doNotDismiss
+            stackingBehavior: .alwaysStack
         )) { _ in
         }
     }

--- a/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
@@ -63,13 +63,15 @@ struct Toast: View {
     VStack {
         Toast(toast: .init(
             message: "Avatar updated! It may take a few minutes to appear everywhere.",
-            type: .info
+            type: .info, 
+            stackingBehavior: .dismissExistingWithSameMessage
         )) { _ in
         }
 
         Toast(toast: .init(
             message: "Something went wrong.",
-            type: .error
+            type: .error,
+            stackingBehavior: .doNotDismiss
         )) { _ in
         }
     }

--- a/Sources/GravatarUI/SwiftUI/Toast/ToastManager.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/ToastManager.swift
@@ -4,7 +4,7 @@ import SwiftUI
 class ToastManager: ObservableObject {
     @Published var toasts: [ToastItem] = []
 
-    func showToast(_ message: String, type: ToastType = .info, stackingBehavior: ToastStackingBehavior = .dismissExistingWithSameMessage) {
+    func showToast(_ message: String, type: ToastType = .info, stackingBehavior: ToastStackingBehavior = .avoidStackingWithSameMessage) {
         let toast = ToastItem(message: message, type: type, stackingBehavior: stackingBehavior)
         dismissExistingIfNeeded(upcomingToast: toast)
         toasts.append(toast)
@@ -16,9 +16,9 @@ class ToastManager: ObservableObject {
     func dismissExistingIfNeeded(upcomingToast: ToastItem) {
         toasts.filter { item in
             switch upcomingToast.stackingBehavior {
-            case .dismissExistingWithSameMessage:
+            case .avoidStackingWithSameMessage:
                 upcomingToast.message == item.message
-            case .doNotDismiss:
+            case .alwaysStack:
                 false
             }
         }.forEach { element in
@@ -45,10 +45,10 @@ enum ToastType: Int {
 }
 
 enum ToastStackingBehavior: Equatable {
-    /// Dismisses the toast with the same message before showing the new one.
-    case dismissExistingWithSameMessage
-    /// Doesn't dismiss.
-    case doNotDismiss
+    /// Dismiss the toast with the same message before showing the new one.
+    case avoidStackingWithSameMessage
+    /// Stack the message without dismissing the existing ones.
+    case alwaysStack
 }
 
 struct ToastItem: Identifiable, Equatable {


### PR DESCRIPTION
Closes #457 

### Description

Upon a request from our designer, i implemented a mechanism to prevent the toasts from stacking. If the new toast has the same message, the previous one will be dismissed first. 

![Oct-04-2024 13-51-47](https://github.com/user-attachments/assets/9b3278da-9efd-489b-af88-9365f309b53e)

### Testing Steps

SwiftUI demo app > Profile editor with oauth
Switch between different avatars and observe the you see only 1 success toast at a time.
Disconnect from internet, try the same thing and observe it for the fail message as well