### PR TITLE
Fix concurrency warning for avatarUpdatedHandler

### DIFF
--- a/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
@@ -35,7 +35,11 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
         isPresented: isPresented,
         customImageEditor: nil as NoCustomEditorBlock?,
         contentLayoutProvider: contentLayoutWithPresentation,
-        avatarUpdatedHandler: onAvatarUpdated
+        avatarUpdatedHandler: {
+            Task { @MainActor in
+                self.onAvatarUpdated?()
+            }
+        }
     ), onHeightChange: { [weak self] newHeight in
         guard let self else { return }
         if self.shouldAcceptHeight(newHeight) {


### PR DESCRIPTION
Closes #

### Description

<img width="1323" alt="Screenshot 2024-10-16 at 12 15 19" src="https://github.com/user-attachments/assets/8d13cb13-32ce-43a0-a9ad-c6115731edfd">

For consistency with the onDismiss handler i solved this by explicitly running the closure on the main actor. 

### Testing Steps

Observe that avatar selection is reflected on the background page in the UIKit demo app.