### PR TITLE
Add support for setting uploaded image as avatar

### DIFF
--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -48,7 +48,8 @@ public struct AvatarService: Sendable {
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
     /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
     public func upload(_ image: UIImage, email: Email, accessToken: String) async throws -> URLResponse {
-        try await imageUploader.uploadImage(image, accessToken: accessToken, avatarSelection: .selectUploadedImage(for: email), additionalHTTPHeaders: nil).response
+        try await imageUploader.uploadImage(image, accessToken: accessToken, avatarSelection: .selectUploadedImage(for: email), additionalHTTPHeaders: nil)
+            .response
     }
 
     /// Uploads an image to be used as the user's Gravatar profile image, and returns the `URLResponse` of the network tasks asynchronously. Throws

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -40,7 +40,7 @@ public struct AvatarService: Sendable {
         return try await imageDownloader.fetchImage(with: gravatarURL, forceRefresh: options.forceRefresh, processingMethod: options.processingMethod)
     }
 
-    /// Uploads an image and sets it as the avatar of the given email's Gravatar profile. Returns the `URLResponse` of the network tasks asynchronously. Throws
+    /// Uploads an image and sets it as the avatar of the given email at Gravatar.com. Returns the `URLResponse` of the network tasks asynchronously. Throws
     /// ``ImageUploadError``.
     /// - Parameters:
     ///   - image: The image to be uploaded.

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -58,7 +58,6 @@ public struct AvatarService: Sendable {
     /// - Parameters:
     ///   - image: The image to be uploaded.
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
-    ///   - avatarSelection: How to handle avatar selection after uploading a new avatar
     /// - Returns: An asynchronously-delivered `AvatarType` instance, containing data of the newly created avatar.
     @discardableResult
     public func upload(_ image: UIImage, accessToken: String) async throws -> AvatarType {

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -47,7 +47,6 @@ public struct AvatarService: Sendable {
     ///   - email: An`Email` object
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
     /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
-    @available(*, deprecated, renamed: "upload(_:accessToken:)")
     public func upload(_ image: UIImage, email: Email, accessToken: String) async throws -> URLResponse {
         try await imageUploader.uploadImage(image, accessToken: accessToken, avatarSelection: .selectUploadedImage(for: email), additionalHTTPHeaders: nil).response
     }

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -40,7 +40,7 @@ public struct AvatarService: Sendable {
         return try await imageDownloader.fetchImage(with: gravatarURL, forceRefresh: options.forceRefresh, processingMethod: options.processingMethod)
     }
 
-    /// Uploads an image to be used as the user's Gravatar profile image, and returns the `URLResponse` of the network tasks asynchronously. Throws
+    /// Uploads an image and sets it as the avatar of the given email's Gravatar profile. Returns the `URLResponse` of the network tasks asynchronously. Throws
     /// ``ImageUploadError``.
     /// - Parameters:
     ///   - image: The image to be uploaded.

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -47,7 +47,6 @@ public struct AvatarService: Sendable {
     ///   - email: An`Email` object
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
     /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
-    @available(iOS, deprecated: 16.0, message: "Use 'upload(_:accessToken:) -> AvatarType' instead")
     public func upload(_ image: UIImage, email: Email, accessToken: String) async throws -> URLResponse {
         try await imageUploader.uploadImage(image, accessToken: accessToken, avatarSelection: .selectUploadedImage(for: email), additionalHTTPHeaders: nil)
             .response

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -47,6 +47,7 @@ public struct AvatarService: Sendable {
     ///   - email: An`Email` object
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
     /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
+    @discardableResult
     public func upload(_ image: UIImage, email: Email, accessToken: String) async throws -> URLResponse {
         try await imageUploader.uploadImage(image, accessToken: accessToken, avatarSelection: .selectUploadedImage(for: email), additionalHTTPHeaders: nil)
             .response

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -47,6 +47,7 @@ public struct AvatarService: Sendable {
     ///   - email: An`Email` object
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
     /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
+    @available(iOS, deprecated: 16.0, message: "Use 'upload(_:accessToken:) -> AvatarType' instead")
     public func upload(_ image: UIImage, email: Email, accessToken: String) async throws -> URLResponse {
         try await imageUploader.uploadImage(image, accessToken: accessToken, avatarSelection: .selectUploadedImage(for: email), additionalHTTPHeaders: nil)
             .response

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -45,10 +45,11 @@ public struct AvatarService: Sendable {
     /// - Parameters:
     ///   - image: The image to be uploaded.
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
+    ///   - avatarSelection: How to handle avatar selection after uploading a new avatar
     /// - Returns: An asynchronously-delivered `AvatarType` instance, containing data of the newly created avatar.
     @discardableResult
-    public func upload(_ image: UIImage, accessToken: String) async throws -> AvatarType {
-        let avatar: Avatar = try await upload(image, accessToken: accessToken)
+    public func upload(_ image: UIImage, accessToken: String, avatarSelection: AvatarSelection = .preserveSelection) async throws -> AvatarType {
+        let avatar: Avatar = try await upload(image, accessToken: accessToken, avatarSelection: avatarSelection)
         return avatar
     }
 
@@ -57,11 +58,12 @@ public struct AvatarService: Sendable {
     /// - Parameters:
     ///   - image: The image to be uploaded.
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
+    ///   - avatarSelection: How to handle avatar selection after uploading a new avatar
     /// - Returns: An asynchronously-delivered `Avatar` instance, containing data of the newly created avatar.
     @discardableResult
-    func upload(_ image: UIImage, accessToken: String) async throws -> Avatar {
+    func upload(_ image: UIImage, accessToken: String, avatarSelection: AvatarSelection) async throws -> Avatar {
         do {
-            let (data, _) = try await imageUploader.uploadImage(image, accessToken: accessToken, additionalHTTPHeaders: nil)
+            let (data, _) = try await imageUploader.uploadImage(image, accessToken: accessToken, avatarSelection: avatarSelection, additionalHTTPHeaders: nil)
             return try data.decode()
         } catch let error as ImageUploadError {
             throw error

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -44,12 +44,24 @@ public struct AvatarService: Sendable {
     /// ``ImageUploadError``.
     /// - Parameters:
     ///   - image: The image to be uploaded.
+    ///   - email: An`Email` object
+    ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
+    /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
+    @available(*, deprecated, renamed: "upload(_:accessToken:)")
+    public func upload(_ image: UIImage, email: Email, accessToken: String) async throws -> URLResponse {
+        try await imageUploader.uploadImage(image, accessToken: accessToken, avatarSelection: .selectUploadedImage(for: email), additionalHTTPHeaders: nil).response
+    }
+
+    /// Uploads an image to be used as the user's Gravatar profile image, and returns the `URLResponse` of the network tasks asynchronously. Throws
+    /// ``ImageUploadError``.
+    /// - Parameters:
+    ///   - image: The image to be uploaded.
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
     ///   - avatarSelection: How to handle avatar selection after uploading a new avatar
     /// - Returns: An asynchronously-delivered `AvatarType` instance, containing data of the newly created avatar.
     @discardableResult
-    public func upload(_ image: UIImage, accessToken: String, avatarSelection: AvatarSelection = .preserveSelection) async throws -> AvatarType {
-        let avatar: Avatar = try await upload(image, accessToken: accessToken, avatarSelection: avatarSelection)
+    public func upload(_ image: UIImage, accessToken: String) async throws -> AvatarType {
+        let avatar: Avatar = try await upload(image, accessToken: accessToken, avatarSelection: .preserveSelection)
         return avatar
     }
 

--- a/Sources/Gravatar/Network/Services/ImageUploadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploadService.swift
@@ -144,8 +144,8 @@ private enum APIVersion {
 
     var imageUploadURL: URL {
         switch self {
-        case .v1: URL(string: "https://api.gravatar.com/v1/upload-image")!
-        case .v3: URL(string: "https://api.gravatar.com/v3/me/avatars")!
+        case .v1: APIConfig.baseURL.appendingPathComponent("v1/upload-image")
+        case .v3: APIConfig.baseURL.appendingPathComponent("v3/me/avatars")
         }
     }
 }

--- a/Sources/Gravatar/Network/Services/ImageUploadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploadService.swift
@@ -53,7 +53,7 @@ struct ImageUploadService: ImageUploader {
 private func imageUploadBody(with imageData: Data, boundary: String, avatarSelection: AvatarSelection) -> Data {
     switch avatarSelection.supportedAPIVersion {
     case .v1:
-        var account: Email? = switch avatarSelection {
+        let account: Email? = switch avatarSelection {
         case .preserveSelection:
             nil
         case .selectUploadedImage(let email), .selectUploadedImageIfNoneSelected(let email):

--- a/Sources/Gravatar/Network/Services/ImageUploadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploadService.swift
@@ -12,7 +12,12 @@ struct ImageUploadService: ImageUploader {
     }
 
     @discardableResult
-    func uploadImage(_ image: UIImage, accessToken: String, additionalHTTPHeaders: [HTTPHeaderField]?) async throws -> (data: Data, response: HTTPURLResponse) {
+    func uploadImage(
+        _ image: UIImage,
+        accessToken: String,
+        avatarSelection: AvatarSelection = .preserveSelection,
+        additionalHTTPHeaders: [HTTPHeaderField]?
+    ) async throws -> (data: Data, response: HTTPURLResponse) {
         guard let data = image.jpegData(compressionQuality: 0.8) else {
             throw ImageUploadError.cannotConvertImageIntoData
         }

--- a/Sources/Gravatar/Network/Services/ImageUploadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploadService.swift
@@ -128,26 +128,7 @@ extension Data {
 
 extension URLRequest {
     fileprivate static func imageUploadRequest(with boundary: String, additionalHTTPHeaders: [HTTPHeaderField]?, apiVersion: APIVersion) -> URLRequest {
-        switch apiVersion {
-        case .v1: imageUploadRequestV1(with: boundary, additionalHTTPHeaders: additionalHTTPHeaders)
-        case .v3: imageUploadRequestV3(with: boundary, additionalHTTPHeaders: additionalHTTPHeaders)
-        }
-    }
-
-    fileprivate static func imageUploadRequestV1(with boundary: String, additionalHTTPHeaders: [HTTPHeaderField]?) -> URLRequest {
-        let url = URL(string: "https://api.gravatar.com/v1/upload-image")!
-        var request = URLRequest(url: url)
-        request.addValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-        request.httpMethod = "POST"
-        additionalHTTPHeaders?.forEach { headerTuple in
-            request.addValue(headerTuple.value, forHTTPHeaderField: headerTuple.name)
-        }
-        return request
-    }
-
-    fileprivate static func imageUploadRequestV3(with boundary: String, additionalHTTPHeaders: [HTTPHeaderField]?) -> URLRequest {
-        let url = URL(string: "https://api.gravatar.com/v3/me/avatars")!
-        var request = URLRequest(url: url)
+        var request = URLRequest(url: apiVersion.imageUploadURL)
         request.addValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.httpMethod = "POST"
         additionalHTTPHeaders?.forEach { headerTuple in
@@ -160,6 +141,13 @@ extension URLRequest {
 private enum APIVersion {
     case v1
     case v3
+
+    var imageUploadURL: URL {
+        switch self {
+        case .v1: URL(string: "https://api.gravatar.com/v1/upload-image")!
+        case .v3: URL(string: "https://api.gravatar.com/v3/me/avatars")!
+        }
+    }
 }
 
 extension AvatarSelection {

--- a/Sources/Gravatar/Network/Services/ImageUploader.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploader.swift
@@ -10,12 +10,14 @@ protocol ImageUploader: Sendable {
     ///   - image: The image to be uploaded.
     ///   - email: The user email account.
     ///   - accessToken: The authentication token for the user.
+    ///   - avatarSelection: How to handle avatar selection after uploading a new avatar
     ///   - additionalHTTPHeaders: Additional headers to add.
     /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
     @discardableResult
     func uploadImage(
         _ image: UIImage,
         accessToken: String,
+        avatarSelection: AvatarSelection,
         additionalHTTPHeaders: [HTTPHeaderField]?
     ) async throws -> (data: Data, response: HTTPURLResponse)
 }

--- a/Sources/Gravatar/Options/AvatarSelection.swift
+++ b/Sources/Gravatar/Options/AvatarSelection.swift
@@ -1,5 +1,5 @@
 /// Defines how to handle avatar selection after uploading a new avatar
-public enum AvatarSelection: Equatable {
+enum AvatarSelection: Equatable {
     case preserveSelection
     case selectUploadedImage(for: Email)
     case selectUploadedImageIfNoneSelected(for: Email)

--- a/Sources/Gravatar/Options/AvatarSelection.swift
+++ b/Sources/Gravatar/Options/AvatarSelection.swift
@@ -1,0 +1,6 @@
+/// Defines how to handle avatar selection after uploading a new avatar
+public enum AvatarSelection {
+    case preserveSelection
+    case selectUploadedImage(for: Email)
+    case selectUploadedImageIfNoneSelected(for: Email)
+}

--- a/Sources/Gravatar/Options/AvatarSelection.swift
+++ b/Sources/Gravatar/Options/AvatarSelection.swift
@@ -1,6 +1,14 @@
 /// Defines how to handle avatar selection after uploading a new avatar
-public enum AvatarSelection {
+public enum AvatarSelection: Equatable {
     case preserveSelection
     case selectUploadedImage(for: Email)
     case selectUploadedImageIfNoneSelected(for: Email)
+
+    public static func allCases(for email: Email) -> [AvatarSelection] {
+        [
+            .preserveSelection,
+            .selectUploadedImage(for: email),
+            .selectUploadedImageIfNoneSelected(for: email),
+        ]
+    }
 }

--- a/Tests/GravatarTests/AvatarServiceTests.swift
+++ b/Tests/GravatarTests/AvatarServiceTests.swift
@@ -128,6 +128,57 @@ final class AvatarServiceTests: XCTestCase {
         XCTAssertEqual(request?.url?.query, expectedQuery)
         XCTAssertNotNil(imageResponse.image)
     }
+
+    // MARK: - Upload Tests using deprecated v1 API
+
+    func testV1UploadImage() async throws {
+        let successResponse = HTTPURLResponse.successResponse()
+        let sessionMock = URLSessionMock(returnData: "Success".data(using: .utf8)!, response: successResponse)
+        let service = avatarService(with: sessionMock)
+
+        let _ = try await service.upload(ImageHelper.testImage, email: Email(TestData.email), accessToken: "AccessToken")
+        let data = await sessionMock.uploadData
+        let uploadData = try XCTUnwrap(data)
+        XCTAssertTrue(
+            String(data: uploadData, encoding: .isoLatin1)!.contains(TestData.email),
+            "Multipart form data should use the raw email address instead of its hash"
+        )
+        let request = await sessionMock.request
+        XCTAssertEqual(request?.url?.absoluteString, "https://api.gravatar.com/v1/upload-image")
+        XCTAssertNotNil(request?.value(forHTTPHeaderField: "Authorization"))
+        XCTAssertEqual(request?.value(forHTTPHeaderField: "Authorization"), "Bearer AccessToken")
+        XCTAssertNotNil(request?.value(forHTTPHeaderField: "Content-Type"))
+        XCTAssertTrue(request?.value(forHTTPHeaderField: "Content-Type")?.hasPrefix("multipart/form-data; boundary=") ?? false)
+    }
+
+    func testV1UploadImageError() async throws {
+        let responseCode = 408
+        let successResponse = HTTPURLResponse.errorResponse(code: responseCode)
+        let sessionMock = URLSessionMock(returnData: "Error".data(using: .utf8)!, response: successResponse)
+        let service = avatarService(with: sessionMock)
+
+        do {
+            let _ = try await service.upload(ImageHelper.testImage, email: Email(TestData.email), accessToken: "AccessToken")
+            XCTFail("This should throw an error")
+        } catch ImageUploadError.responseError(reason: let reason) where reason.httpStatusCode == responseCode {
+            // Expected error has occurred.
+        } catch {
+            XCTFail("This should have thrown an invalidHTTPStatusCode with:\(responseCode)")
+        }
+    }
+
+    func testV1UploadImageDataError() async throws {
+        let successResponse = HTTPURLResponse.errorResponse(code: 408)
+        let sessionMock = URLSessionMock(returnData: "Error".data(using: .utf8)!, response: successResponse)
+        let service = avatarService(with: sessionMock)
+
+        do {
+            let _ = try await service.upload(UIImage(), email: Email(TestData.email), accessToken: "AccessToken")
+            XCTFail("This should throw an error")
+        } catch let error as ImageUploadError {
+            XCTAssertEqual(error, ImageUploadError.cannotConvertImageIntoData)
+        }
+    }
 }
 
 private func avatarService(with session: URLSessionProtocol, cache: ImageCaching? = nil) -> AvatarService {


### PR DESCRIPTION
Closes #491 

### Description

This restores support for uploading images via the `v1` API.

### Testing Steps
