### PR TITLE
Fix RemoteSVGView crash

### DIFF
--- a/Sources/GravatarUI/ProfileView/AccountIconWebView/RemoteSVGView.swift
+++ b/Sources/GravatarUI/ProfileView/AccountIconWebView/RemoteSVGView.swift
@@ -20,11 +20,6 @@ class RemoteSVGButton: UIControl, WKNavigationDelegate {
     private var iconURL: URL?
     private static let cache: NSCache<NSString, NSString> = .init()
 
-    init(iconSize: CGSize) {
-        self.iconSize = iconSize
-        super.init()
-    }
-
     private lazy var webView: WKWebView = {
         let webView = WKWebView()
         webView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
Closes #

### Description

Fixes a crash when opening the RemoteSVGView demo screen on UIKit demo app.

### Testing Steps

- Run UIKit demo app
- Open the RemoteSVGView demo screen.
  - Check that the icons load as expected. 