### PR TITLE
Show close button when external token is expired

### DIFF
--- a/Demo/Demo/Gravatar-UIKit-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/DemoQuickEditorViewController.swift
@@ -201,7 +201,8 @@ final class DemoQuickEditorViewController: UIViewController {
 
 extension DemoQuickEditorViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
-        if textField == emailField, let emailText = textField.text, Email(emailText).isValid {
+        guard textField == emailField else { return }
+        if let emailText = textField.text, Email(emailText).isValid {
             fetchProfile(with: emailText)
             showButton.isEnabled = true
         } else {

--- a/Demo/Demo/Gravatar-UIKit-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/DemoQuickEditorViewController.swift
@@ -225,6 +225,11 @@ extension DemoQuickEditorViewController: UITextFieldDelegate {
             savedToken = textField.text
         }
     }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
 }
 
 extension Email {

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -76,7 +76,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
                 isPresented: $isPresented,
                 contentLayoutProvider: contentLayoutProvider,
                 customImageEditor: customImageEditor,
-                tokenErrorHandler: {
+                tokenErrorHandler: fetchedToken == nil ? nil : {
                     oauthSession.markSessionAsExpired(with: email)
                     performAuthentication()
                 },

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -76,7 +76,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
                 isPresented: $isPresented,
                 contentLayoutProvider: contentLayoutProvider,
                 customImageEditor: customImageEditor,
-                tokenErrorHandler: fetchedToken == nil ? nil : {
+                tokenErrorHandler: externalToken != nil ? nil : {
                     oauthSession.markSessionAsExpired(with: email)
                     performAuthentication()
                 },


### PR DESCRIPTION
Closes #

### Description

This PR fixes an issue where, when an external token is expired, the SDK would try to re-authenticate the user.
Now it will prompt the user to close the QE instead. 


https://github.com/user-attachments/assets/72fd7607-8220-4941-be5d-400e3b045bd8


### Testing Steps

- Open UIKit demo app.
- Go to Quick Editor screen.
- Tap on Log out button if it's present.
- Introduce an expired (or wrong) token.
- Open the Quick Editor.
  - Check that the action button says `Close` .
  - Check that the Quick Editor is closed after taping on Close button.