### PR TITLE
Handle https callback url

### DIFF
--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
@@ -84,7 +84,7 @@ public struct OAuthSession: Sendable {
             await shared.authenticationSession.cancel()
             postNotification(.authorizationFinished)
             return true
-        } catch OAuthError.couldNotParseAccessCode(email.rawValue) {
+        } catch OAuthError.couldNotParseAccessCode {
             return false // The URL was not a Gravatar callback URL with a token.
         } catch {
             await shared.authenticationSession.cancel()

--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OldAuthenticationSession+Environment.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OldAuthenticationSession+Environment.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 private struct OAuthSessionKey: EnvironmentKey {
-    static let defaultValue: OAuthSession = .init()
+    static let defaultValue: OAuthSession = .shared
 }
 
 extension EnvironmentValues {

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -73,6 +73,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
                 guard let error = notification.object as? OAuthError else { return }
                 Task { @MainActor in
                     oauthError = error
+                    onAuthenticationFinished()
                 }
             }
         }

--- a/Tests/GravatarUITests/OAuthSessionTests.swift
+++ b/Tests/GravatarUITests/OAuthSessionTests.swift
@@ -9,6 +9,9 @@ final class OAuthSessionTests: XCTestCase {
 }
 
 class AuthenticationSessionMock: AuthenticationSession, @unchecked Sendable {
+    func cancel() async {
+    }
+    
     let responseURL: URL
 
     init(responseURL: URL) {

--- a/Tests/GravatarUITests/OAuthSessionTests.swift
+++ b/Tests/GravatarUITests/OAuthSessionTests.swift
@@ -9,9 +9,8 @@ final class OAuthSessionTests: XCTestCase {
 }
 
 class AuthenticationSessionMock: AuthenticationSession, @unchecked Sendable {
-    func cancel() async {
-    }
-    
+    func cancel() async {}
+
     let responseURL: URL
 
     init(responseURL: URL) {


### PR DESCRIPTION
Closes #

### Description

This PR is aimed to solve the problem where a oauth callback used has a https scheme.
Since WP.com OAuth only supports `https`, custom schemes can not be used.

### Testing Steps

Pocket Casts PR for testing: https://github.com/Automattic/pocket-casts-ios/pull/2267
Tests on both SDK and PocketCasts:

- Cancel the OAuth flow before completing it.
  - See the `Login required` error screen.
- Full OAuth flow:
  - Open the quick editor and complete the OAuth flow successfully
- OAuth errors:
  - [Revoque](https://wordpress.com/me/security/connected-applications) the access token (it should appear as Pocket Casts for the Pocket Casts app).
  - Open the Quick Editor after it being logged in successfully.
    -  See the `Token expired` error.
  - Log in with a different email.
  - Open the Quick Editor. It should show the previous email on the web view.
  - Accept without changing the email.
    - See the `wrong email` error.


