### PR TITLE
Use `.gravatarBlue` for selected avatar's border

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
@@ -34,7 +34,7 @@ struct AvatarPickerAvatarView: View {
         .aspectRatio(1, contentMode: .fill)
         .shape(
             RoundedRectangle(cornerRadius: AvatarGridConstants.avatarCornerRadius),
-            borderColor: .accentColor,
+            borderColor: Color(uiColor: .gravatarBlue),
             borderWidth: shouldSelect() ? AvatarGridConstants.selectedBorderWidth : 0
         )
         .overlay {


### PR DESCRIPTION
Closes #

### Description

Something I noticed during the Jetpack integration is that we use `.accentColor` for the selection border, and that can vary from app to app: 

<img src="https://github.com/user-attachments/assets/acb6a6da-8f16-403f-bb98-9fdfa154b0f3" width=300/>

We don't want that, we want to use `.gravatarBlue` according to designs.

### Testing Steps

Just check the border in the demo app and verify it's `.gravatarBlue`, it's slightly different than the default accent color.

