### PR TITLE
Adding helpful extensions to `AvatarPickerConfiguration`

### DIFF
--- a/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
@@ -26,7 +26,22 @@ public struct AvatarPickerConfiguration: Sendable {
 }
 
 extension AvatarPickerConfiguration {
+    /// Configuration where the avatars collection scrolls horizontally, and the modal sheet height is equal to the content height.
     public static var horizontalInstrinsicHeight: AvatarPickerConfiguration { .init(contentLayout: .horizontal(presentationStyle: .intrinsicHeight)) }
+    /// Configuration where the avatars collection scrolls vertically, and the modal sheet height covers the screen.
+    /// This is equal to a `large` sheet detent.
     public static var verticalLarge: AvatarPickerConfiguration { .init(contentLayout: .vertical(presentationStyle: .large)) }
-    public static var verticalScrollable: AvatarPickerConfiguration { .init(contentLayout: .vertical(presentationStyle: .expandableMedium())) }
+    /// Configuration where the avatars collection scrolls vertically, with a medium detent height.
+    /// By default, scrolling the sheet upwards will transition the sheet presentation to a large detent.
+    /// - Parameters:
+    ///   - initialFraction: The initial detent height, as a fraction of the maximum height.
+    ///   - prioritizeScrollOverResize: When set to `true` scrolling the avatar collection vertically will take presedent.
+    ///   Otherwise, the modal sheet resize will take presedence.
+    /// - Returns: A configured ``AvatarPickerConfiguration`` instance.
+    public static func verticalMediumExpandable(initialFraction: CGFloat = 0.7, prioritizeScrollOverResize: Bool = false) -> AvatarPickerConfiguration {
+        .init(contentLayout: .vertical(presentationStyle: .expandableMedium(
+            initialFraction: initialFraction,
+            prioritizeScrollOverResize: prioritizeScrollOverResize
+        )))
+    }
 }

--- a/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
@@ -24,3 +24,9 @@ public struct AvatarPickerConfiguration: Sendable {
         contentLayout: .horizontal(presentationStyle: .intrinsicHeight)
     )
 }
+
+extension AvatarPickerConfiguration {
+    public static var horizontalInstrinsicHeight: AvatarPickerConfiguration { .init(contentLayout: .horizontal(presentationStyle: .intrinsicHeight)) }
+    public static var verticalLarge: AvatarPickerConfiguration { .init(contentLayout: .vertical(presentationStyle: .large)) }
+    public static var verticalScrollable: AvatarPickerConfiguration { .init(contentLayout: .vertical(presentationStyle: .expandableMedium())) }
+}

--- a/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
@@ -168,7 +168,7 @@ public struct QuickEditorPresenter {
         animated: Bool = true,
         completion: (() -> Void)? = nil,
         onAvatarUpdated: (() -> Void)? = nil,
-        onDismiss: @escaping () -> Void
+        onDismiss: (() -> Void)? = nil
     ) {
         let quickEditor = QuickEditorViewController(
             email: email,


### PR DESCRIPTION
Closes #

### Description

Small set of extensions on `AvatarPickerConfiguration` to make the scope configuration easier.

Now it can be written as:
`scope: .avatarPicker(.verticalScrollable),`
instead of:
`scope: .avatarPicker(.init(contentLayout: .vertical(presentationStyle: .expandableMedium()))),`

Same for the other options.
If the developer want's to modify the defaults (i.e: Making content scrolling priority) they still can use the previous detailed definition.

### Testing Steps

Since this is syntax sugar, the best way to test it is in code:
- Go to `DemoQuickEditorViewController`
- On line 188, test the different extensions on the `AvatarPickerConfiguration`
