### PR TITLE
Add GravatarUI docs to the SPI documentation building

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -6,5 +6,5 @@
 version: 1
 builder:
     configs:
-    - documentation_targets: [Gravatar]
+    - documentation_targets: [Gravatar, GravatarUI]
       platform: ios


### PR DESCRIPTION
Closes #

### Description

This adds the `GravatarUI` docs back in to the SPI documentation building job.  It was originally removed in #302 as a test.

### Testing Steps

I believe the only way to test this is to merge it into a branch.  We can merge it into a `rc` branch/tag though before releasing  in the final release.