### PR TITLE
Update secrets removing client secret

### DIFF
--- a/.configure
+++ b/.configure
@@ -1,7 +1,7 @@
 {
   "project_name": "Gravatar-SDK-iOS",
   "branch": "trunk",
-  "pinned_hash": "1761b0a77a5371f9127c5d0575c90f938d864537",
+  "pinned_hash": "c9d82e0decf9d2e47b37a3f4bbe1c4387b604297",
   "files_to_copy": [
     {
       "file": "iOS/GravatarSDK/Secrets.swift",

--- a/.configure-files/Secrets.swift.enc
+++ b/.configure-files/Secrets.swift.enc
@@ -1,2 +1,2 @@
-ømòâ	!u*ò¡;h™i¸ÄftH#L(¬ï~}H+^Ç*_(,ƒTg Ÿ¦ÞñÉ¥< ÷g¼fŸÖø.º¢ª.Úl)Ì™é—Z~×Oë(s9·1î_Òfhþê°éÕŽ•€½RRèÌÛ‡x6ˆ]d67²¬:C¸j2²ÈpÃ…2î/5èª"g{F}:-»H‡%kõ,-ï&©ÅVÊñ˜Äå’~•h#ƒ„ y0=õtŠQ¡Yç…®›h7 ¹Û¤DlýeD!9çÅûo€Æ÷´¯Ä1{`|6b`M‡ÔZþXQŽÒUÇRTª·BÀK0>—^ÿÐ(lÝ/—•Ð™¾‹)¢´U±gI<xP{ii¥ÞêÈ=aÜÃ‰$®¤½ÄìJÅzÔÒœ¥j”Ývõñ{H’r`ÓÑBX€´'XŽ¹¯:‹š¡Ñþpm
-¦Çõ	ul&‰P—w
+ømòâ	!u*ò¡;h™i¸ÄftH#L(¬ï~}H+^Ç*_(,ƒTg Ÿ¦ÞñÉ¥< ÷g¼fŸÖø.º¢ª.Úl)Ì™é—Z~×Oë(s9·1î_Òfhþê°éÕŽ•€½RRèÌÛ‡x6ˆ]d67²¬:C¸j2²ÈpÃ…2î/5èª"g{F}:-»H‡%kõ,-ï&©ÅVÊñ˜Äå’~•Å\r\(µÓk\ÎÕ¬‘q@—À¯•²9®k™‘m¿GUâ&j­2}˜ñ„r	&=Ê:.
+Fà/¬µí6ÇF/ŠÑ´1«h±‚"ÌÕ T

--- a/Demo/Demo/Secrets.tpl
+++ b/Demo/Demo/Secrets.tpl
@@ -6,6 +6,5 @@
 struct Secrets {
     static let apiKey: String? = nil
     static let clientID: String = ""
-    static let clientSecret: String = ""
     static let redirectURI: String = ""
 }


### PR DESCRIPTION
Closes #

### Description

This PR removes the not-needed `clientSecret` field from the Secrets struct.
Both the local template and the internal secrets repo has been updated.

### Testing Steps

- Install a CI build
- Check that the Quick Editor authentication works as expected.