### PR TITLE
QE: Add empty check for the profile card field

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
@@ -29,9 +29,11 @@ struct AvatarPickerProfileView: View {
                     Text(model.displayName)
                         .font(.title3)
                         .fontWeight(.bold)
-                    Text(model.location)
-                        .font(.footnote)
-                        .foregroundColor(Color(UIColor.secondaryLabel))
+                    if !model.location.isEmpty {
+                        Text(model.location)
+                            .font(.footnote)
+                            .foregroundColor(Color(UIColor.secondaryLabel))
+                    }
                     Button(Localized.viewProfileButtonTitle) {
                         viewProfileAction?()
                     }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
@@ -39,6 +39,7 @@ struct AvatarPickerProfileView: View {
                     }
                     .font(.footnote)
                     .foregroundColor(Color(UIColor.label))
+                    .padding(.init(top: .DS.Padding.half, leading: 0, bottom: 0, trailing: 0))
                 }
             } else {
                 emptyViews()


### PR DESCRIPTION
Closes #478 

### Description

Fixes the reported bug. 

Before can be seen here: https://github.com/Automattic/Gravatar-SDK-iOS/issues/478#issuecomment-2402046592

After: 

<img width="300" alt="Screenshot 2024-10-09 at 15 25 55" src="https://github.com/user-attachments/assets/d9b9fce3-e3dc-4f85-81c5-fac4164816e1">


### Testing Steps

Omit the location from your profile 

Open the QE with the SwiftUI Demo app:
Observe that there's no excess space between the "View profile" button and name