### PR TITLE
Remove open-api deprecations

### DIFF
--- a/Sources/Gravatar/OpenApi/Generated/AssociatedResponse.swift
+++ b/Sources/Gravatar/OpenApi/Generated/AssociatedResponse.swift
@@ -4,32 +4,18 @@ struct AssociatedResponse: Codable, Hashable, Sendable {
     /// Whether the entity is associated with the account.
     private(set) var associated: Bool
 
-    @available(*, deprecated, message: "init will become internal on the next release")
     init(associated: Bool) {
         self.associated = associated
     }
 
-    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
     enum CodingKeys: String, CodingKey, CaseIterable {
-        case associated
-    }
-
-    enum InternalCodingKeys: String, CodingKey, CaseIterable {
         case associated
     }
 
     // Encodable protocol methods
 
     func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(associated, forKey: .associated)
-    }
-
-    // Decodable protocol methods
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
-
-        associated = try container.decode(Bool.self, forKey: .associated)
     }
 }

--- a/Sources/Gravatar/OpenApi/Generated/Avatar.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Avatar.swift
@@ -23,7 +23,6 @@ package struct Avatar: Codable, Hashable, Sendable {
     /// Whether the image is currently selected as the provided selected email's avatar.
     package private(set) var selected: Bool?
 
-    @available(*, deprecated, message: "init will become internal on the next release")
     package init(imageId: String, imageUrl: String, rating: Rating, updatedDate: Date, altText: String, selected: Bool? = nil) {
         self.imageId = imageId
         self.imageUrl = imageUrl
@@ -33,17 +32,7 @@ package struct Avatar: Codable, Hashable, Sendable {
         self.selected = selected
     }
 
-    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
-    package enum CodingKeys: String, CodingKey, CaseIterable {
-        case imageId = "image_id"
-        case imageUrl = "image_url"
-        case rating
-        case updatedDate = "updated_date"
-        case altText = "alt_text"
-        case selected
-    }
-
-    enum InternalCodingKeys: String, CodingKey, CaseIterable {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case imageId = "image_id"
         case imageUrl = "image_url"
         case rating
@@ -55,25 +44,12 @@ package struct Avatar: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     package func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(imageId, forKey: .imageId)
         try container.encode(imageUrl, forKey: .imageUrl)
         try container.encode(rating, forKey: .rating)
         try container.encode(updatedDate, forKey: .updatedDate)
         try container.encode(altText, forKey: .altText)
         try container.encodeIfPresent(selected, forKey: .selected)
-    }
-
-    // Decodable protocol methods
-
-    package init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
-
-        imageId = try container.decode(String.self, forKey: .imageId)
-        imageUrl = try container.decode(String.self, forKey: .imageUrl)
-        rating = try container.decode(Rating.self, forKey: .rating)
-        updatedDate = try container.decode(Date.self, forKey: .updatedDate)
-        altText = try container.decode(String.self, forKey: .altText)
-        selected = try container.decodeIfPresent(Bool.self, forKey: .selected)
     }
 }

--- a/Sources/Gravatar/OpenApi/Generated/CryptoWalletAddress.swift
+++ b/Sources/Gravatar/OpenApi/Generated/CryptoWalletAddress.swift
@@ -8,19 +8,12 @@ public struct CryptoWalletAddress: Codable, Hashable, Sendable {
     /// The wallet address for the crypto currency.
     public private(set) var address: String
 
-    @available(*, deprecated, message: "init will become internal on the next release")
-    public init(label: String, address: String) {
+    init(label: String, address: String) {
         self.label = label
         self.address = address
     }
 
-    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
-    public enum CodingKeys: String, CodingKey, CaseIterable {
-        case label
-        case address
-    }
-
-    enum InternalCodingKeys: String, CodingKey, CaseIterable {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case label
         case address
     }
@@ -28,17 +21,8 @@ public struct CryptoWalletAddress: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(label, forKey: .label)
         try container.encode(address, forKey: .address)
-    }
-
-    // Decodable protocol methods
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
-
-        label = try container.decode(String.self, forKey: .label)
-        address = try container.decode(String.self, forKey: .address)
     }
 }

--- a/Sources/Gravatar/OpenApi/Generated/GalleryImage.swift
+++ b/Sources/Gravatar/OpenApi/Generated/GalleryImage.swift
@@ -8,24 +8,12 @@ public struct GalleryImage: Codable, Hashable, Sendable {
     /// The image alt text.
     public private(set) var altText: String?
 
-    @available(*, deprecated, message: "init will become internal on the next release")
-    public init(url: String) {
-        self.url = url
-    }
-
-    // NOTE: This init is maintained manually.
-    // Avoid deleting this init until the deprecation of is applied.
     init(url: String, altText: String? = nil) {
         self.url = url
         self.altText = altText
     }
 
-    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
-    public enum CodingKeys: String, CodingKey, CaseIterable {
-        case url
-    }
-
-    enum InternalCodingKeys: String, CodingKey, CaseIterable {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case url
         case altText = "alt_text"
     }
@@ -33,17 +21,8 @@ public struct GalleryImage: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(url, forKey: .url)
         try container.encodeIfPresent(altText, forKey: .altText)
-    }
-
-    // Decodable protocol methods
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
-
-        url = try container.decode(String.self, forKey: .url)
-        altText = try container.decodeIfPresent(String.self, forKey: .altText)
     }
 }

--- a/Sources/Gravatar/OpenApi/Generated/Interest.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Interest.swift
@@ -8,19 +8,12 @@ public struct Interest: Codable, Hashable, Sendable {
     /// The name of the interest.
     public private(set) var name: String
 
-    @available(*, deprecated, message: "init will become internal on the next release")
-    public init(id: Int, name: String) {
+    init(id: Int, name: String) {
         self.id = id
         self.name = name
     }
 
-    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
-    public enum CodingKeys: String, CodingKey, CaseIterable {
-        case id
-        case name
-    }
-
-    enum InternalCodingKeys: String, CodingKey, CaseIterable {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case id
         case name
     }
@@ -28,17 +21,8 @@ public struct Interest: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(name, forKey: .name)
-    }
-
-    // Decodable protocol methods
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
-
-        id = try container.decode(Int.self, forKey: .id)
-        name = try container.decode(String.self, forKey: .name)
     }
 }

--- a/Sources/Gravatar/OpenApi/Generated/Language.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Language.swift
@@ -12,23 +12,14 @@ public struct Language: Codable, Hashable, Sendable {
     /// The order of the language in the user's profile.
     public private(set) var order: Int
 
-    @available(*, deprecated, message: "init will become internal on the next release")
-    public init(code: String, name: String, isPrimary: Bool, order: Int) {
+    init(code: String, name: String, isPrimary: Bool, order: Int) {
         self.code = code
         self.name = name
         self.isPrimary = isPrimary
         self.order = order
     }
 
-    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
-    public enum CodingKeys: String, CodingKey, CaseIterable {
-        case code
-        case name
-        case isPrimary = "is_primary"
-        case order
-    }
-
-    enum InternalCodingKeys: String, CodingKey, CaseIterable {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case code
         case name
         case isPrimary = "is_primary"
@@ -38,21 +29,10 @@ public struct Language: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(code, forKey: .code)
         try container.encode(name, forKey: .name)
         try container.encode(isPrimary, forKey: .isPrimary)
         try container.encode(order, forKey: .order)
-    }
-
-    // Decodable protocol methods
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
-
-        code = try container.decode(String.self, forKey: .code)
-        name = try container.decode(String.self, forKey: .name)
-        isPrimary = try container.decode(Bool.self, forKey: .isPrimary)
-        order = try container.decode(Int.self, forKey: .order)
     }
 }

--- a/Sources/Gravatar/OpenApi/Generated/Link.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Link.swift
@@ -8,19 +8,12 @@ public struct Link: Codable, Hashable, Sendable {
     /// The URL to the link.
     public private(set) var url: String
 
-    @available(*, deprecated, message: "init will become internal on the next release")
-    public init(label: String, url: String) {
+    init(label: String, url: String) {
         self.label = label
         self.url = url
     }
 
-    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
-    public enum CodingKeys: String, CodingKey, CaseIterable {
-        case label
-        case url
-    }
-
-    enum InternalCodingKeys: String, CodingKey, CaseIterable {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case label
         case url
     }
@@ -28,17 +21,8 @@ public struct Link: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(label, forKey: .label)
         try container.encode(url, forKey: .url)
-    }
-
-    // Decodable protocol methods
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
-
-        label = try container.decode(String.self, forKey: .label)
-        url = try container.decode(String.self, forKey: .url)
     }
 }

--- a/Sources/Gravatar/OpenApi/Generated/ModelError.swift
+++ b/Sources/Gravatar/OpenApi/Generated/ModelError.swift
@@ -8,19 +8,12 @@ struct ModelError: Codable, Hashable, Sendable {
     /// The error code for the error message
     private(set) var code: String?
 
-    @available(*, deprecated, message: "init will become internal on the next release")
     init(error: String, code: String? = nil) {
         self.error = error
         self.code = code
     }
 
-    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
     enum CodingKeys: String, CodingKey, CaseIterable {
-        case error
-        case code
-    }
-
-    enum InternalCodingKeys: String, CodingKey, CaseIterable {
         case error
         case code
     }
@@ -28,17 +21,8 @@ struct ModelError: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(error, forKey: .error)
         try container.encodeIfPresent(code, forKey: .code)
-    }
-
-    // Decodable protocol methods
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
-
-        error = try container.decode(String.self, forKey: .error)
-        code = try container.decodeIfPresent(String.self, forKey: .code)
     }
 }

--- a/Sources/Gravatar/OpenApi/Generated/Profile.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Profile.swift
@@ -53,51 +53,6 @@ public struct Profile: Codable, Hashable, Sendable {
     /// The date the user registered their account. This is only provided in authenticated API requests.
     public private(set) var registrationDate: Date?
 
-    @available(*, deprecated, message: "init will become internal on the next release")
-    public init(
-        hash: String,
-        displayName: String,
-        profileUrl: String,
-        avatarUrl: String,
-        avatarAltText: String,
-        location: String,
-        description: String,
-        jobTitle: String,
-        company: String,
-        verifiedAccounts: [VerifiedAccount],
-        pronunciation: String,
-        pronouns: String,
-        links: [Link]? = nil,
-        payments: ProfilePayments? = nil,
-        contactInfo: ProfileContactInfo? = nil,
-        gallery: [GalleryImage]? = nil,
-        numberVerifiedAccounts: Int? = nil,
-        lastProfileEdit: Date? = nil,
-        registrationDate: Date? = nil
-    ) {
-        self.hash = hash
-        self.displayName = displayName
-        self.profileUrl = profileUrl
-        self.avatarUrl = avatarUrl
-        self.avatarAltText = avatarAltText
-        self.location = location
-        self.description = description
-        self.jobTitle = jobTitle
-        self.company = company
-        self.verifiedAccounts = verifiedAccounts
-        self.pronunciation = pronunciation
-        self.pronouns = pronouns
-        self.links = links
-        self.payments = payments
-        self.contactInfo = contactInfo
-        self.gallery = gallery
-        self.numberVerifiedAccounts = numberVerifiedAccounts
-        self.lastProfileEdit = lastProfileEdit
-        self.registrationDate = registrationDate
-    }
-
-    // NOTE: This init is maintained manually.
-    // Avoid deleting this init until the deprecation is applied.
     init(
         hash: String,
         displayName: String,
@@ -152,36 +107,7 @@ public struct Profile: Codable, Hashable, Sendable {
         self.registrationDate = registrationDate
     }
 
-    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
-    public enum CodingKeys: String, CodingKey, CaseIterable {
-        case hash
-        case displayName = "display_name"
-        case profileUrl = "profile_url"
-        case avatarUrl = "avatar_url"
-        case avatarAltText = "avatar_alt_text"
-        case location
-        case description
-        case jobTitle = "job_title"
-        case company
-        case verifiedAccounts = "verified_accounts"
-        case pronunciation
-        case pronouns
-        case timezone
-        case languages
-        case firstName = "first_name"
-        case lastName = "last_name"
-        case isOrganization = "is_organization"
-        case links
-        case interests
-        case payments
-        case contactInfo = "contact_info"
-        case gallery
-        case numberVerifiedAccounts = "number_verified_accounts"
-        case lastProfileEdit = "last_profile_edit"
-        case registrationDate = "registration_date"
-    }
-
-    enum InternalCodingKeys: String, CodingKey, CaseIterable {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case hash
         case displayName = "display_name"
         case profileUrl = "profile_url"
@@ -212,7 +138,7 @@ public struct Profile: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(hash, forKey: .hash)
         try container.encode(displayName, forKey: .displayName)
         try container.encode(profileUrl, forKey: .profileUrl)
@@ -238,37 +164,5 @@ public struct Profile: Codable, Hashable, Sendable {
         try container.encodeIfPresent(numberVerifiedAccounts, forKey: .numberVerifiedAccounts)
         try container.encodeIfPresent(lastProfileEdit, forKey: .lastProfileEdit)
         try container.encodeIfPresent(registrationDate, forKey: .registrationDate)
-    }
-
-    // Decodable protocol methods
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
-
-        hash = try container.decode(String.self, forKey: .hash)
-        displayName = try container.decode(String.self, forKey: .displayName)
-        profileUrl = try container.decode(String.self, forKey: .profileUrl)
-        avatarUrl = try container.decode(String.self, forKey: .avatarUrl)
-        avatarAltText = try container.decode(String.self, forKey: .avatarAltText)
-        location = try container.decode(String.self, forKey: .location)
-        description = try container.decode(String.self, forKey: .description)
-        jobTitle = try container.decode(String.self, forKey: .jobTitle)
-        company = try container.decode(String.self, forKey: .company)
-        verifiedAccounts = try container.decode([VerifiedAccount].self, forKey: .verifiedAccounts)
-        pronunciation = try container.decode(String.self, forKey: .pronunciation)
-        pronouns = try container.decode(String.self, forKey: .pronouns)
-        timezone = try container.decodeIfPresent(String.self, forKey: .timezone)
-        languages = try container.decodeIfPresent([Language].self, forKey: .languages)
-        firstName = try container.decodeIfPresent(String.self, forKey: .firstName)
-        lastName = try container.decodeIfPresent(String.self, forKey: .lastName)
-        isOrganization = try container.decodeIfPresent(Bool.self, forKey: .isOrganization)
-        links = try container.decodeIfPresent([Link].self, forKey: .links)
-        interests = try container.decodeIfPresent([Interest].self, forKey: .interests)
-        payments = try container.decodeIfPresent(ProfilePayments.self, forKey: .payments)
-        contactInfo = try container.decodeIfPresent(ProfileContactInfo.self, forKey: .contactInfo)
-        gallery = try container.decodeIfPresent([GalleryImage].self, forKey: .gallery)
-        numberVerifiedAccounts = try container.decodeIfPresent(Int.self, forKey: .numberVerifiedAccounts)
-        lastProfileEdit = try container.decodeIfPresent(Date.self, forKey: .lastProfileEdit)
-        registrationDate = try container.decodeIfPresent(Date.self, forKey: .registrationDate)
     }
 }

--- a/Sources/Gravatar/OpenApi/Generated/ProfileContactInfo.swift
+++ b/Sources/Gravatar/OpenApi/Generated/ProfileContactInfo.swift
@@ -16,8 +16,7 @@ public struct ProfileContactInfo: Codable, Hashable, Sendable {
     /// The URL to the user's calendar.
     public private(set) var calendar: String?
 
-    @available(*, deprecated, message: "init will become internal on the next release")
-    public init(
+    init(
         homePhone: String? = nil,
         workPhone: String? = nil,
         cellPhone: String? = nil,
@@ -33,17 +32,7 @@ public struct ProfileContactInfo: Codable, Hashable, Sendable {
         self.calendar = calendar
     }
 
-    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
-    public enum CodingKeys: String, CodingKey, CaseIterable {
-        case homePhone = "home_phone"
-        case workPhone = "work_phone"
-        case cellPhone = "cell_phone"
-        case email
-        case contactForm = "contact_form"
-        case calendar
-    }
-
-    enum InternalCodingKeys: String, CodingKey, CaseIterable {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case homePhone = "home_phone"
         case workPhone = "work_phone"
         case cellPhone = "cell_phone"
@@ -55,25 +44,12 @@ public struct ProfileContactInfo: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(homePhone, forKey: .homePhone)
         try container.encodeIfPresent(workPhone, forKey: .workPhone)
         try container.encodeIfPresent(cellPhone, forKey: .cellPhone)
         try container.encodeIfPresent(email, forKey: .email)
         try container.encodeIfPresent(contactForm, forKey: .contactForm)
         try container.encodeIfPresent(calendar, forKey: .calendar)
-    }
-
-    // Decodable protocol methods
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
-
-        homePhone = try container.decodeIfPresent(String.self, forKey: .homePhone)
-        workPhone = try container.decodeIfPresent(String.self, forKey: .workPhone)
-        cellPhone = try container.decodeIfPresent(String.self, forKey: .cellPhone)
-        email = try container.decodeIfPresent(String.self, forKey: .email)
-        contactForm = try container.decodeIfPresent(String.self, forKey: .contactForm)
-        calendar = try container.decodeIfPresent(String.self, forKey: .calendar)
     }
 }

--- a/Sources/Gravatar/OpenApi/Generated/ProfilePayments.swift
+++ b/Sources/Gravatar/OpenApi/Generated/ProfilePayments.swift
@@ -8,19 +8,12 @@ public struct ProfilePayments: Codable, Hashable, Sendable {
     /// A list of crypto currencies the user accepts.
     public private(set) var cryptoWallets: [CryptoWalletAddress]
 
-    @available(*, deprecated, message: "init will become internal on the next release")
-    public init(links: [Link], cryptoWallets: [CryptoWalletAddress]) {
+    init(links: [Link], cryptoWallets: [CryptoWalletAddress]) {
         self.links = links
         self.cryptoWallets = cryptoWallets
     }
 
-    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
-    public enum CodingKeys: String, CodingKey, CaseIterable {
-        case links
-        case cryptoWallets = "crypto_wallets"
-    }
-
-    enum InternalCodingKeys: String, CodingKey, CaseIterable {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case links
         case cryptoWallets = "crypto_wallets"
     }
@@ -28,17 +21,8 @@ public struct ProfilePayments: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(links, forKey: .links)
         try container.encode(cryptoWallets, forKey: .cryptoWallets)
-    }
-
-    // Decodable protocol methods
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
-
-        links = try container.decode([Link].self, forKey: .links)
-        cryptoWallets = try container.decode([CryptoWalletAddress].self, forKey: .cryptoWallets)
     }
 }

--- a/Sources/Gravatar/OpenApi/Generated/SetEmailAvatarRequest.swift
+++ b/Sources/Gravatar/OpenApi/Generated/SetEmailAvatarRequest.swift
@@ -4,22 +4,18 @@ struct SetEmailAvatarRequest: Codable, Hashable, Sendable {
     /// The email SHA256 hash to set the avatar for.
     private(set) var emailHash: String
 
-    enum InternalCodingKeys: String, CodingKey, CaseIterable {
+    init(emailHash: String) {
+        self.emailHash = emailHash
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case emailHash = "email_hash"
     }
 
     // Encodable protocol methods
 
     func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(emailHash, forKey: .emailHash)
-    }
-
-    // Decodable protocol methods
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
-
-        emailHash = try container.decode(String.self, forKey: .emailHash)
     }
 }

--- a/Sources/Gravatar/OpenApi/Generated/VerifiedAccount.swift
+++ b/Sources/Gravatar/OpenApi/Generated/VerifiedAccount.swift
@@ -14,19 +14,6 @@ public struct VerifiedAccount: Codable, Hashable, Sendable {
     /// Whether the verified account is hidden from the user's profile.
     public private(set) var isHidden: Bool
 
-    // NOTE: This init is maintained manually.
-    // Avoid deleting this init until the deprecation of is applied.
-    @available(*, deprecated, message: "init will become internal on the next release")
-    public init(serviceLabel: String, serviceIcon: String, url: String) {
-        self.init(
-            serviceType: "",
-            serviceLabel: serviceLabel,
-            serviceIcon: serviceIcon,
-            url: url,
-            isHidden: false
-        )
-    }
-
     init(serviceType: String, serviceLabel: String, serviceIcon: String, url: String, isHidden: Bool) {
         self.serviceType = serviceType
         self.serviceLabel = serviceLabel
@@ -35,14 +22,7 @@ public struct VerifiedAccount: Codable, Hashable, Sendable {
         self.isHidden = isHidden
     }
 
-    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
-    public enum CodingKeys: String, CodingKey, CaseIterable {
-        case serviceLabel = "service_label"
-        case serviceIcon = "service_icon"
-        case url
-    }
-
-    enum InternalCodingKeys: String, CodingKey, CaseIterable {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case serviceType = "service_type"
         case serviceLabel = "service_label"
         case serviceIcon = "service_icon"
@@ -53,23 +33,11 @@ public struct VerifiedAccount: Codable, Hashable, Sendable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(serviceType, forKey: .serviceType)
         try container.encode(serviceLabel, forKey: .serviceLabel)
         try container.encode(serviceIcon, forKey: .serviceIcon)
         try container.encode(url, forKey: .url)
         try container.encode(isHidden, forKey: .isHidden)
-    }
-
-    // Decodable protocol methods
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
-
-        serviceType = try container.decode(String.self, forKey: .serviceType)
-        serviceLabel = try container.decode(String.self, forKey: .serviceLabel)
-        serviceIcon = try container.decode(String.self, forKey: .serviceIcon)
-        url = try container.decode(String.self, forKey: .url)
-        isHidden = try container.decode(Bool.self, forKey: .isHidden)
     }
 }

--- a/openapi/modelObject.mustache
+++ b/openapi/modelObject.mustache
@@ -51,18 +51,14 @@
 {{/allVars}}
 {{#hasVars}}
 
-{{! DEPRECARED public init }}
-    @available(*, deprecated, message: "init will become internal on the next release")
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init({{#allVars}}{{{name}}}: {{#vendorExtensions.x-null-encodable}}NullEncodable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-null-encodable}}{{^vendorExtensions.x-null-encodable}}{{{datatypeWithEnum}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}}{{/vendorExtensions.x-null-encodable}}{{#defaultValue}} = {{#vendorExtensions.x-null-encodable}}{{{vendorExtensions.x-null-encodable-default-value}}}{{/vendorExtensions.x-null-encodable}}{{^vendorExtensions.x-null-encodable}}{{{.}}}{{/vendorExtensions.x-null-encodable}}{{/defaultValue}}{{^defaultValue}}{{^required}} = {{#vendorExtensions.x-null-encodable}}.encodeNull{{/vendorExtensions.x-null-encodable}}{{^vendorExtensions.x-null-encodable}}nil{{/vendorExtensions.x-null-encodable}}{{/required}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/allVars}}) {
+    init({{#allVars}}{{{name}}}: {{#vendorExtensions.x-null-encodable}}NullEncodable<{{{datatypeWithEnum}}}>{{/vendorExtensions.x-null-encodable}}{{^vendorExtensions.x-null-encodable}}{{{datatypeWithEnum}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}}{{/vendorExtensions.x-null-encodable}}{{#defaultValue}} = {{#vendorExtensions.x-null-encodable}}{{{vendorExtensions.x-null-encodable-default-value}}}{{/vendorExtensions.x-null-encodable}}{{^vendorExtensions.x-null-encodable}}{{{.}}}{{/vendorExtensions.x-null-encodable}}{{/defaultValue}}{{^defaultValue}}{{^required}} = {{#vendorExtensions.x-null-encodable}}.encodeNull{{/vendorExtensions.x-null-encodable}}{{^vendorExtensions.x-null-encodable}}nil{{/vendorExtensions.x-null-encodable}}{{/required}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/allVars}}) {
         {{#allVars}}
         self.{{{name}}} = {{{name}}}
         {{/allVars}}
     }
 {{/hasVars}}
 
-{{! DEPRECARED public coding keys }}
-    @available(*, deprecated, message: "CodingKeys will become internal on the next release.")
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum CodingKeys: {{#hasVars}}String, {{/hasVars}}CodingKey, CaseIterable {
+    internal enum CodingKeys: {{#hasVars}}String, {{/hasVars}}CodingKey, CaseIterable {
         {{#allVars}}
         case {{{name}}}{{#vendorExtensions.x-codegen-escaped-property-name}} = "{{{baseName}}}"{{/vendorExtensions.x-codegen-escaped-property-name}}
         {{/allVars}}
@@ -82,41 +78,11 @@
             additionalProperties[key] = newValue
         }
     }{{/additionalPropertiesType}}{{/generateModelAdditionalProperties}}
-
-
-
-{{!----- BEGINNING OF INTERNAL CODING KEYS ------ }}
-{{! When the public CodingKeys get removed, we can rename this one back to "CodingKeys", making it internal }}
-
-    internal enum InternalCodingKeys: {{#hasVars}}String, {{/hasVars}}CodingKey, CaseIterable {
-        {{#allVars}}
-        case {{{name}}}{{#vendorExtensions.x-codegen-escaped-property-name}} = "{{{baseName}}}"{{/vendorExtensions.x-codegen-escaped-property-name}}
-        {{/allVars}}
-    }{{#generateModelAdditionalProperties}}{{#additionalPropertiesType}}
-
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} {{#readonlyProperties}}private(set) {{/readonlyProperties}}var additionalProperties: [String: {{{additionalPropertiesType}}}] = [:]
-
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} subscript(key: String) -> {{{additionalPropertiesType}}}? {
-        get {
-            if let value = additionalProperties[key] {
-                return value
-            }
-            return nil
-        }
-
-        set {
-            additionalProperties[key] = newValue
-        }
-    }{{/additionalPropertiesType}}{{/generateModelAdditionalProperties}}
-
-{{!----- END OF INTERNAL CODING KEYS ------ }}
-
-
 
     // Encodable protocol methods
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: InternalCodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         {{#allVars}}
         {{#vendorExtensions.x-null-encodable}}
         switch {{{name}}} {
@@ -137,18 +103,7 @@
     }
 
     {{#generateModelAdditionalProperties}}
-
-    // Decodable protocol methods
-
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: InternalCodingKeys.self)
-
-        {{#allVars}}
-        {{{name}}} = try container.decode{{#required}}{{#isNullable}}IfPresent{{/isNullable}}{{/required}}{{^required}}IfPresent{{/required}}({{{datatypeWithEnum}}}.self, forKey: .{{{name}}})
-        {{/allVars}}
-    }
     {{/generateModelAdditionalProperties}}
-
 
     {{^objcCompatible}}{{#useClasses}}{{#vendorExtensions.x-swift-hashable}}
 


### PR DESCRIPTION
Closes #

### Description

Removing open-api deprecations and its custom generator code.

The only things left on manual up-keeping are the access control changes.

### Testing Steps

- Run the UIKit demo app
- Test the Profile Fetch demo screen
- Run the SwiftUI demo app
- Test the Quick Editor demo app