### PR TITLE
Add delay to avatar update callback

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -264,8 +264,16 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
 
     func selectAvatar(with id: String) {
         Task {
-            if await model.selectAvatar(with: id, shouldAddDelay: avatarUpdatedHandler != nil) != nil {
-                avatarUpdatedHandler?()
+            if await model.selectAvatar(with: id) != nil {
+                if let avatarUpdatedHandler {
+                    // Delay to wait until the server has updated the selected avatar before updating the UI.
+                    // Without the delay the cache busting remains insufficient to capture the new avatar.
+                    // With less than 800 ms, we can still see the issue.
+                    // Hopefully, we can remove this delay soon.
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                        avatarUpdatedHandler()
+                    }
+                }
             }
         }
     }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -264,7 +264,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
 
     func selectAvatar(with id: String) {
         Task {
-            if await model.selectAvatar(with: id) != nil {
+            if await model.selectAvatar(with: id, shouldAddDelay: avatarUpdatedHandler != nil) != nil {
                 avatarUpdatedHandler?()
             }
         }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -75,7 +75,7 @@ class AvatarPickerViewModel: ObservableObject {
         }
     }
 
-    func selectAvatar(with id: String, shouldAddDelay: Bool) async -> Avatar? {
+    func selectAvatar(with id: String) async -> Avatar? {
         guard
             let email,
             let authToken,
@@ -86,13 +86,13 @@ class AvatarPickerViewModel: ObservableObject {
         avatarSelectionTask?.cancel()
 
         avatarSelectionTask = Task {
-            await postAvatarSelection(with: id, authToken: authToken, identifier: .email(email), shouldAddDelay: shouldAddDelay)
+            await postAvatarSelection(with: id, authToken: authToken, identifier: .email(email))
         }
 
         return await avatarSelectionTask?.value
     }
 
-    func postAvatarSelection(with avatarID: String, authToken: String, identifier: ProfileIdentifier, shouldAddDelay: Bool) async -> Avatar? {
+    func postAvatarSelection(with avatarID: String, authToken: String, identifier: ProfileIdentifier) async -> Avatar? {
         defer {
             grid.setState(to: .loaded, onAvatarWithID: avatarID)
         }
@@ -101,13 +101,7 @@ class AvatarPickerViewModel: ObservableObject {
 
         do {
             let response = try await profileService.selectAvatar(token: authToken, profileID: identifier, avatarID: avatarID)
-            if shouldAddDelay {
-                // Delay to wait until the server has updated the selected avatar before updating the UI.
-                // Without the delay the cache busting remains insufficient to capture the new avatar.
-                // With less than 800 ms, we can still see the issue.
-                // Hopefully, we can remove this delay soon.
-                try await Task.sleep(nanoseconds: UInt64(0.8 * 1_000_000_000))
-            }
+
             toastManager.showToast("Avatar updated! It may take a few minutes to appear everywhere.", type: .info)
 
             selectedAvatarResult = .success(response.imageId)


### PR DESCRIPTION
Continuation of #459 

### Description

Adding a delay to wait until the server has updated the selected avatar before updating the UI. Without the delay the cache busting remains insufficient to capture the new avatar.
With less than 800 ms, we can still see the issue (see [comment](https://github.com/Automattic/Gravatar-SDK-Android/pull/350/files#r1787548797)).
Hopefully, we can remove this delay soon.

### Testing Steps

Use the steps in #459 

Check if the avatar in the demo app gets refreshed
