### PR TITLE
Fix the first time we upload avatar

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -185,6 +185,12 @@ class AvatarPickerViewModel: ObservableObject {
 
             let newModel = AvatarImageModel(id: avatar.id, source: .remote(url: avatar.url))
             grid.replaceModel(withID: localID, with: newModel)
+            if selectedAvatarURL == nil {
+                // server side has some auto-selection logic that kicks in
+                // during the avatar upload if there's no selected avatar.
+                // so let's get synced.
+                refresh()
+            }
         } catch ImageUploadError.responseError(reason: let .invalidHTTPStatusCode(response, errorPayload))
             where response.statusCode == HTTPStatus.badRequest.rawValue || response.statusCode == HTTPStatus.payloadTooLarge.rawValue
         {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -151,7 +151,8 @@ class AvatarPickerViewModel: ObservableObject {
     func upload(_ image: UIImage, shouldSquareImage: Bool) async {
         guard let authToken else { return }
 
-        // objectWillChange is the only way that makes the UI update when the initial state is empty.
+        // SwiftUI doesn't update the UI if the grid is empty.
+        // objectWillChange forces the update.
         objectWillChange.send()
         let squareImage = shouldSquareImage ? image.squared() : image
         let localID = UUID().uuidString

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -151,6 +151,8 @@ class AvatarPickerViewModel: ObservableObject {
     func upload(_ image: UIImage, shouldSquareImage: Bool) async {
         guard let authToken else { return }
 
+        // objectWillChange is the only way that makes the UI update when the initial state is empty.
+        objectWillChange.send()
         let squareImage = shouldSquareImage ? image.squared() : image
         let localID = UUID().uuidString
 


### PR DESCRIPTION
Closes #489 

### Description

For some reason SwiftUI doesn't update the UI during the avatar upload if the grid is empty. Applying `@Published` property wrapper doesn't help. So I am adding `objectWillChange.send()`.

We should also refresh the page to sync with the BE and get the latest avatar selection.

### Testing Steps

Delete all your avatars
Upload an avatar
Observe that the UI updates as expected
