### PR TITLE
Solve warnings on xcode16

### DIFF
--- a/Demo/Demo/Gravatar-SwiftUI-Demo/TestImageCropper.swift
+++ b/Demo/Demo/Gravatar-SwiftUI-Demo/TestImageCropper.swift
@@ -3,7 +3,7 @@ import GravatarUI
 
 struct TestImageCropper: View, ImageEditorView {
     var inputImage: UIImage
-    var editingDidFinish: ((UIImage) -> Void)
+    var editingDidFinish: (@Sendable (UIImage) -> Void)
     
     init(inputImage: UIImage, editingDidFinish: @escaping (UIImage) -> Void) {
         self.inputImage = inputImage

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/ImageEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/ImageEditorView.swift
@@ -8,7 +8,7 @@ public protocol ImageEditorView: View {
     var inputImage: UIImage { get }
 
     /// Callback to call when the editing is done. Pass the edited image here.
-    var editingDidFinish: (UIImage) -> Void { get set }
+    var editingDidFinish: @Sendable (UIImage) -> Void { get set }
 }
 
 public typealias ImageEditorBlock<ImageEditor: ImageEditorView> = (UIImage, _ editingDidFinish: @escaping (UIImage) -> Void) -> ImageEditor
@@ -18,7 +18,7 @@ public typealias ImageEditorBlock<ImageEditor: ImageEditorView> = (UIImage, _ ed
 /// passed value is `nil`.
 public struct NoCustomEditor: ImageEditorView {
     public var inputImage: UIImage
-    public var editingDidFinish: (UIImage) -> Void
+    public var editingDidFinish: @Sendable (UIImage) -> Void
 
     public var body: some View {
         EmptyView()

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/SystemImagePickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/SystemImagePickerView.swift
@@ -54,7 +54,9 @@ private struct ImagePicker<Label, ImageEditor: ImageEditorView>: View where Labe
                         }
                     } else {
                         ImageCropper(inputImage: item.image) { croppedImage in
-                            self.onImageEdited(croppedImage)
+                            Task {
+                                await self.onImageEdited(croppedImage)
+                            }
                         } onCancel: {
                             imagePickerSelectedItem = nil
                         }.ignoresSafeArea()

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/SystemImagePickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/SystemImagePickerView.swift
@@ -91,7 +91,9 @@ private struct ImagePicker<Label, ImageEditor: ImageEditorView>: View where Labe
     }
 
     private func pickerDidSelectImage(_ item: ImagePickerItem) {
-        UIApplication.shared.dismissKeyboard()
+        Task {
+            await UIApplication.shared.dismissKeyboard()
+        }
         imagePickerSelectedItem = item
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/SystemImagePickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/SystemImagePicker/SystemImagePickerView.swift
@@ -91,9 +91,7 @@ private struct ImagePicker<Label, ImageEditor: ImageEditorView>: View where Labe
     }
 
     private func pickerDidSelectImage(_ item: ImagePickerItem) {
-        Task {
-            await UIApplication.shared.dismissKeyboard()
-        }
+        UIApplication.shared.dismissKeyboard()
         imagePickerSelectedItem = item
     }
 }

--- a/Sources/GravatarUI/SwiftUI/ImageCropper.swift
+++ b/Sources/GravatarUI/SwiftUI/ImageCropper.swift
@@ -2,12 +2,12 @@ import SwiftUI
 
 struct ImageCropper: UIViewControllerRepresentable, ImageEditorView {
     let inputImage: UIImage
-    var editingDidFinish: (UIImage) -> Void
+    var editingDidFinish: @Sendable (UIImage) -> Void
     var onCancel: () -> Void
 
     typealias UIViewControllerType = UINavigationController
 
-    init(inputImage: UIImage, editingDidFinish: @escaping (UIImage) -> Void, onCancel: @escaping () -> Void) {
+    init(inputImage: UIImage, editingDidFinish: @escaping @Sendable (UIImage) -> Void, onCancel: @escaping () -> Void) {
         self.inputImage = inputImage
         self.editingDidFinish = editingDidFinish
         self.onCancel = onCancel


### PR DESCRIPTION
Closes #

### Description

This PR takes the work from https://github.com/Automattic/Gravatar-SDK-iOS/pull/510, applying them using Xcode 16.

Xcode 16 finds less warnings than Xcode 15.4, so less changes are required.

### Testing Steps

- Test image picking & cropping.