### PR TITLE
Fix keyboard covering cropper

### DIFF
--- a/Sources/GravatarUI/Base/UIApplication+Additions.swift
+++ b/Sources/GravatarUI/Base/UIApplication+Additions.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+extension UIApplication {
+    func dismissKeyboard() {
+        sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/SystemImagePickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/SystemImagePickerView.swift
@@ -89,7 +89,9 @@ private struct ImagePicker<Label, ImageEditor: ImageEditorView>: View where Labe
     }
 
     private func pickerDidSelectImage(_ item: ImagePickerItem) {
-        UIApplication.shared.dismissKeyboard()
+        Task {
+            await UIApplication.shared.dismissKeyboard()
+        }
         imagePickerSelectedItem = item
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/SystemImagePickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/SystemImagePickerView.swift
@@ -89,6 +89,7 @@ private struct ImagePicker<Label, ImageEditor: ImageEditorView>: View where Labe
     }
 
     private func pickerDidSelectImage(_ item: ImagePickerItem) {
+        UIApplication.shared.dismissKeyboard()
         imagePickerSelectedItem = item
     }
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/Gravatar-SDK-iOS/issues/497

### Description

Fixes the issue described in https://github.com/Automattic/Gravatar-SDK-iOS/issues/497
Dismissing the iOS PhotoPicker's keyboard directly doesn't seem possible in SwiftUI so i added a piece of code to force the first responder to resign by sending an action to the shared application.

### Testing Steps

Follow the steps in: https://github.com/Automattic/Gravatar-SDK-iOS/issues/497
