### PR TITLE
Making some access to OAuthSession static

### DIFF
--- a/Demo/Demo/Gravatar-UIKit-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/DemoQuickEditorViewController.swift
@@ -125,18 +125,16 @@ final class DemoQuickEditorViewController: UIViewController {
 
     func updateLogoutButton(_ button: UIButton? = nil) {
         guard let savedEmail else { return }
-        let session = OAuthSession()
         let button = button ?? logoutButton
         UIView.animate {
-            button.isHidden = !session.hasSession(with: Email(savedEmail))
+            button.isHidden = !OAuthSession.hasSession(with: Email(savedEmail))
             button.alpha = button.isHidden ? 0 : 1
         }
     }
 
     func logout() {
         guard let savedEmail else { return }
-        let session = OAuthSession()
-        session.deleteSession(with: Email(savedEmail))
+        OAuthSession.deleteSession(with: Email(savedEmail))
         updateLogoutButton()
     }
 

--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
@@ -1,6 +1,8 @@
 import AuthenticationServices
 
 public struct OAuthSession: Sendable {
+    private static let shared = OAuthSession()
+
     private let storage: SecureStorage
     private let authenticationSession: AuthenticationSession
     private let snakeCaseDecoder: JSONDecoder = {
@@ -14,13 +16,12 @@ public struct OAuthSession: Sendable {
         self.storage = storage
     }
 
-    public init() {
-        self.authenticationSession = OldAuthenticationSession()
-        self.storage = Keychain()
-    }
-
     public func hasSession(with email: Email) -> Bool {
         (try? storage.secret(with: email.rawValue) ?? nil) != nil
+    }
+
+    public static func hasSession(with email: Email) -> Bool {
+        shared.hasSession(with: email)
     }
 
     func hasValidSession(with email: Email) -> Bool {
@@ -43,6 +44,10 @@ public struct OAuthSession: Sendable {
 
     public func deleteSession(with email: Email) {
         try? storage.deleteSecret(with: email.rawValue)
+    }
+
+    public static func deleteSession(with email: Email) {
+        shared.deleteSession(with: email)
     }
 
     func sessionToken(with email: Email) -> KeychainToken? {


### PR DESCRIPTION
Closes #

### Description

On this PR we change a bit the public interface of OAuthSession.
Since the session and tokens are globally stored and accessed, we've added static functions to access `hasSession` and `deleteSession` methods.

### Testing Steps

- On UIKit Demo app.
- Go to Quick Editor demo.
- Log in to the quick editor.
- Close the editor.
- Open it again.
  - Check that it remembers the last session.
- Close the editor.
- Tap on the `Logout` button.
- Open the editor.
  - Check that it request for authorization again. 