### PR TITLE
Replace the condition to `notifyAvatarSelection()` with an opt-in mechanism

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -138,10 +138,8 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
         .onChange(of: authToken ?? "") { newValue in
             model.update(authToken: newValue)
         }
-        .onChange(of: model.selectedAvatarURL) { _ in
-            if !model.isFirstLoad {
-                notifyAvatarSelection()
-            }
+        .onChange(of: model.backendSelectedAvatarURL) { _ in
+            notifyAvatarSelection()
         }
     }
 
@@ -320,7 +318,9 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
 
     func selectAvatar(with id: String) {
         Task {
-            await model.selectAvatar(with: id)
+            if await model.selectAvatar(with: id) != nil {
+                notifyAvatarSelection()
+            }
         }
     }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -26,7 +26,7 @@ class AvatarPickerViewModel: ObservableObject {
     }
 
     @Published var selectedAvatarURL: URL?
-    @Published var isFirstLoad: Bool = true
+    @Published var backendSelectedAvatarURL: URL?
     @Published private(set) var gridResponseStatus: Result<Void, Error>?
 
     let grid: AvatarGridModel = .init(avatars: [])
@@ -134,7 +134,6 @@ class AvatarPickerViewModel: ObservableObject {
             gridResponseStatus = .failure(error)
             isAvatarsLoading = false
         }
-        isFirstLoad = false
     }
 
     func fetchProfile() async {
@@ -197,6 +196,7 @@ class AvatarPickerViewModel: ObservableObject {
             if avatar.isSelected {
                 grid.selectAvatar(withID: avatar.id)
                 self.selectedAvatarURL = URL(string: avatar.url)
+                self.backendSelectedAvatarURL = URL(string: avatar.url)
             }
         } catch ImageUploadError.responseError(reason: let .invalidHTTPStatusCode(response, errorPayload))
             where response.statusCode == HTTPStatus.badRequest.rawValue || response.statusCode == HTTPStatus.payloadTooLarge.rawValue


### PR DESCRIPTION
Closes #

### Description

Replace the opt-out mechanism about when to call  `notifyAvatarSelection` with an opt-in mechanism.

This way we notify the main app only when the avatar changes via:
- user tap
- backend auto-select

### Testing Steps
