### PR TITLE
Remove unused client secret

### DIFF
--- a/Demo/Demo/Gravatar-SwiftUI-Demo/DemoApp.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/DemoApp.swift
@@ -25,7 +25,6 @@ struct DemoApp: App {
                 with: Secrets.apiKey,
                 oauthSecrets: .init(
                     clientID: Secrets.clientID,
-                    clientSecret: Secrets.clientSecret,
                     redirectURI: Secrets.redirectURI
                 )
             )

--- a/Demo/Demo/Gravatar-UIKit-Demo/AppDelegate.swift
+++ b/Demo/Demo/Gravatar-UIKit-Demo/AppDelegate.swift
@@ -10,7 +10,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 with: Secrets.apiKey,
                 oauthSecrets: .init(
                     clientID: Secrets.clientID,
-                    clientSecret: Secrets.clientSecret,
                     redirectURI: Secrets.redirectURI
                 )
             )

--- a/Sources/Gravatar/Configuration.swift
+++ b/Sources/Gravatar/Configuration.swift
@@ -4,15 +4,13 @@ import Foundation
 public actor Configuration {
     public struct OAuthSecrets: Sendable {
         package let clientID: String
-        package let clientSecret: String
         package let redirectURI: String
         package var callbackScheme: String {
             URLComponents(string: redirectURI)?.scheme ?? ""
         }
 
-        public init(clientID: String, clientSecret: String, redirectURI: String) {
+        public init(clientID: String, redirectURI: String) {
             self.clientID = clientID
-            self.clientSecret = clientSecret
             self.redirectURI = redirectURI
         }
     }

--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
@@ -140,14 +140,12 @@ extension OAuthError {
 private struct AccessTokenRequestParams: Encodable {
     let clientID: String
     let redirectURI: String
-    let clientSecret: String
     let grantType: String = "authorization_code"
     let code: String
 
     init(secrets: Configuration.OAuthSecrets, code: String) {
         clientID = secrets.clientID
         redirectURI = secrets.redirectURI
-        clientSecret = secrets.clientSecret
         self.code = code
     }
 }


### PR DESCRIPTION
Closes #

### Description

This PR removes the request of Client Secret on the secrets configuration, which is not needed as we use the `token` response OAuth configuration.

### Testing Steps
- Test the OAuth of the Quick Editor in both SwiftUI and UIKit demos.
