### PR TITLE
Remove the swiftlint plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,7 @@ let package = Package(
             resources: [.process("Resources")],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency")
-            ],
-            plugins: [.plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins")]
+            ]
         ),
         .testTarget(
             name: "GravatarTests",
@@ -52,8 +51,7 @@ let package = Package(
             resources: [.process("Resources")],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency")
-            ],
-            plugins: [.plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins")]
+            ]
         ),
         .testTarget(
             name: "GravatarUITests",


### PR DESCRIPTION
Closes #

### Description

This is to fix the CI error happening in the [WPiOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/23701).

https://buildkite.com/automattic/wordpress-ios/builds/24291#0192c309-9143-44d1-9694-e370477ac26d 

`error: "SwiftLintBuildToolPlugin" must be enabled before it can be used`

This is a quick solution to unblock the release. We can bring it back once we find a way to disable it when the Gravatar SDK is integrated into a client app.

### Testing Steps
