### PR TITLE
Bringing back old image upload method

### DIFF
--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -47,7 +47,6 @@ public struct AvatarService: Sendable {
     ///   - email: An`Email` object
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
     /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
-    @available(*, deprecated, renamed: "upload(_:accessToken:)")
     public func upload(_ image: UIImage, email: Email, accessToken: String) async throws -> URLResponse {
         try await imageUploader.uploadImage(image, accessToken: accessToken, avatarSelection: .selectUploadedImage(for: email), additionalHTTPHeaders: nil).response
     }

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -44,12 +44,24 @@ public struct AvatarService: Sendable {
     /// ``ImageUploadError``.
     /// - Parameters:
     ///   - image: The image to be uploaded.
+    ///   - email: An`Email` object
+    ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
+    /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
+    @available(*, deprecated, renamed: "upload(_:accessToken:)")
+    public func upload(_ image: UIImage, email: Email, accessToken: String) async throws -> URLResponse {
+        try await imageUploader.uploadImage(image, accessToken: accessToken, avatarSelection: .selectUploadedImage(for: email), additionalHTTPHeaders: nil).response
+    }
+
+    /// Uploads an image to be used as the user's Gravatar profile image, and returns the `URLResponse` of the network tasks asynchronously. Throws
+    /// ``ImageUploadError``.
+    /// - Parameters:
+    ///   - image: The image to be uploaded.
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
     ///   - avatarSelection: How to handle avatar selection after uploading a new avatar
     /// - Returns: An asynchronously-delivered `AvatarType` instance, containing data of the newly created avatar.
     @discardableResult
-    public func upload(_ image: UIImage, accessToken: String, avatarSelection: AvatarSelection = .preserveSelection) async throws -> AvatarType {
-        let avatar: Avatar = try await upload(image, accessToken: accessToken, avatarSelection: avatarSelection)
+    public func upload(_ image: UIImage, accessToken: String) async throws -> AvatarType {
+        let avatar: Avatar = try await upload(image, accessToken: accessToken, avatarSelection: .preserveSelection)
         return avatar
     }
 

--- a/Sources/Gravatar/Options/AvatarSelection.swift
+++ b/Sources/Gravatar/Options/AvatarSelection.swift
@@ -1,5 +1,5 @@
 /// Defines how to handle avatar selection after uploading a new avatar
-public enum AvatarSelection: Equatable {
+enum AvatarSelection: Equatable {
     case preserveSelection
     case selectUploadedImage(for: Email)
     case selectUploadedImageIfNoneSelected(for: Email)


### PR DESCRIPTION
Closes #

### Description

This PR continues the work on https://github.com/Automattic/Gravatar-SDK-iOS/pull/492 and targets it.

- Bringing back old good `upload(_:email: accessToken:) -> URLResponse`, which uses the v1 upload endpoint
- Removing `avatarSelection` from the v3 image upload method.
- AvatarSelection is now internal.

`upload(_:email: accessToken:) -> URLResponse`
and
`upload(_:accessToken:) -> AvatarType`
use the v1 and v3 endpoints respectively.

### Testing Steps
