### PR TITLE
Add localization progress check and linting of localized strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ fastlane/README.md
 fastlane/report.xml
 fastlane/test_output
 
+# SwiftGen (part of wpmreleasetoolkit)
+vendor/swiftgen
+
 # Other
 openapi-generator/
 Demo/Demo/Secrets.swift

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,7 +14,7 @@ XCODEPROJ_PATH = File.join(PROJECT_ROOT_FOLDER, 'Gravatar-Demo.xcodeproj')
 DEMO_APPS_SOURCES_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'Demo')
 XCCONFIG_PROTOTYPE_BUILD_SWIFTUI = File.join(DEMO_APPS_SOURCES_FOLDER, 'Gravatar-SwiftUI-Demo', 'Gravatar-SwiftUI-Demo.Release.xcconfig')
 XCCONFIG_PROTOTYPE_BUILD_UIKIT = File.join(DEMO_APPS_SOURCES_FOLDER, 'Gravatar-UIKit-Demo', 'Gravatar-UIKit-Demo.Release.xcconfig')
-COMMON_XCARGS = ['-skipPackagePluginValidation'] # Allow SwiftPM plugins (e.g. swiftlint) called from Xcode to be used on CI without prior manual approval
+COMMON_XCARGS = ['-skipPackagePluginValidation'].freeze # Allow SwiftPM plugins (e.g. swiftlint) called from Xcode to be used on CI without prior manual approval
 
 GITHUB_REPO = 'Automattic/Gravatar-SDK-iOS'
 GITHUB_URL = "https://github.com/#{GITHUB_REPO}".freeze

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -64,6 +64,11 @@ platform :ios do
     SOURCES_TO_LOCALIZE.each do |source|
       next if source.gp_project_url.nil?
 
+      check_translation_progress(
+        glotpress_url: source.gp_project_url,
+        abort_on_violations: false
+      )
+
       ios_download_strings_files_from_glotpress(
         project_url: source.gp_project_url,
         locales: GLOTPRESS_TO_LPROJ_APP_LOCALE_CODES,

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -75,6 +75,10 @@ platform :ios do
         download_dir: source.localizations_root
       )
 
+      ios_lint_localizations(
+        input_dir: source.localizations_root
+      )
+
       next if skip_commit
 
       paths_to_commit << source.localizations_root


### PR DESCRIPTION
Closes #

### Description

This adds two checks when downloading localizations:
1. Adds a progress check before downloading
   - If any localizations are less than 100% completed, you are prompted to continue or stop
2. Adds linting after localizations are downloaded:
   - Checks for duplicate keys (which shouldn't happen for us, since we are generating our `.strings` file from source)
   - Compares the localizations against the base language to find potential mismatches for the %s/%d/… parameter placeholders between locales.

### Testing Steps
Both of these functions are provided by the [wpmreleasetoolkit](https://github.com/wordpress-mobile/release-toolkit) fastlane plugin:
- [ios_lint_localizations](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb)
- [check_translation_progress](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/check_translation_progress.rb)

#### Testing the Progress Check
At the moment, our translations are below 100%.  So you can test the first part easily:
1. Run `make download-translations`
- [ ] OBSERVE that you see a prompt like the following:
```
The translations for the following languages are below the 100% threshold:
 - ar is at 55%.
 - de is at 55%.
 - es is at 55%.
 - fr is at 55%.
 - he is at 55%.
 - id is at 55%.
 - it is at 55%.
 - ja is at 55%.
 - ko is at 55%.
 - nl is at 55%.
 - pt-br is at 55%.
 - ru is at 55%.
 - sv is at 55%.
 - tr is at 55%.
 - zh-cn is at 55%.
 - zh-tw is at 55%.
Do you want to continue? (y/n)
```

#### Testing Localization Linting
This requires creating a linting problem.  Since we don't have one, you will have to create one, and then manually comment out the download portion of the lane:

1. Edit one of the non-English `Localizable.strings` files by creating a string with a number of placeholders that does NOT match the same string in the english `Localizable.strings` file.  At the moment, none of our source strings with placeholders have been localized.  So you will have to add one.  You can use the one below:
_Note: this sample string already has an extra `%@` placeholder (the original has one, this has two).  So you can paste this directly into one of the non-English `Localizable.strings` files._
```
/* A message describing the error and advising the user to login again to resolve the issue */
"AvatarPicker.ContentLoading.Failure.WrongEmailError.subtext" = "It looks like you used the wrong email to log in. Please try again using %@ %@ this time. Thanks!";
```
2. In the `fastlane/lanes/localization.rb` file, in the `:download_localized_strings` lane, comment out two functions (lines 67-76):
```ruby
   SOURCES_TO_LOCALIZE.each do |source|
      next if source.gp_project_url.nil?

      # check_translation_progress(
      #   glotpress_url: source.gp_project_url,
      #   abort_on_violations: false
      # )

      # ios_download_strings_files_from_glotpress(
      #   project_url: source.gp_project_url,
      #   locales: GLOTPRESS_TO_LPROJ_APP_LOCALE_CODES,
      #   download_dir: source.localizations_root
      # )

      ios_lint_localizations(
        input_dir: source.localizations_root
      )

      next if skip_commit

      paths_to_commit << source.localizations_root
    end
```
3. Save those changes
4. Run `make download-strings`
- [ ] OBSERVE that you see a failure with an error like the following:
```
[12:30:29]: Inconsistencies found between 'en' and 'fr':

`AvatarPicker.ContentLoading.Failure.WrongEmailError.subtext` expected placeholders for [String] but found [String,String] instead.
```