### PR TITLE
Fix concurrency warning about editingDidFinish

### DIFF
--- a/Demo/Demo/Gravatar-SwiftUI-Demo/TestImageCropper.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/TestImageCropper.swift
@@ -3,9 +3,9 @@ import GravatarUI
 
 struct TestImageCropper: View, ImageEditorView {
     var inputImage: UIImage
-    var editingDidFinish: ((UIImage) -> Void)
+    var editingDidFinish: (@Sendable (UIImage) -> Void)
     
-    init(inputImage: UIImage, editingDidFinish: @escaping (UIImage) -> Void) {
+    init(inputImage: UIImage, editingDidFinish: @escaping @Sendable (UIImage) -> Void) {
         self.inputImage = inputImage
         self.editingDidFinish = editingDidFinish
     }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/ImageEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/ImageEditorView.swift
@@ -8,17 +8,17 @@ public protocol ImageEditorView: View {
     var inputImage: UIImage { get }
 
     /// Callback to call when the editing is done. Pass the edited image here.
-    var editingDidFinish: (UIImage) -> Void { get set }
+    var editingDidFinish: @Sendable (UIImage) -> Void { get set }
 }
 
-public typealias ImageEditorBlock<ImageEditor: ImageEditorView> = (UIImage, _ editingDidFinish: @escaping (UIImage) -> Void) -> ImageEditor
+public typealias ImageEditorBlock<ImageEditor: ImageEditorView> = (UIImage, _ editingDidFinish: @escaping @Sendable (UIImage) -> Void) -> ImageEditor
 
 /// Because of how generics work, the compiler must resolve the image editor's concrete type.
 /// When its value is `nil` though, the compiler can't resolve the concrete type, and it complains. This type here is used to make the compiler happy when the
 /// passed value is `nil`.
 public struct NoCustomEditor: ImageEditorView {
     public var inputImage: UIImage
-    public var editingDidFinish: (UIImage) -> Void
+    public var editingDidFinish: @Sendable (UIImage) -> Void
 
     public var body: some View {
         EmptyView()

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/SystemImagePickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/SystemImagePickerView.swift
@@ -11,6 +11,7 @@ struct SystemImagePickerView<Label, ImageEditor: ImageEditorView>: View where La
     }
 }
 
+@MainActor
 private struct ImagePicker<Label, ImageEditor: ImageEditorView>: View where Label: View {
     enum SourceType: CaseIterable, Identifiable {
         case photoLibrary
@@ -50,11 +51,15 @@ private struct ImagePicker<Label, ImageEditor: ImageEditorView>: View where Labe
                 .sheet(item: $imagePickerSelectedItem, content: { item in
                     if let customEditor {
                         customEditor(item.image) { editedImage in
-                            self.onImageEdited(editedImage)
+                            Task {
+                                await self.onImageEdited(editedImage)
+                            }
                         }
                     } else {
                         ImageCropper(inputImage: item.image) { croppedImage in
-                            self.onImageEdited(croppedImage)
+                            Task {
+                                await self.onImageEdited(croppedImage)
+                            }
                         } onCancel: {
                             imagePickerSelectedItem = nil
                         }.ignoresSafeArea()
@@ -89,9 +94,7 @@ private struct ImagePicker<Label, ImageEditor: ImageEditorView>: View where Labe
     }
 
     private func pickerDidSelectImage(_ item: ImagePickerItem) {
-        Task {
-            await UIApplication.shared.dismissKeyboard()
-        }
+        UIApplication.shared.dismissKeyboard()
         imagePickerSelectedItem = item
     }
 }

--- a/Sources/GravatarUI/SwiftUI/ImageCropper.swift
+++ b/Sources/GravatarUI/SwiftUI/ImageCropper.swift
@@ -2,12 +2,12 @@ import SwiftUI
 
 struct ImageCropper: UIViewControllerRepresentable, ImageEditorView {
     let inputImage: UIImage
-    var editingDidFinish: (UIImage) -> Void
+    var editingDidFinish: @Sendable (UIImage) -> Void
     var onCancel: () -> Void
 
     typealias UIViewControllerType = UINavigationController
 
-    init(inputImage: UIImage, editingDidFinish: @escaping (UIImage) -> Void, onCancel: @escaping () -> Void) {
+    init(inputImage: UIImage, editingDidFinish: @escaping @Sendable (UIImage) -> Void, onCancel: @escaping () -> Void) {
         self.inputImage = inputImage
         self.editingDidFinish = editingDidFinish
         self.onCancel = onCancel


### PR DESCRIPTION
Closes #

### Description

<img width="1321" alt="Screenshot 2024-10-16 at 11 26 53" src="https://github.com/user-attachments/assets/08c0e580-5b9d-4bdd-9fa7-2229d811e7b4">

Swift implicitly assumes that editingDidFinish is an actor-isolated property(due to its use in a View protocol). To address this, we can explicitly mark the property as `@MainActor`, or alternatively, we can make editingDidFinish a `@Sendable` closure. I did the second which means we don't assume it must run on the main actor. 

And then i got a new warning in our ImagePicker:

<img width="890" alt="Screenshot 2024-10-16 at 12 01 19" src="https://github.com/user-attachments/assets/2e401e5e-bb8e-41ca-9911-dee921936129">

Even though ImagePicker is a View, the system this time doesn't automatically assume it runs on the main actor. So I added the `@MainActor` explicitly.

And then i got:

<img width="868" alt="Screenshot 2024-10-16 at 12 03 19" src="https://github.com/user-attachments/assets/09fcfe5a-b5ec-4e7e-8d86-96cf06b5ae6c">

Then i put the call inside `Task { ... }`

### Testing Steps

Test image picking & cropping.