### PR TITLE
Update image upload request with new options

### DIFF
--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -40,19 +40,6 @@ public struct AvatarService: Sendable {
         return try await imageDownloader.fetchImage(with: gravatarURL, forceRefresh: options.forceRefresh, processingMethod: options.processingMethod)
     }
 
-    /// Uploads an image and sets it as the avatar of the given email at Gravatar.com. Returns the `URLResponse` of the network tasks asynchronously. Throws
-    /// ``ImageUploadError``.
-    /// - Parameters:
-    ///   - image: The image to be uploaded.
-    ///   - email: An`Email` object
-    ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
-    /// - Returns: An asynchronously-delivered `URLResponse` instance, containing the response of the upload network task.
-    @discardableResult
-    public func upload(_ image: UIImage, email: Email, accessToken: String) async throws -> URLResponse {
-        try await imageUploader.uploadImage(image, accessToken: accessToken, avatarSelection: .selectUploadedImage(for: email), additionalHTTPHeaders: nil)
-            .response
-    }
-
     /// Uploads an image to be used as the user's Gravatar profile image, and returns the `URLResponse` of the network tasks asynchronously. Throws
     /// ``ImageUploadError``.
     /// - Parameters:
@@ -60,8 +47,8 @@ public struct AvatarService: Sendable {
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
     /// - Returns: An asynchronously-delivered `AvatarType` instance, containing data of the newly created avatar.
     @discardableResult
-    public func upload(_ image: UIImage, accessToken: String) async throws -> AvatarType {
-        let avatar: Avatar = try await upload(image, accessToken: accessToken, avatarSelection: .preserveSelection)
+    public func upload(_ image: UIImage, selectionBehavior: AvatarSelection, accessToken: String) async throws -> AvatarType {
+        let avatar: Avatar = try await upload(image, accessToken: accessToken, avatarSelection: selectionBehavior)
         return avatar
     }
 

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -48,7 +48,7 @@ public struct AvatarService: Sendable {
     /// - Returns: An asynchronously-delivered `AvatarType` instance, containing data of the newly created avatar.
     @discardableResult
     public func upload(_ image: UIImage, selectionBehavior: AvatarSelection, accessToken: String) async throws -> AvatarType {
-        let avatar: Avatar = try await upload(image, selectionBehavior: selectionBehavior, accessToken: accessToken)
+        let avatar: Avatar = try await upload(image, accessToken: accessToken, selectionBehavior: selectionBehavior)
         return avatar
     }
 
@@ -60,7 +60,7 @@ public struct AvatarService: Sendable {
     ///   - avatarSelection: How to handle avatar selection after uploading a new avatar
     /// - Returns: An asynchronously-delivered `Avatar` instance, containing data of the newly created avatar.
     @discardableResult
-    package func upload(_ image: UIImage, selectionBehavior: AvatarSelection, accessToken: String) async throws -> Avatar {
+    package func upload(_ image: UIImage, accessToken: String, selectionBehavior: AvatarSelection) async throws -> Avatar {
         do {
             let (data, _) = try await imageUploader.uploadImage(image, accessToken: accessToken, avatarSelection: selectionBehavior, additionalHTTPHeaders: nil)
             return try data.decode()

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -44,6 +44,7 @@ public struct AvatarService: Sendable {
     /// ``ImageUploadError``.
     /// - Parameters:
     ///   - image: The image to be uploaded.
+    ///   - avatarSelection: How to handle avatar selection after uploading a new avatar
     ///   - accessToken: The authentication token for the user. This is a WordPress.com OAuth2 access token.
     /// - Returns: An asynchronously-delivered `AvatarType` instance, containing data of the newly created avatar.
     @discardableResult

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -48,7 +48,7 @@ public struct AvatarService: Sendable {
     /// - Returns: An asynchronously-delivered `AvatarType` instance, containing data of the newly created avatar.
     @discardableResult
     public func upload(_ image: UIImage, selectionBehavior: AvatarSelection, accessToken: String) async throws -> AvatarType {
-        let avatar: Avatar = try await upload(image, accessToken: accessToken, avatarSelection: selectionBehavior)
+        let avatar: Avatar = try await upload(image, selectionBehavior: selectionBehavior, accessToken: accessToken)
         return avatar
     }
 
@@ -60,9 +60,9 @@ public struct AvatarService: Sendable {
     ///   - avatarSelection: How to handle avatar selection after uploading a new avatar
     /// - Returns: An asynchronously-delivered `Avatar` instance, containing data of the newly created avatar.
     @discardableResult
-    func upload(_ image: UIImage, accessToken: String, avatarSelection: AvatarSelection) async throws -> Avatar {
+    package func upload(_ image: UIImage, selectionBehavior: AvatarSelection, accessToken: String) async throws -> Avatar {
         do {
-            let (data, _) = try await imageUploader.uploadImage(image, accessToken: accessToken, avatarSelection: avatarSelection, additionalHTTPHeaders: nil)
+            let (data, _) = try await imageUploader.uploadImage(image, accessToken: accessToken, avatarSelection: selectionBehavior, additionalHTTPHeaders: nil)
             return try data.decode()
         } catch let error as ImageUploadError {
             throw error

--- a/Sources/Gravatar/Network/Services/ImageUploadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploadService.swift
@@ -41,11 +41,10 @@ struct ImageUploadService: ImageUploader {
         let request = URLRequest.imageUploadRequest(
             with: boundary,
             additionalHTTPHeaders: additionalHTTPHeaders,
-            apiVersion: avatarSelection.supportedAPIVersion
-        )
-        .settingAuthorizationHeaderField(with: accessToken)
-        // For the Multipart form/data, we need to send the email address, not the id of the emai address
-        let body = imageUploadBody(with: data, boundary: boundary, avatarSelection: avatarSelection)
+            selectionBehavior: avatarSelection
+        ).settingAuthorizationHeaderField(with: accessToken)
+
+        let body = imageUploadBody(with: data, boundary: boundary)
         do {
             return try await client.uploadData(with: request, data: body)
         } catch let error as HTTPClientError {
@@ -56,50 +55,8 @@ struct ImageUploadService: ImageUploader {
     }
 }
 
-private func imageUploadBody(with imageData: Data, boundary: String, avatarSelection: AvatarSelection) -> Data {
-    switch avatarSelection.supportedAPIVersion {
-    case .v1:
-        let account: Email? = switch avatarSelection {
-        case .preserveSelection:
-            nil
-        case .selectUploadedImage(let email), .selectUploadedImageIfNoneSelected(let email):
-            email
-        }
-
-        return imageUploadBodyV1(with: imageData, account: account, boundary: boundary)
-    case .v3:
-        return imageUploadBodyV3(with: imageData, boundary: boundary)
-    }
-}
-
-private func imageUploadBodyV1(with imageData: Data, account: Email?, boundary: String) -> Data {
-    enum UploadParameters {
-        static let contentType = "application/octet-stream"
-        static let filename = "profile.png"
-        static let imageKey = "filedata"
-        static let accountKey = "account"
-    }
-
-    var body = Data()
-
-    // Image Payload
-    body.append("--\(boundary)\r\n")
-    body.append("Content-Disposition: form-data; name=\(UploadParameters.imageKey); ")
-    body.append("filename=\(UploadParameters.filename)\r\n")
-    body.append("Content-Type: \(UploadParameters.contentType);\r\n\r\n")
-    body.append(imageData)
-    body.append("\r\n")
-
-    // Account Payload
-    if let email = account?.string {
-        body.append("--\(boundary)\r\n")
-        body.append("Content-Disposition: form-data; name=\"\(UploadParameters.accountKey)\"\r\n\r\n")
-        body.append("\(email)\r\n")
-    }
-    // EOF!
-    body.append("--\(boundary)--\r\n")
-
-    return body
+private func imageUploadBody(with imageData: Data, boundary: String) -> Data {
+    imageUploadBodyV3(with: imageData, boundary: boundary)
 }
 
 private func imageUploadBodyV3(with imageData: Data, boundary: String) -> Data {
@@ -133,8 +90,8 @@ extension Data {
 }
 
 extension URLRequest {
-    fileprivate static func imageUploadRequest(with boundary: String, additionalHTTPHeaders: [HTTPHeaderField]?, apiVersion: APIVersion) -> URLRequest {
-        var request = URLRequest(url: apiVersion.imageUploadURL)
+    fileprivate static func imageUploadRequest(with boundary: String, additionalHTTPHeaders: [HTTPHeaderField]?, selectionBehavior: AvatarSelection) -> URLRequest {
+        var request = URLRequest(url: .imageUploadURL.appendingQueryItems(for: selectionBehavior))
         request.addValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.httpMethod = "POST"
         additionalHTTPHeaders?.forEach { headerTuple in
@@ -144,23 +101,37 @@ extension URLRequest {
     }
 }
 
-private enum APIVersion {
-    case v1
-    case v3
+private extension URL {
+    static var imageUploadURL: URL {
+        APIConfig.baseURL.appendingPathComponent("v3/me/avatars")
+    }
+}
 
-    var imageUploadURL: URL {
-        switch self {
-        case .v1: APIConfig.baseURL.appendingPathComponent("v1/upload-image")
-        case .v3: APIConfig.baseURL.appendingPathComponent("v3/me/avatars")
+extension URL {
+    func appendingQueryItems(for selectionBehavior: AvatarSelection) -> URL {
+        let queryItems = selectionBehavior.queryItems
+        if #available(iOS 16.0, *) {
+            return self.appending(queryItems: queryItems)
+        } else {
+            var components = URLComponents(string: absoluteString)
+            components?.queryItems = queryItems
+            return components?.url ?? self
         }
     }
 }
 
 extension AvatarSelection {
-    fileprivate var supportedAPIVersion: APIVersion {
+    var queryItems: [URLQueryItem] {
         switch self {
-        case .selectUploadedImageIfNoneSelected, .selectUploadedImage: .v1
-        case .preserveSelection: .v3
+            case .selectUploadedImage(let email):
+                return [
+                    .init(name: "select_avatar", value: "true"),
+                    .init(name: "selected_email_hash", value: email.id)
+                ]
+            case .preserveSelection:
+                return [.init(name: "select_avatar", value: "false")]
+            case .selectUploadedImageIfNoneSelected(let email):
+                return [.init(name: "selected_email_hash", value: email.id)]
         }
     }
 }

--- a/Sources/Gravatar/Network/Services/ImageUploadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploadService.swift
@@ -90,7 +90,11 @@ extension Data {
 }
 
 extension URLRequest {
-    fileprivate static func imageUploadRequest(with boundary: String, additionalHTTPHeaders: [HTTPHeaderField]?, selectionBehavior: AvatarSelection) -> URLRequest {
+    fileprivate static func imageUploadRequest(
+        with boundary: String,
+        additionalHTTPHeaders: [HTTPHeaderField]?,
+        selectionBehavior: AvatarSelection
+    ) -> URLRequest {
         var request = URLRequest(url: .imageUploadURL.appendingQueryItems(for: selectionBehavior))
         request.addValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.httpMethod = "POST"
@@ -101,8 +105,8 @@ extension URLRequest {
     }
 }
 
-private extension URL {
-    static var imageUploadURL: URL {
+extension URL {
+    fileprivate static var imageUploadURL: URL {
         APIConfig.baseURL.appendingPathComponent("v3/me/avatars")
     }
 }
@@ -123,15 +127,15 @@ extension URL {
 extension AvatarSelection {
     var queryItems: [URLQueryItem] {
         switch self {
-            case .selectUploadedImage(let email):
-                return [
-                    .init(name: "select_avatar", value: "true"),
-                    .init(name: "selected_email_hash", value: email.id)
-                ]
-            case .preserveSelection:
-                return [.init(name: "select_avatar", value: "false")]
-            case .selectUploadedImageIfNoneSelected(let email):
-                return [.init(name: "selected_email_hash", value: email.id)]
+        case .selectUploadedImage(let email):
+            [
+                .init(name: "select_avatar", value: "true"),
+                .init(name: "selected_email_hash", value: email.id),
+            ]
+        case .preserveSelection:
+            [.init(name: "select_avatar", value: "false")]
+        case .selectUploadedImageIfNoneSelected(let email):
+            [.init(name: "selected_email_hash", value: email.id)]
         }
     }
 }

--- a/Sources/Gravatar/Network/Services/ImageUploadService.swift
+++ b/Sources/Gravatar/Network/Services/ImageUploadService.swift
@@ -56,10 +56,6 @@ struct ImageUploadService: ImageUploader {
 }
 
 private func imageUploadBody(with imageData: Data, boundary: String) -> Data {
-    imageUploadBodyV3(with: imageData, boundary: boundary)
-}
-
-private func imageUploadBodyV3(with imageData: Data, boundary: String) -> Data {
     enum UploadParameters {
         static let contentType = "application/octet-stream"
         static let filename = "profile"

--- a/Sources/Gravatar/Options/AvatarSelection.swift
+++ b/Sources/Gravatar/Options/AvatarSelection.swift
@@ -1,5 +1,5 @@
 /// Defines how to handle avatar selection after uploading a new avatar
-enum AvatarSelection: Equatable {
+public enum AvatarSelection: Equatable {
     case preserveSelection
     case selectUploadedImage(for: Email)
     case selectUploadedImageIfNoneSelected(for: Email)

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -138,6 +138,11 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
         .onChange(of: authToken ?? "") { newValue in
             model.update(authToken: newValue)
         }
+        .onChange(of: model.selectedAvatarURL) { newValue in
+            if !model.isFirstLoad {
+                notifyAvatarSelection()
+            }
+        }
     }
 
     private func header() -> some View {
@@ -315,16 +320,18 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
 
     func selectAvatar(with id: String) {
         Task {
-            if await model.selectAvatar(with: id) != nil {
-                if let avatarUpdatedHandler {
-                    // Delay to wait until the server has updated the selected avatar before updating the UI.
-                    // Without the delay the cache busting remains insufficient to capture the new avatar.
-                    // With less than 800 ms, we can still see the issue.
-                    // Hopefully, we can remove this delay soon.
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-                        avatarUpdatedHandler()
-                    }
-                }
+            await model.selectAvatar(with: id)
+        }
+    }
+
+    func notifyAvatarSelection() {
+        if let avatarUpdatedHandler {
+            // Delay to wait until the server has updated the selected avatar before updating the UI.
+            // Without the delay the cache busting remains insufficient to capture the new avatar.
+            // With less than 800 ms, we can still see the issue.
+            // Hopefully, we can remove this delay soon.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                avatarUpdatedHandler()
             }
         }
     }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -138,10 +138,8 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
         .onChange(of: authToken ?? "") { newValue in
             model.update(authToken: newValue)
         }
-        .onChange(of: model.selectedAvatarURL) { _ in
-            if !model.isFirstLoad {
-                notifyAvatarSelection()
-            }
+        .onChange(of: model.backendSelectedAvatarURL) { _ in
+            notifyAvatarSelection()
         }
     }
 
@@ -320,7 +318,9 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
 
     func selectAvatar(with id: String) {
         Task {
-            await model.selectAvatar(with: id)
+            if await model.selectAvatar(with: id) != nil {
+                notifyAvatarSelection()
+            }
         }
     }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -138,7 +138,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
         .onChange(of: authToken ?? "") { newValue in
             model.update(authToken: newValue)
         }
-        .onChange(of: model.selectedAvatarURL) { newValue in
+        .onChange(of: model.selectedAvatarURL) { _ in
             if !model.isFirstLoad {
                 notifyAvatarSelection()
             }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -184,10 +184,10 @@ class AvatarPickerViewModel: ObservableObject {
         guard let email else { return }
         let service = AvatarService()
         do {
-            let avatar: Avatar = try await service.upload(
+            let avatar = try await service.upload(
                 squareImage,
-                selectionBehavior: .selectUploadedImageIfNoneSelected(for: email),
-                accessToken: accessToken
+                accessToken: accessToken,
+                selectionBehavior: .selectUploadedImageIfNoneSelected(for: email)
             )
             ImageCache.shared.setEntry(.ready(squareImage), for: avatar.url)
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -26,7 +26,7 @@ class AvatarPickerViewModel: ObservableObject {
     }
 
     @Published var selectedAvatarURL: URL?
-    @Published var isFirstLoad: Bool = true
+    @Published var backendSelectedAvatarURL: URL?
     @Published private(set) var gridResponseStatus: Result<Void, Error>?
 
     let grid: AvatarGridModel = .init(avatars: [])
@@ -134,7 +134,6 @@ class AvatarPickerViewModel: ObservableObject {
             gridResponseStatus = .failure(error)
             isAvatarsLoading = false
         }
-        isFirstLoad = false
     }
 
     func fetchProfile() async {
@@ -197,6 +196,7 @@ class AvatarPickerViewModel: ObservableObject {
             if avatar.isSelected {
                 grid.selectAvatar(withID: avatar.id)
                 self.selectedAvatarURL = URL(string: avatar.url)
+                self.backendSelectedAvatarURL = URL(string: avatar.url)
             }
         } catch ImageUploadError.responseError(reason: let .invalidHTTPStatusCode(response, errorPayload))
             where response.statusCode == HTTPStatus.badRequest.rawValue || response.statusCode == HTTPStatus.payloadTooLarge.rawValue

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -26,7 +26,7 @@ class AvatarPickerViewModel: ObservableObject {
     }
 
     @Published var selectedAvatarURL: URL?
-    @Published var backendSelectedAvatarURL: URL?
+    @Published private(set) var backendSelectedAvatarURL: URL?
     @Published private(set) var gridResponseStatus: Result<Void, Error>?
 
     let grid: AvatarGridModel = .init(avatars: [])

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -184,7 +184,11 @@ class AvatarPickerViewModel: ObservableObject {
         guard let email else { return }
         let service = AvatarService()
         do {
-            let avatar: Avatar = try await service.upload(squareImage, selectionBehavior: .selectUploadedImageIfNoneSelected(for: email), accessToken: accessToken)
+            let avatar: Avatar = try await service.upload(
+                squareImage,
+                selectionBehavior: .selectUploadedImageIfNoneSelected(for: email),
+                accessToken: accessToken
+            )
             ImageCache.shared.setEntry(.ready(squareImage), for: avatar.url)
 
             let newModel = AvatarImageModel(id: avatar.id, source: .remote(url: avatar.url))

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -26,6 +26,7 @@ class AvatarPickerViewModel: ObservableObject {
     }
 
     @Published var selectedAvatarURL: URL?
+    @Published var isFirstLoad: Bool = true
     @Published private(set) var gridResponseStatus: Result<Void, Error>?
 
     let grid: AvatarGridModel = .init(avatars: [])
@@ -133,6 +134,7 @@ class AvatarPickerViewModel: ObservableObject {
             gridResponseStatus = .failure(error)
             isAvatarsLoading = false
         }
+        isFirstLoad = false
     }
 
     func fetchProfile() async {
@@ -182,16 +184,15 @@ class AvatarPickerViewModel: ObservableObject {
         guard let email else { return }
         let service = AvatarService()
         do {
-            let avatar = try await service.upload(squareImage, selectionBehavior: .selectUploadedImageIfNoneSelected(for: email), accessToken: accessToken)
+            let avatar: Avatar = try await service.upload(squareImage, selectionBehavior: .selectUploadedImageIfNoneSelected(for: email), accessToken: accessToken)
             ImageCache.shared.setEntry(.ready(squareImage), for: avatar.url)
 
             let newModel = AvatarImageModel(id: avatar.id, source: .remote(url: avatar.url))
             grid.replaceModel(withID: localID, with: newModel)
-            if selectedAvatarURL == nil {
-                // server side has some auto-selection logic that kicks in
-                // during the avatar upload if there's no selected avatar.
-                // so let's get synced.
-                refresh()
+
+            if avatar.isSelected {
+                grid.selectAvatar(withID: avatar.id)
+                self.selectedAvatarURL = URL(string: avatar.url)
             }
         } catch ImageUploadError.responseError(reason: let .invalidHTTPStatusCode(response, errorPayload))
             where response.statusCode == HTTPStatus.badRequest.rawValue || response.statusCode == HTTPStatus.payloadTooLarge.rawValue

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -179,9 +179,10 @@ class AvatarPickerViewModel: ObservableObject {
     }
 
     private func doUpload(squareImage: UIImage, localID: String, accessToken: String) async {
+        guard let email else { return }
         let service = AvatarService()
         do {
-            let avatar = try await service.upload(squareImage, accessToken: accessToken)
+            let avatar = try await service.upload(squareImage, selectionBehavior: .selectUploadedImageIfNoneSelected(for: email), accessToken: accessToken)
             ImageCache.shared.setEntry(.ready(squareImage), for: avatar.url)
 
             let newModel = AvatarImageModel(id: avatar.id, source: .remote(url: avatar.url))

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -626,12 +626,12 @@ paths:
         - name: selected_email_hash
           in: query
           description: >-
-            The sha256 hash of the email address used to determine which avatar
+            The SHA256 hash of the email address used to determine which avatar
             is selected. The 'selected' attribute in the avatar list will be set
             to 'true' for the avatar associated with this email.
           schema:
             type: string
-            default: null
+            default: ''
       responses:
         '200':
           description: Successful retrieval of avatars
@@ -655,6 +655,28 @@ paths:
       operationId: uploadAvatar
       security:
         - oauth: []
+      parameters:
+        - name: selected_email_hash
+          in: query
+          description: >-
+            The SHA256 hash of email. If provided, the uploaded image will be
+            selected as the avatar for this email.
+          required: false
+          schema:
+            type: string
+        - name: select_avatar
+          in: query
+          description: >-
+            Determines if the uploaded image should be set as the avatar for the
+            email. If not passed, the image is only selected as the email's
+            avatar if no previous avatar has been set. Accepts '1'/'true' to
+            always set the avatar or '0'/'false' to never set the avatar.
+          required: false
+          schema:
+            type:
+              - boolean
+              - 'null'
+            default: null
       requestBody:
         required: true
         content:


### PR DESCRIPTION
Closes #

### Description

This PR updates the image upload request with the new image selection options.

- The Quick Editor will automatically select an image when there's no image previously selected.
- The avatar selected callback will be called now also when a selection happens because of an image upload.
- openapi spec updated 👍 

### Testing Steps

#### Image selection options
- Run the UIKit app
- Go to Image Upload demo screen.
- Add email, token, and choose the 3 different options for image upload.
- Check on web that the image selection hapens as desired.

#### Image selected callback
- Run the UIKit app
- Go to Quick Editor.
- Open the Quick Editor on  Horizontal layout (to see the avatar changes)
  - Select an avatar
    -  See that the avatar on the background changes acordingly
  - Upload a new image.
    - Check that no selection happens. 
  - On web, delete the selected avatar to not have any selected
  - On the demo app, upload a new image
    - Check that the newly uploaded image gets selected on the QE.
    - Check that the avatar on the background changes acordingly.
