### PR TITLE
Fix podspec publishing

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,7 +47,6 @@ steps:
     plugins: [$CI_TOOLKIT]
     depends_on:
       - "test"
-      - "test_demo"
       - "validate"
       - "lint"
     if: build.tag != null


### PR DESCRIPTION
Closes #

### Description

This fixes a problem with the CI pipeline that prevents the podspecs from being published.

### Testing Steps

We're going to have to test this one in production:
1. Merge this PR into the release branch
2. Add a new release: `3.0.0-rc.2`
- [ ] OBSERVE that the `Publish Podspecs` step runs successfully in CI on the release branch (not this PR)