### PR TITLE
Update gravatar icon's action to open the static URL `https://gravatar.com/profile`

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -125,7 +125,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
             title: Constants.title,
             actionButtonDisabled: model.profileModel?.profileURL == nil,
             onActionButtonPressed: {
-                openProfileInSafari()
+                openProfileEditInSafari()
             },
             onDoneButtonPressed: {
                 isPresented = false
@@ -356,6 +356,11 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
         safariURL = model.profileModel?.profileURL
     }
 
+    private func openProfileEditInSafari() {
+        guard let url = URL(string: "https://gravatar.com/profile") else { return }
+        safariURL = url
+    }
+    
     @ViewBuilder
     private func profileView() -> some View {
         VStack(alignment: .leading, content: {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -360,7 +360,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
         guard let url = URL(string: "https://gravatar.com/profile") else { return }
         safariURL = url
     }
-    
+
     @ViewBuilder
     private func profileView() -> some View {
         VStack(alignment: .leading, content: {


### PR DESCRIPTION
Closes #

### Description

This is to keep parity with https://github.com/Automattic/Gravatar-SDK-Android/pull/400 

### Testing Steps

Open the QE
Tap on the Gravatar icon on the navigation bar
It should take you to `https://gravatar.com/profile` (login appears first)