### PR TITLE
Update to Xcode 16.1

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,6 +3,6 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export IMAGE_ID="xcode-16.0-v7"
+export IMAGE_ID="xcode-16.1"
 
 export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.2.2"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,7 +2,7 @@
 
 default_platform(:ios)
 
-OS = '17.5'
+OS = '18.1'
 IPHONE_DEVICE = "iPhone SE (3rd generation) (#{OS})".freeze
 
 PROJECT_ROOT_FOLDER = File.join(File.dirname(File.expand_path(__dir__)), 'Demo')


### PR DESCRIPTION
Closes #559 

### Description

- Updates to Xcode 16.1.
- CI nodes have an updated version of `xcbeautify`, which supports outputting Swift Testing properly.

### Testing Steps

- CI is 🟢 
- CI show successful Swift Testing tests in the logs