### PR TITLE
Making some openapi structs internal

### DIFF
--- a/Sources/Gravatar/Network/AvatarType.swift
+++ b/Sources/Gravatar/Network/AvatarType.swift
@@ -1,4 +1,4 @@
-public protocol AvatarType {
+public protocol AvatarType: Sendable {
     var url: String { get }
     var id: String { get }
 }

--- a/Sources/Gravatar/Network/AvatarType.swift
+++ b/Sources/Gravatar/Network/AvatarType.swift
@@ -1,0 +1,18 @@
+public protocol AvatarType {
+    var url: String { get }
+    var id: String { get }
+}
+
+extension Avatar: AvatarType {
+    public var id: String {
+        imageId
+    }
+
+    public var url: String {
+        imageUrl
+    }
+
+    package var isSelected: Bool {
+        selected ?? false
+    }
+}

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -55,12 +55,25 @@ public struct AvatarService: Sendable {
     /// - Parameters:
     ///   - image: The image to be uploaded.
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
-    /// - Returns: An asynchronously-delivered `AvatarModel` instance, containing data of the newly created avatar.
+    /// - Returns: An asynchronously-delivered `AvatarType` instance, containing data of the newly created avatar.
     @discardableResult
-    public func upload(_ image: UIImage, accessToken: String) async throws -> Avatar {
+    public func upload(_ image: UIImage, accessToken: String) async throws -> AvatarType {
+        let avatar: Avatar = try await upload(image, accessToken: accessToken)
+        return avatar
+    }
+
+    /// Uploads an image to be used as the user's Gravatar profile image, and returns the `URLResponse` of the network tasks asynchronously. Throws
+    /// ``ImageUploadError``.
+    /// - Parameters:
+    ///   - image: The image to be uploaded.
+    ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
+    /// - Returns: An asynchronously-delivered `Avatar` instance, containing data of the newly created avatar.
+    @discardableResult
+    func upload(_ image: UIImage, accessToken: String) async throws -> Avatar {
         do {
             let (data, _) = try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: nil)
-            return try data.decode()
+            let avatar: Avatar = try data.decode()
+            return avatar
         } catch let error as ImageUploadError {
             throw error
         } catch {

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -84,8 +84,7 @@ public struct AvatarService: Sendable {
     func upload(_ image: UIImage, accessToken: String) async throws -> Avatar {
         do {
             let (data, _) = try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: nil)
-            let avatar: Avatar = try data.decode()
-            return avatar
+            return try data.decode()
         } catch let error as ImageUploadError {
             throw error
         } catch {

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -15,7 +15,7 @@ public struct AvatarService: Sendable {
     /// - Parameters:
     ///   - client: A type which will perform basic networking operations.
     ///   - cache: A type which will perform image caching operations.
-    public init(client: HTTPClient? = nil, cache: ImageCaching? = nil) {
+    public init(client: HTTPClient, cache: ImageCaching? = nil) {
         self.imageDownloader = ImageDownloadService(client: client, cache: cache)
         self.imageUploader = ImageUploadService(client: client)
     }

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -20,6 +20,18 @@ public struct AvatarService: Sendable {
         self.imageUploader = ImageUploadService(client: client)
     }
 
+    /// Creates a new `AvatarService`
+    ///
+    /// Optionally, you can pass a custom type conforming to ``URLSessionProtocol``.
+    /// Similarly, you can pass a custom type conforming to ``ImageCaching`` to use your custom caching system.
+    /// - Parameters:
+    ///   - session: A type which will perform basic networking operations. By default, a properly configured URLSession instance will be used.
+    ///   - cache: A type which will perform image caching operations.
+    public init(session: URLSessionProtocol? = nil, cache: ImageCaching? = nil) {
+        let client = URLSessionHTTPClient(urlSession: session)
+        self.init(client: client, cache: cache)
+    }
+
     /// Fetches a Gravatar user profile image using an `AvatarId`, and delivers the image asynchronously. See also: ``ImageDownloadService`` to
     /// download the avatar via URL.
     /// - Parameters:

--- a/Sources/Gravatar/Network/Services/ProfileService.swift
+++ b/Sources/Gravatar/Network/Services/ProfileService.swift
@@ -85,20 +85,6 @@ extension URLRequest {
     }
 }
 
-extension Avatar {
-    public var id: String {
-        imageId
-    }
-
-    public var url: String {
-        imageUrl
-    }
-
-    public var isSelected: Bool {
-        selected == true
-    }
-}
-
 private struct SelectAvatarBody: Encodable, Sendable {
     private let emailHash: String
 

--- a/Sources/Gravatar/OpenApi/Generated/AssociatedResponse.swift
+++ b/Sources/Gravatar/OpenApi/Generated/AssociatedResponse.swift
@@ -1,16 +1,16 @@
 import Foundation
 
-public struct AssociatedResponse: Codable, Hashable, Sendable {
+struct AssociatedResponse: Codable, Hashable, Sendable {
     /// Whether the entity is associated with the account.
-    public private(set) var associated: Bool
+    private(set) var associated: Bool
 
     @available(*, deprecated, message: "init will become internal on the next release")
-    public init(associated: Bool) {
+    init(associated: Bool) {
         self.associated = associated
     }
 
     @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
-    public enum CodingKeys: String, CodingKey, CaseIterable {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case associated
     }
 
@@ -20,14 +20,14 @@ public struct AssociatedResponse: Codable, Hashable, Sendable {
 
     // Encodable protocol methods
 
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: InternalCodingKeys.self)
         try container.encode(associated, forKey: .associated)
     }
 
     // Decodable protocol methods
 
-    public init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: InternalCodingKeys.self)
 
         associated = try container.decode(Bool.self, forKey: .associated)

--- a/Sources/Gravatar/OpenApi/Generated/Avatar.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Avatar.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// An avatar that the user has already uploaded to their Gravatar account.
 ///
-public struct Avatar: Codable, Hashable, Sendable {
-    public enum Rating: String, Codable, CaseIterable, Sendable {
+package struct Avatar: Codable, Hashable, Sendable {
+    package enum Rating: String, Codable, CaseIterable, Sendable {
         case g = "G"
         case pg = "PG"
         case r = "R"
@@ -11,20 +11,20 @@ public struct Avatar: Codable, Hashable, Sendable {
     }
 
     /// Unique identifier for the image.
-    public private(set) var imageId: String
+    package private(set) var imageId: String
     /// Image URL
-    public private(set) var imageUrl: String
+    package private(set) var imageUrl: String
     /// Rating associated with the image.
-    public private(set) var rating: Rating
+    package private(set) var rating: Rating
     /// Date and time when the image was last updated.
-    public private(set) var updatedDate: Date
+    package private(set) var updatedDate: Date
     /// Alternative text description of the image.
-    public private(set) var altText: String
+    package private(set) var altText: String
     /// Whether the image is currently selected as the provided selected email's avatar.
-    public private(set) var selected: Bool?
+    package private(set) var selected: Bool?
 
     @available(*, deprecated, message: "init will become internal on the next release")
-    public init(imageId: String, imageUrl: String, rating: Rating, updatedDate: Date, altText: String, selected: Bool? = nil) {
+    package init(imageId: String, imageUrl: String, rating: Rating, updatedDate: Date, altText: String, selected: Bool? = nil) {
         self.imageId = imageId
         self.imageUrl = imageUrl
         self.rating = rating
@@ -34,7 +34,7 @@ public struct Avatar: Codable, Hashable, Sendable {
     }
 
     @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
-    public enum CodingKeys: String, CodingKey, CaseIterable {
+    package enum CodingKeys: String, CodingKey, CaseIterable {
         case imageId = "image_id"
         case imageUrl = "image_url"
         case rating
@@ -54,7 +54,7 @@ public struct Avatar: Codable, Hashable, Sendable {
 
     // Encodable protocol methods
 
-    public func encode(to encoder: Encoder) throws {
+    package func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: InternalCodingKeys.self)
         try container.encode(imageId, forKey: .imageId)
         try container.encode(imageUrl, forKey: .imageUrl)
@@ -66,7 +66,7 @@ public struct Avatar: Codable, Hashable, Sendable {
 
     // Decodable protocol methods
 
-    public init(from decoder: Decoder) throws {
+    package init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: InternalCodingKeys.self)
 
         imageId = try container.decode(String.self, forKey: .imageId)

--- a/Sources/Gravatar/OpenApi/Generated/ModelError.swift
+++ b/Sources/Gravatar/OpenApi/Generated/ModelError.swift
@@ -2,20 +2,20 @@ import Foundation
 
 /// An error response from the API.
 ///
-public struct ModelError: Codable, Hashable, Sendable {
+struct ModelError: Codable, Hashable, Sendable {
     /// The error message
-    public private(set) var error: String
+    private(set) var error: String
     /// The error code for the error message
-    public private(set) var code: String
+    private(set) var code: String
 
     @available(*, deprecated, message: "init will become internal on the next release")
-    public init(error: String, code: String) {
+    init(error: String, code: String) {
         self.error = error
         self.code = code
     }
 
     @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
-    public enum CodingKeys: String, CodingKey, CaseIterable {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case error
         case code
     }
@@ -27,7 +27,7 @@ public struct ModelError: Codable, Hashable, Sendable {
 
     // Encodable protocol methods
 
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: InternalCodingKeys.self)
         try container.encode(error, forKey: .error)
         try container.encode(code, forKey: .code)
@@ -35,7 +35,7 @@ public struct ModelError: Codable, Hashable, Sendable {
 
     // Decodable protocol methods
 
-    public init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: InternalCodingKeys.self)
 
         error = try container.decode(String.self, forKey: .error)

--- a/Sources/Gravatar/OpenApi/Generated/SetEmailAvatarRequest.swift
+++ b/Sources/Gravatar/OpenApi/Generated/SetEmailAvatarRequest.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public struct SetEmailAvatarRequest: Codable, Hashable, Sendable {
+struct SetEmailAvatarRequest: Codable, Hashable, Sendable {
     /// The email SHA256 hash to set the avatar for.
-    public private(set) var emailHash: String
+    private(set) var emailHash: String
 
     enum InternalCodingKeys: String, CodingKey, CaseIterable {
         case emailHash = "email_hash"
@@ -10,14 +10,14 @@ public struct SetEmailAvatarRequest: Codable, Hashable, Sendable {
 
     // Encodable protocol methods
 
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: InternalCodingKeys.self)
         try container.encode(emailHash, forKey: .emailHash)
     }
 
     // Decodable protocol methods
 
-    public init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: InternalCodingKeys.self)
 
         emailHash = try container.decode(String.self, forKey: .emailHash)

--- a/Tests/GravatarTests/AvatarServiceTests.swift
+++ b/Tests/GravatarTests/AvatarServiceTests.swift
@@ -1,4 +1,4 @@
-@testable import Gravatar
+import Gravatar
 import TestHelpers
 import XCTest
 
@@ -131,7 +131,6 @@ final class AvatarServiceTests: XCTestCase {
 }
 
 private func avatarService(with session: URLSessionProtocol, cache: ImageCaching? = nil) -> AvatarService {
-    let client = URLSessionHTTPClient(urlSession: session)
-    let service = AvatarService(client: client, cache: cache)
+    let service = AvatarService(session: session, cache: cache)
     return service
 }


### PR DESCRIPTION
Closes #

### Description

Making some of the openapi structs internal.

`Avatar` struct is being used by:
```swift
public func upload(_ image: UIImage, accessToken: String) async throws -> Avatar
```

I made a second commit replacing it with a public protocol, to consider and discuss.

### Testing Steps
- CI should be 🍏 
- Avatar picker should work as expected
