### PR TITLE
Upload heic image format

### DIFF
--- a/Sources/Gravatar/Network/Services/ImageUploadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploadService.swift
@@ -18,7 +18,13 @@ struct ImageUploadService: ImageUploader {
         avatarSelection: AvatarSelection = .preserveSelection,
         additionalHTTPHeaders: [HTTPHeaderField]?
     ) async throws -> (data: Data, response: HTTPURLResponse) {
-        guard let data = image.jpegData(compressionQuality: 0.8) else {
+        guard let data: Data = {
+            if #available(iOS 17.0, *) {
+                image.heicData()
+            } else {
+                image.jpegData(compressionQuality: 0.8)
+            }
+        }() else {
             throw ImageUploadError.cannotConvertImageIntoData
         }
 


### PR DESCRIPTION
Closes #

### Description

Testing uploading HEIC instead of JPEG image format.

- The image size is constantly slightly better while the quality seems unchanged.
- The processing time, in all my tests, where either almost equal (slightly better), and some times considerably better.

In no case I saw neither bigger image size nor increased processing time.
The smaller processing time might be related to the smaller image size.

### Testing Steps

- Upload many images checking both image size and overall request time.
