### PR TITLE
Refactor to use enum with associated values

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoUploadImageViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoUploadImageViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Gravatar
 
-class DemoUploadImageViewController: UIViewController {
+class DemoUploadImageViewController: UIViewController, UITextFieldDelegate {
     let rootStackView: UIStackView = {
         let stack = UIStackView()
         stack.translatesAutoresizingMaskIntoConstraints = false
@@ -132,8 +132,16 @@ class DemoUploadImageViewController: UIViewController {
     }()
 
     private var avatarSelectionBehavior: AvatarSelection = .preserveSelection
-    private var cropToFitThresholdValue: CGFloat? = 0.02
+    private var cropToFitThresholdValue: CGFloat = 0.02
     private var imageSquaringMechanism: SquaringMechanism = .imagePickerController
+    private var squaringStrategy: SquaringStrategy {
+        switch imageSquaringMechanism {
+        case .imagePickerController:
+            return .none
+        case .onUpload:
+            return .crop(behavior: .threshold(cropToFitThresholdValue))
+        }
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -182,11 +190,11 @@ class DemoUploadImageViewController: UIViewController {
     @objc func thresholdEditingDidEnd(_ sender: UITextField) {
         guard let cropToFitThresholdString = cropToFitThreshold.text,
               cropToFitThresholdString.isEmpty == false else {
-            self.cropToFitThresholdValue = nil
+            self.cropToFitThresholdValue = 0.02
             return
         }
         
-        self.cropToFitThresholdValue = CGFloat(cropToFitThresholdString)
+        self.cropToFitThresholdValue = CGFloat(cropToFitThresholdString) ?? 0.02
     }
     
     @objc func selectImage(_ sender: UIButton) {
@@ -223,7 +231,7 @@ class DemoUploadImageViewController: UIViewController {
 
         Task {
             do {
-                let avatarModel = try await service.upload(image, selectionBehavior: avatarSelectionBehavior, accessToken: token, cropToFitThreshold: cropToFitThresholdValue)
+                let avatarModel = try await service.upload(image, selectionBehavior: avatarSelectionBehavior, accessToken: token, squaringStrategy: squaringStrategy)
                 resultLabel.text = "✅ Avatar id \(avatarModel.id)"
             } catch {
                 resultLabel.text = "Error \((error as NSError).code): \(error.localizedDescription)"

--- a/Demo/Demo/Gravatar-Demo/DemoUploadImageViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoUploadImageViewController.swift
@@ -139,7 +139,7 @@ class DemoUploadImageViewController: UIViewController, UITextFieldDelegate {
         case .imagePickerController:
             return .none
         case .onUpload:
-            return .crop(behavior: .threshold(cropToFitThresholdValue))
+            return .default
         }
     }
 

--- a/Sources/Gravatar/Extensions/UIImage.swift
+++ b/Sources/Gravatar/Extensions/UIImage.swift
@@ -4,40 +4,4 @@ extension UIImage {
     package func isSquare() -> Bool {
         size.height == size.width
     }
-
-    package func squared(cropToFitThreshold: CGFloat? = 0.02) -> UIImage {
-        if isSquare() {
-            return self
-        }
-
-        guard let cropToFitThreshold else {
-            return self
-        }
-
-        let (height, width) = (size.height, size.width)
-
-        // Determine the side length for the square (aspect fill or fit logic)
-
-        let squareSide = (abs(width - height) / min(width, height)) <= cropToFitThreshold
-            ? min(width, height) // Aspect fill
-            : max(width, height) // Aspect fit
-
-        let squareSize = CGSize(width: squareSide, height: squareSide)
-        let imageOrigin = CGPoint(
-            x: (squareSize.width - width) / 2,
-            y: (squareSize.height - height) / 2
-        )
-
-        let format = UIGraphicsImageRendererFormat()
-        format.scale = self.scale // Respect original image scale
-        format.opaque = true
-
-        return UIGraphicsImageRenderer(size: squareSize, format: format).image { context in
-            UIColor.black.setFill() // Background color
-            context.fill(CGRect(origin: .zero, size: squareSize)) // Fill background
-
-            // Draw the image in the center of the new square context
-            self.draw(in: CGRect(origin: imageOrigin, size: size))
-        }
-    }
 }

--- a/Sources/Gravatar/Extensions/UIImage.swift
+++ b/Sources/Gravatar/Extensions/UIImage.swift
@@ -5,7 +5,12 @@ extension UIImage {
         size.height == size.width
     }
 
-    package var edgeRatio: CGFloat {
+    /// Describes how close to square an image's `size` is, by comparing the `shortEdge` and `longEdge` of the image.
+    ///
+    /// `Squareness` is similar to `Aspect Ratio`, except that all values are in the range `0...1`
+    /// - A square UIImage (`100 x 100`) has a `squareness` of `1`
+    /// - A UIImage with a `size` of `100 x 200` has a `squareness of `0.5`
+    var squareness: CGFloat {
         if isSquare() { // This catches 0x0 images, which would cause a divide-by-zero error
             return 1
         }
@@ -13,11 +18,11 @@ extension UIImage {
         return shortEdge / longEdge
     }
 
-    package var shortEdge: CGFloat {
+    var shortEdge: CGFloat {
         min(self.size.width, self.size.height)
     }
 
-    package var longEdge: CGFloat {
+    var longEdge: CGFloat {
         max(self.size.width, self.size.height)
     }
 }

--- a/Sources/Gravatar/Extensions/UIImage.swift
+++ b/Sources/Gravatar/Extensions/UIImage.swift
@@ -4,4 +4,20 @@ extension UIImage {
     package func isSquare() -> Bool {
         size.height == size.width
     }
+
+    package var edgeRatio: CGFloat {
+        if isSquare() { // This catches 0x0 images, which would cause a divide-by-zero error
+            return 1
+        }
+
+        return shortEdge / longEdge
+    }
+
+    package var shortEdge: CGFloat {
+        min(self.size.width, self.size.height)
+    }
+
+    package var longEdge: CGFloat {
+        max(self.size.width, self.size.height)
+    }
 }

--- a/Sources/Gravatar/Network/Services/AvatarService.swift
+++ b/Sources/Gravatar/Network/Services/AvatarService.swift
@@ -65,9 +65,9 @@ public struct AvatarService: Sendable {
         _ image: UIImage,
         selectionBehavior: AvatarSelection,
         accessToken: String,
-        cropToFitThreshold: CGFloat? = 0.2
+        squaringStrategy: SquaringStrategy = .default
     ) async throws -> AvatarType {
-        let avatar: Avatar = try await upload(image, accessToken: accessToken, selectionBehavior: selectionBehavior, cropToFitThreshold: cropToFitThreshold)
+        let avatar: Avatar = try await upload(image, accessToken: accessToken, selectionBehavior: selectionBehavior, squaringStrategy: squaringStrategy)
         return avatar
     }
 
@@ -96,11 +96,11 @@ public struct AvatarService: Sendable {
         _ image: UIImage,
         accessToken: String,
         selectionBehavior: AvatarSelection,
-        cropToFitThreshold: CGFloat? = 0.2
+        squaringStrategy: SquaringStrategy = .default
     ) async throws -> Avatar {
         do {
             let (data, _) = try await imageUploader.uploadImage(
-                image.squared(cropToFitThreshold: cropToFitThreshold),
+                squaringStrategy.square(image),
                 accessToken: accessToken,
                 avatarSelection: selectionBehavior,
                 additionalHTTPHeaders: nil

--- a/Sources/Gravatar/UIImage/ImageSquarer.swift
+++ b/Sources/Gravatar/UIImage/ImageSquarer.swift
@@ -16,7 +16,7 @@ struct ImageSquarer {
 
         // Determine the side length for the square (aspect fill or fit logic)
 
-        let squareSide = image.squareness > aspectFillMinSquareness
+        let squareSide = image.squareness >= aspectFillMinSquareness
             ? image.shortEdge // Aspect fill
             : image.longEdge // Aspect fit
 

--- a/Sources/Gravatar/UIImage/ImageSquarer.swift
+++ b/Sources/Gravatar/UIImage/ImageSquarer.swift
@@ -1,10 +1,10 @@
 import UIKit
 
 struct ImageSquarer {
-    private let squarenessThreshold: CGFloat
+    private let aspectFillMinSquareness: CGFloat
 
-    init(squarenessThreshold: CGFloat) {
-        self.squarenessThreshold = squarenessThreshold.clamp(to: 0 ... 1)
+    init(aspectFillMinSquareness: CGFloat) {
+        self.aspectFillMinSquareness = aspectFillMinSquareness.clamp(to: 0 ... 1)
     }
 
     func square(_ image: UIImage) -> UIImage {
@@ -16,7 +16,7 @@ struct ImageSquarer {
 
         // Determine the side length for the square (aspect fill or fit logic)
 
-        let squareSide = image.squareness > squarenessThreshold
+        let squareSide = image.squareness > aspectFillMinSquareness
             ? image.shortEdge // Aspect fill
             : image.longEdge // Aspect fit
 

--- a/Sources/Gravatar/UIImage/ImageSquarer.swift
+++ b/Sources/Gravatar/UIImage/ImageSquarer.swift
@@ -1,10 +1,10 @@
 import UIKit
 
 struct ImageSquarer {
-    private let edgeRatioThreshold: CGFloat
+    private let squarenessThreshold: CGFloat
 
-    init(edgeRatioThreshold: CGFloat) {
-        self.edgeRatioThreshold = edgeRatioThreshold.clamp(to: 0 ... 1)
+    init(squarenessThreshold: CGFloat) {
+        self.squarenessThreshold = squarenessThreshold.clamp(to: 0 ... 1)
     }
 
     func square(_ image: UIImage) -> UIImage {
@@ -16,7 +16,7 @@ struct ImageSquarer {
 
         // Determine the side length for the square (aspect fill or fit logic)
 
-        let squareSide = image.edgeRatio > edgeRatioThreshold
+        let squareSide = image.squareness > squarenessThreshold
             ? image.shortEdge // Aspect fill
             : image.longEdge // Aspect fit
 

--- a/Sources/Gravatar/UIImage/ImageSquarer.swift
+++ b/Sources/Gravatar/UIImage/ImageSquarer.swift
@@ -1,17 +1,13 @@
 import UIKit
 
-public protocol ImageSquarer {
-    func square(_ image: UIImage) -> UIImage
-}
+struct ImageSquarer {
+    private let edgeRatioThreshold: CGFloat
 
-package struct GravatarImageSquarer: ImageSquarer {
-    private let threshold: CGFloat
-
-    package init(threshold: CGFloat) {
-        self.threshold = threshold.clamp(to: 0 ... 1)
+    init(edgeRatioThreshold: CGFloat) {
+        self.edgeRatioThreshold = edgeRatioThreshold.clamp(to: 0 ... 1)
     }
 
-    package func square(_ image: UIImage) -> UIImage {
+    func square(_ image: UIImage) -> UIImage {
         if image.isSquare() {
             return image
         }
@@ -20,9 +16,9 @@ package struct GravatarImageSquarer: ImageSquarer {
 
         // Determine the side length for the square (aspect fill or fit logic)
 
-        let squareSide = (abs(width - height) / min(width, height)) <= threshold
-            ? min(width, height) // Aspect fill
-            : max(width, height) // Aspect fit
+        let squareSide = image.edgeRatio > edgeRatioThreshold
+            ? image.shortEdge // Aspect fill
+            : image.longEdge // Aspect fit
 
         let squareSize = CGSize(width: squareSide, height: squareSide)
         let imageOrigin = CGPoint(
@@ -41,12 +37,6 @@ package struct GravatarImageSquarer: ImageSquarer {
             // Draw the image in the center of the new square context
             image.draw(in: CGRect(origin: imageOrigin, size: image.size))
         }
-    }
-}
-
-struct NoSquaring: ImageSquarer {
-    func square(_ image: UIImage) -> UIImage {
-        image
     }
 }
 

--- a/Sources/Gravatar/UIImage/ImageSquarer.swift
+++ b/Sources/Gravatar/UIImage/ImageSquarer.swift
@@ -1,0 +1,57 @@
+import UIKit
+
+public protocol ImageSquarer {
+    func square(_ image: UIImage) -> UIImage
+}
+
+package struct GravatarImageSquarer: ImageSquarer {
+    private let threshold: CGFloat
+
+    package init(threshold: CGFloat) {
+        self.threshold = threshold.clamp(to: 0 ... 1)
+    }
+
+    package func square(_ image: UIImage) -> UIImage {
+        if image.isSquare() {
+            return image
+        }
+
+        let (height, width) = (image.size.height, image.size.width)
+
+        // Determine the side length for the square (aspect fill or fit logic)
+
+        let squareSide = (abs(width - height) / min(width, height)) <= threshold
+            ? min(width, height) // Aspect fill
+            : max(width, height) // Aspect fit
+
+        let squareSize = CGSize(width: squareSide, height: squareSide)
+        let imageOrigin = CGPoint(
+            x: (squareSize.width - width) / 2,
+            y: (squareSize.height - height) / 2
+        )
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = image.scale // Respect original image scale
+        format.opaque = true
+
+        return UIGraphicsImageRenderer(size: squareSize, format: format).image { context in
+            UIColor.black.setFill() // Background color
+            context.fill(CGRect(origin: .zero, size: squareSize)) // Fill background
+
+            // Draw the image in the center of the new square context
+            image.draw(in: CGRect(origin: imageOrigin, size: image.size))
+        }
+    }
+}
+
+struct NoSquaring: ImageSquarer {
+    func square(_ image: UIImage) -> UIImage {
+        image
+    }
+}
+
+extension CGFloat {
+    func clamp(to range: ClosedRange<Self>) -> Self {
+        CGFloat.minimum(CGFloat.maximum(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/Sources/Gravatar/UIImage/SquaringStrategy.swift
+++ b/Sources/Gravatar/UIImage/SquaringStrategy.swift
@@ -1,0 +1,49 @@
+import UIKit
+
+public enum SquaringStrategy {
+    case crop(behavior: CroppingBehavior)
+    case custom(strategy: ImageSquarer)
+    case `default`
+    case none
+
+    package var square: (UIImage) -> UIImage {
+        let squarer: ImageSquarer = switch self {
+        case .crop(let behavior):
+            GravatarImageSquarer(threshold: behavior.threshold)
+        case .custom(let strategy):
+            strategy
+        case .default:
+            GravatarImageSquarer(threshold: .defaultThreshold)
+        case .none:
+            NoSquaring()
+        }
+
+        return squarer.square(_:)
+    }
+}
+
+public enum CroppingBehavior {
+    case aspectFill
+    case aspectFit
+    case threshold(CGFloat)
+    case `default`
+
+    var threshold: CGFloat {
+        switch self {
+        case .aspectFill:
+            .aspectFillThreshold
+        case .aspectFit:
+            .aspectFitThreshold
+        case .threshold(let value):
+            value
+        case .default:
+            .defaultThreshold
+        }
+    }
+}
+
+extension CGFloat {
+    public static let defaultThreshold: CGFloat = 0.02
+    public static let aspectFitThreshold: CGFloat = 0.0
+    public static let aspectFillThreshold: CGFloat = 1.0
+}

--- a/Sources/Gravatar/UIImage/SquaringStrategy.swift
+++ b/Sources/Gravatar/UIImage/SquaringStrategy.swift
@@ -1,22 +1,35 @@
 import UIKit
 
+/// A strategy for handline images that are not square.
+///
+/// ## Squareness
+/// `Squareness` is similar to `Aspect Ratio`, except that all values are in the range `0...1`
+/// - A square UIImage (`100 x 100`) has a `squareness` of `1`
+/// - A UIImage with a `size` of `100 x 200` has a `squareness of `0.5`
 public enum SquaringStrategy {
+    /// Sqares the image using an `aspectFill` strategy
     case aspectFill
+    /// Sqares the image using an `aspectFit` strategy
     case aspectFit
-    case edgeRatioDeterminesFitOrFill(edgeRatio: CGFloat)
+    /// Determines the squaring strategy based on how close the image is to square, by comparing the `shortEdge` and `longEdge` of the image.
+    ///
+    /// `Squareness` is similar to `Aspect Ratio`, except that all values are in the range `0...1`
+    /// - A square `UIImage` (`100 x 100`) has a `squareness` of `1`
+    /// - A rectangular `UIImage` with a `size` of `100 x 200` (or `200 x 100`) has a squareness of `0.5`
+    case squarenessDeterminesFitOrFill(squarenessThreshold: CGFloat)
     case `default`
     case none
 
     package func square(_ image: UIImage) -> UIImage {
         switch self {
         case .aspectFit:
-            ImageSquarer(edgeRatioThreshold: .aspectFitThreshold).square(image)
+            ImageSquarer(squarenessThreshold: .aspectFitThreshold).square(image)
         case .aspectFill:
-            ImageSquarer(edgeRatioThreshold: .aspectFillThreshold).square(image)
-        case .edgeRatioDeterminesFitOrFill(let edgeRatio):
-            ImageSquarer(edgeRatioThreshold: edgeRatio).square(image)
+            ImageSquarer(squarenessThreshold: .aspectFillThreshold).square(image)
+        case .squarenessDeterminesFitOrFill(let squarenessThreshold):
+            ImageSquarer(squarenessThreshold: squarenessThreshold).square(image)
         case .default:
-            ImageSquarer(edgeRatioThreshold: .defaultThreshold).square(image)
+            ImageSquarer(squarenessThreshold: .defaultThreshold).square(image)
         case .none:
             image
         }

--- a/Sources/Gravatar/UIImage/SquaringStrategy.swift
+++ b/Sources/Gravatar/UIImage/SquaringStrategy.swift
@@ -10,40 +10,34 @@ import UIKit
 /// `Squareness` is similar to `Aspect Ratio`, except that all values are in the range `0...1`
 /// - A square UIImage (`100 x 100`) has a `squareness` of `1`
 /// - A UIImage with a `size` of `100 x 200` has a `squareness of `0.5`
-public enum SquaringStrategy {
-    /// Sqares the image using an `aspectFill` strategy
-    case aspectFill
+public enum SquaringStrategy: Sendable {
+    /// The default `SquaringStrategy`. Uses a high `aspectFillMinSquareness` value to limit which images are cropped to `aspectFill`
+    public static let `default`: SquaringStrategy = .squarenessDeterminesFitOrFill(aspectFillMinSquareness: .defaultMinSquareness)
 
-    /// Sqares the image using an `aspectFit` strategy
-    case aspectFit
+    /// Square all images by cropping the image to `aspectFill`.
+    public static let aspectFill: SquaringStrategy = .squarenessDeterminesFitOrFill(aspectFillMinSquareness: .aspectFillMinSquareness)
 
-    /// The defaul squaring strategy
+    /// Square all iamges by cropping the image to `aspectFit`, and adding a background color to fill in the square
+    public static let aspectFit: SquaringStrategy = .squarenessDeterminesFitOrFill(aspectFillMinSquareness: .aspectFitMinSquareness)
+
+    /// Determines the squaring strategy based on how close the image is to square, by defining a minimum squareness for which `aspectFill` will be used,
+    /// and below which `.aspectFit` will be used.
     ///
-    /// This strategy uses a high aspectFillMinSquareness to determine `aspectFit` or `aspectFill`.  Only images that are very close to square will use
-    /// `aspectFill`, which minimizes the amount of image loss that happens during cropping.  All other images will use `aspectFit`.
-    case `default`
+    /// This `SquaringStrategy` is intended to crop non-square images responsbility.  When an image is only slighlyt off from square, we can safely trim the
+    /// image in order to square it.  For images that are more rectangular, cropping to `aspectFit` may meaningful impact the image.  In those cases, we crop to
+    /// `aspectFit`, and then add a background color to fill in the square.
+    case squarenessDeterminesFitOrFill(aspectFillMinSquareness: CGFloat)
 
     /// No squaring will be applied to images
     case none
 
-    /// Determines the squaring strategy based on how close the image is to square, by defining a minimum squareness for which `aspectFill` will be used, and
-    /// below which `.aspectFit` will be used.
-    ///
-    /// `Squareness` is similar to `Aspect Ratio`, except that all values are in the range `0...1`
-    /// - A square `UIImage` (`100 x 100`) has a `squareness` of `1`
-    /// - A rectangular `UIImage` with a `size` of `100 x 200` (or `200 x 100`) has a squareness of `0.5`
-    case squarenessDeterminesFitOrFill(aspectFillMinSquareness: CGFloat)
-
+    /// Applies the `SquaringStrategy` to a `UIImage`
+    /// - Parameter image: a `UIImage` that should be squared
+    /// - Returns: a `UIImage` with the `SquaringStrategy` applied.
     package func square(_ image: UIImage) -> UIImage {
         switch self {
-        case .aspectFit:
-            ImageSquarer(aspectFillMinSquareness: .aspectFitThreshold).square(image)
-        case .aspectFill:
-            ImageSquarer(aspectFillMinSquareness: .aspectFillThreshold).square(image)
         case .squarenessDeterminesFitOrFill(let aspectFillMinSquareness):
             ImageSquarer(aspectFillMinSquareness: aspectFillMinSquareness).square(image)
-        case .default:
-            ImageSquarer(aspectFillMinSquareness: .defaultThreshold).square(image)
         case .none:
             // TODO: Check for squareness and log non-square images
             image
@@ -52,7 +46,12 @@ public enum SquaringStrategy {
 }
 
 extension CGFloat {
-    fileprivate static let defaultThreshold: CGFloat = 0.98
-    fileprivate static let aspectFitThreshold: CGFloat = 1.0
-    fileprivate static let aspectFillThreshold: CGFloat = 0.0
+    /// The default `aspecptFillMinSquareness` value
+    fileprivate static let defaultMinSquareness: CGFloat = 0.98
+
+    /// The `aspectFillMinSquareness` value that will cause the `SquaringStrategy` to apply `aspectFit` squaring logic to all images
+    fileprivate static let aspectFitMinSquareness: CGFloat = 1.0
+
+    /// The `aspectFillMinSquareness` value that will cause the `SquaringStrategy` to apply `aspectFill` squaring logic to all images
+    fileprivate static let aspectFillMinSquareness: CGFloat = 0.0
 }

--- a/Sources/Gravatar/UIImage/SquaringStrategy.swift
+++ b/Sources/Gravatar/UIImage/SquaringStrategy.swift
@@ -2,6 +2,10 @@ import UIKit
 
 /// A strategy for handline images that are not square.
 ///
+/// ## Gravatar API
+/// The Gravatar API will return an error when an image that is not square is uploaded, even if the difference is a single row of pixels.  `SquaringStrategy` is
+/// a safeguard, making sure that an image is properly squared before uploading.
+///
 /// ## Squareness
 /// `Squareness` is similar to `Aspect Ratio`, except that all values are in the range `0...1`
 /// - A square UIImage (`100 x 100`) has a `squareness` of `1`
@@ -9,16 +13,25 @@ import UIKit
 public enum SquaringStrategy {
     /// Sqares the image using an `aspectFill` strategy
     case aspectFill
+
     /// Sqares the image using an `aspectFit` strategy
     case aspectFit
+
+    /// The defaul squaring strategy
+    ///
+    /// This strategy uses a high squarenessThreshold to determine `aspectFit` or `aspectFill`.  Only images that are very close to square will use
+    /// `aspectFill`, which minimizes the amount of image loss that happens during cropping.  All other images will use `aspectFit`.
+    case `default`
+
+    /// No squaring will be applied to images
+    case none
+
     /// Determines the squaring strategy based on how close the image is to square, by comparing the `shortEdge` and `longEdge` of the image.
     ///
     /// `Squareness` is similar to `Aspect Ratio`, except that all values are in the range `0...1`
     /// - A square `UIImage` (`100 x 100`) has a `squareness` of `1`
     /// - A rectangular `UIImage` with a `size` of `100 x 200` (or `200 x 100`) has a squareness of `0.5`
     case squarenessDeterminesFitOrFill(squarenessThreshold: CGFloat)
-    case `default`
-    case none
 
     package func square(_ image: UIImage) -> UIImage {
         switch self {
@@ -31,6 +44,7 @@ public enum SquaringStrategy {
         case .default:
             ImageSquarer(squarenessThreshold: .defaultThreshold).square(image)
         case .none:
+            // TODO: Check for squareness and log non-square images
             image
         }
     }

--- a/Sources/Gravatar/UIImage/SquaringStrategy.swift
+++ b/Sources/Gravatar/UIImage/SquaringStrategy.swift
@@ -1,49 +1,30 @@
 import UIKit
 
 public enum SquaringStrategy {
-    case crop(behavior: CroppingBehavior)
-    case custom(strategy: ImageSquarer)
+    case aspectFill
+    case aspectFit
+    case edgeRatioDeterminesFitOrFill(edgeRatio: CGFloat)
     case `default`
     case none
 
-    package var square: (UIImage) -> UIImage {
-        let squarer: ImageSquarer = switch self {
-        case .crop(let behavior):
-            GravatarImageSquarer(threshold: behavior.threshold)
-        case .custom(let strategy):
-            strategy
-        case .default:
-            GravatarImageSquarer(threshold: .defaultThreshold)
-        case .none:
-            NoSquaring()
-        }
-
-        return squarer.square(_:)
-    }
-}
-
-public enum CroppingBehavior {
-    case aspectFill
-    case aspectFit
-    case threshold(CGFloat)
-    case `default`
-
-    var threshold: CGFloat {
+    package func square(_ image: UIImage) -> UIImage {
         switch self {
-        case .aspectFill:
-            .aspectFillThreshold
         case .aspectFit:
-            .aspectFitThreshold
-        case .threshold(let value):
-            value
+            ImageSquarer(edgeRatioThreshold: .aspectFitThreshold).square(image)
+        case .aspectFill:
+            ImageSquarer(edgeRatioThreshold: .aspectFillThreshold).square(image)
+        case .edgeRatioDeterminesFitOrFill(let edgeRatio):
+            ImageSquarer(edgeRatioThreshold: edgeRatio).square(image)
         case .default:
-            .defaultThreshold
+            ImageSquarer(edgeRatioThreshold: .defaultThreshold).square(image)
+        case .none:
+            image
         }
     }
 }
 
 extension CGFloat {
-    public static let defaultThreshold: CGFloat = 0.02
-    public static let aspectFitThreshold: CGFloat = 0.0
-    public static let aspectFillThreshold: CGFloat = 1.0
+    fileprivate static let defaultThreshold: CGFloat = 0.98
+    fileprivate static let aspectFitThreshold: CGFloat = 1.0
+    fileprivate static let aspectFillThreshold: CGFloat = 0.0
 }

--- a/Sources/Gravatar/UIImage/SquaringStrategy.swift
+++ b/Sources/Gravatar/UIImage/SquaringStrategy.swift
@@ -26,7 +26,8 @@ public enum SquaringStrategy {
     /// No squaring will be applied to images
     case none
 
-    /// Determines the squaring strategy based on how close the image is to square, by comparing the `shortEdge` and `longEdge` of the image.
+    /// Determines the squaring strategy based on how close the image is to square, by defining a minimum squareness for which `aspectFill` will be used, and
+    /// below which `.aspectFit` will be used.
     ///
     /// `Squareness` is similar to `Aspect Ratio`, except that all values are in the range `0...1`
     /// - A square `UIImage` (`100 x 100`) has a `squareness` of `1`

--- a/Sources/Gravatar/UIImage/SquaringStrategy.swift
+++ b/Sources/Gravatar/UIImage/SquaringStrategy.swift
@@ -19,7 +19,7 @@ public enum SquaringStrategy {
 
     /// The defaul squaring strategy
     ///
-    /// This strategy uses a high squarenessThreshold to determine `aspectFit` or `aspectFill`.  Only images that are very close to square will use
+    /// This strategy uses a high aspectFillMinSquareness to determine `aspectFit` or `aspectFill`.  Only images that are very close to square will use
     /// `aspectFill`, which minimizes the amount of image loss that happens during cropping.  All other images will use `aspectFit`.
     case `default`
 
@@ -31,18 +31,18 @@ public enum SquaringStrategy {
     /// `Squareness` is similar to `Aspect Ratio`, except that all values are in the range `0...1`
     /// - A square `UIImage` (`100 x 100`) has a `squareness` of `1`
     /// - A rectangular `UIImage` with a `size` of `100 x 200` (or `200 x 100`) has a squareness of `0.5`
-    case squarenessDeterminesFitOrFill(squarenessThreshold: CGFloat)
+    case squarenessDeterminesFitOrFill(aspectFillMinSquareness: CGFloat)
 
     package func square(_ image: UIImage) -> UIImage {
         switch self {
         case .aspectFit:
-            ImageSquarer(squarenessThreshold: .aspectFitThreshold).square(image)
+            ImageSquarer(aspectFillMinSquareness: .aspectFitThreshold).square(image)
         case .aspectFill:
-            ImageSquarer(squarenessThreshold: .aspectFillThreshold).square(image)
-        case .squarenessDeterminesFitOrFill(let squarenessThreshold):
-            ImageSquarer(squarenessThreshold: squarenessThreshold).square(image)
+            ImageSquarer(aspectFillMinSquareness: .aspectFillThreshold).square(image)
+        case .squarenessDeterminesFitOrFill(let aspectFillMinSquareness):
+            ImageSquarer(aspectFillMinSquareness: aspectFillMinSquareness).square(image)
         case .default:
-            ImageSquarer(squarenessThreshold: .defaultThreshold).square(image)
+            ImageSquarer(aspectFillMinSquareness: .defaultThreshold).square(image)
         case .none:
             // TODO: Check for squareness and log non-square images
             image

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -155,7 +155,7 @@ class AvatarPickerViewModel: ObservableObject {
         // SwiftUI doesn't update the UI if the grid is empty.
         // objectWillChange forces the update.
         objectWillChange.send()
-        let squareImage = shouldSquareImage ? image.squared() : image
+        let squareImage = shouldSquareImage ? SquaringStrategy.default.square(image) : image
         assert(squareImage.isSquare(), "Image must be square before uploading: \(squareImage.size.height) x \(squareImage.size.width)")
 
         let localID = UUID().uuidString

--- a/Tests/GravatarTests/ImageSquaringTests.swift
+++ b/Tests/GravatarTests/ImageSquaringTests.swift
@@ -194,10 +194,10 @@ final class ImageSquaringTests: XCTestCase {
         // Given an image with a minor size difference (100x102) where the edge ratio (`0.9804`)
         // is above the custom squareness (`0.97`)
         let slightDifferenceImage = createImage(width: 100, height: 102)
-        let squarenessThreshold: CGFloat = 0.97
+        let aspectFillMinSquareness: CGFloat = 0.97
 
         // When the custom squaring function is applied
-        let result = SquaringStrategy.squarenessDeterminesFitOrFill(squarenessThreshold: squarenessThreshold).square(slightDifferenceImage)
+        let result = SquaringStrategy.squarenessDeterminesFitOrFill(aspectFillMinSquareness: aspectFillMinSquareness).square(slightDifferenceImage)
 
         // Then the result should aspect-fill and become 100x100
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -209,10 +209,10 @@ final class ImageSquaringTests: XCTestCase {
         // Given an image with a minor size difference (100x104) where the edge ratio (`0.9615`)
         // is below the custom squareness (`0.97`)
         let slightDifferenceImage = createImage(width: 100, height: 104)
-        let squarenessThreshold: CGFloat = 0.97
+        let aspectFillMinSquareness: CGFloat = 0.97
 
         // When the custom squaring function is applied
-        let result = SquaringStrategy.squarenessDeterminesFitOrFill(squarenessThreshold: squarenessThreshold).square(slightDifferenceImage)
+        let result = SquaringStrategy.squarenessDeterminesFitOrFill(aspectFillMinSquareness: aspectFillMinSquareness).square(slightDifferenceImage)
 
         // Then the result should aspect-fit and become 102x102
         XCTAssertTrue(result.isSquare(), "Image should be square")

--- a/Tests/GravatarTests/ImageSquaringTests.swift
+++ b/Tests/GravatarTests/ImageSquaringTests.swift
@@ -192,12 +192,12 @@ final class ImageSquaringTests: XCTestCase {
 
     func testMinorAspectDifferenceAboveCustomEdgeRatioThresholdImageShouldUseAspectFill() {
         // Given an image with a minor size difference (100x102) where the edge ratio (`0.9804`)
-        // is above the custom edgeRatio (`0.97`)
+        // is above the custom squareness (`0.97`)
         let slightDifferenceImage = createImage(width: 100, height: 102)
-        let edgeRatio: CGFloat = 0.97
+        let squarenessThreshold: CGFloat = 0.97
 
         // When the custom squaring function is applied
-        let result = SquaringStrategy.edgeRatioDeterminesFitOrFill(edgeRatio: edgeRatio).square(slightDifferenceImage)
+        let result = SquaringStrategy.squarenessDeterminesFitOrFill(squarenessThreshold: squarenessThreshold).square(slightDifferenceImage)
 
         // Then the result should aspect-fill and become 100x100
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -207,12 +207,12 @@ final class ImageSquaringTests: XCTestCase {
 
     func testMinorAspectDifferenceBelowCustomEdgeRatioThresholdImageShouldUseAspectFit() {
         // Given an image with a minor size difference (100x104) where the edge ratio (`0.9615`)
-        // is below the custom edgeRatio (`0.97`)
+        // is below the custom squareness (`0.97`)
         let slightDifferenceImage = createImage(width: 100, height: 104)
-        let edgeRatio: CGFloat = 0.97
+        let squarenessThreshold: CGFloat = 0.97
 
         // When the custom squaring function is applied
-        let result = SquaringStrategy.edgeRatioDeterminesFitOrFill(edgeRatio: edgeRatio).square(slightDifferenceImage)
+        let result = SquaringStrategy.squarenessDeterminesFitOrFill(squarenessThreshold: squarenessThreshold).square(slightDifferenceImage)
 
         // Then the result should aspect-fit and become 102x102
         XCTAssertTrue(result.isSquare(), "Image should be square")

--- a/Tests/GravatarTests/ImageSquaringTests.swift
+++ b/Tests/GravatarTests/ImageSquaringTests.swift
@@ -10,8 +10,8 @@ final class ImageSquaringTests: XCTestCase {
         // Given a square image
         let squareImage = createImage(width: 100, height: 100)
 
-        // When the default squaring function is applied
-        let result = squareImage.squared()
+        // When the default squaring strategy is applied
+        let result = SquaringStrategy.default.square(squareImage)
 
         // Then it should remain unchanged
         XCTAssertEqual(result, squareImage, "UIImage objects should be identical")
@@ -21,8 +21,8 @@ final class ImageSquaringTests: XCTestCase {
         // Given a portrait image (50x100)
         let portraitImage = createImage(width: 50, height: 100)
 
-        // When the default squaring function is applied
-        let result = portraitImage.squared()
+        // When the default squaring strategy is applied
+        let result = SquaringStrategy.default.square(portraitImage)
 
         // Then the result should be a square image (100x100)
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -34,8 +34,8 @@ final class ImageSquaringTests: XCTestCase {
         // Given a landscape image (200x100)
         let landscapeImage = createImage(width: 200, height: 100)
 
-        // When the default squaring function is applied
-        let result = landscapeImage.squared()
+        // When the default squaring strategy is applied
+        let result = SquaringStrategy.default.square(landscapeImage)
 
         // Then the result should be a square image (200x200)
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -48,8 +48,8 @@ final class ImageSquaringTests: XCTestCase {
         // the default `cropToFitTolerance` of `0.02` (image difference: `0.01`)
         let slightDifferenceImage = createImage(width: 100, height: 101)
 
-        // When the default squaring function is applied
-        let result = slightDifferenceImage.squared()
+        // When the default squaring strategy is applied
+        let result = SquaringStrategy.default.square(slightDifferenceImage)
 
         // Then the result should aspect-fill and become 100x100
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -62,8 +62,8 @@ final class ImageSquaringTests: XCTestCase {
         // the default `cropToFitTolerance` of `0.02` (image difference: `0.02`)
         let slightDifferenceImage = createImage(width: 100, height: 102)
 
-        // When the default squaring function is applied
-        let result = slightDifferenceImage.squared()
+        // When the default squaring strategy is applied
+        let result = SquaringStrategy.default.square(slightDifferenceImage)
 
         // Then the result should aspect-fill and become 100x100
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -76,8 +76,8 @@ final class ImageSquaringTests: XCTestCase {
         // the default `cropToFitTolerance` of `0.02` (image difference: `0.03`)
         let slightDifferenceImage = createImage(width: 100, height: 103)
 
-        // When the default squaring function is applied
-        let result = slightDifferenceImage.squared()
+        // When the default squaring strategy is applied
+        let result = SquaringStrategy.default.square(slightDifferenceImage)
 
         // Then the result should aspect-fit and become 102x102
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -91,8 +91,8 @@ final class ImageSquaringTests: XCTestCase {
         // Given a very small image (1x1)
         let smallImage = createImage(width: 1, height: 1)
 
-        // When the default squaring function is applied
-        let result = smallImage.squared()
+        // When the default squaring strategy is applied
+        let result = SquaringStrategy.default.square(smallImage)
 
         // Then it should remain a 1x1 image since it's already square
         XCTAssertTrue(result.isSquare(), "Image should remain square")
@@ -104,8 +104,8 @@ final class ImageSquaringTests: XCTestCase {
         // Given a large image (5_000x3_000)
         let largeImage = createImage(width: 5000, height: 3000)
 
-        // When the default squaring function is applied
-        let result = largeImage.squared()
+        // When the default squaring strategy is applied
+        let result = SquaringStrategy.default.square(largeImage)
 
         // Then the result should be a 5_000x5_000 square image
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -117,8 +117,8 @@ final class ImageSquaringTests: XCTestCase {
         // Given an extremely wide image (10_000x500)
         let wideImage = createImage(width: 10000, height: 500)
 
-        // When the default squaring function is applied
-        let result = wideImage.squared()
+        // When the default squaring strategy is applied
+        let result = SquaringStrategy.default.square(wideImage)
 
         // Then the result should be a 10_000x10_000 square image
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -130,8 +130,8 @@ final class ImageSquaringTests: XCTestCase {
         // Given an extremely tall image (500x10_000)
         let tallImage = createImage(width: 500, height: 10000)
 
-        // When the default squaring function is applied
-        let result = tallImage.squared()
+        // When the default squaring strategy is applied
+        let result = SquaringStrategy.default.square(tallImage)
 
         // Then the result should be a 10_000x10_000 square image
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -145,8 +145,8 @@ final class ImageSquaringTests: XCTestCase {
         // Given a retina image (@2x) with size 300x500
         let image = createImage(width: 300, height: 500, scale: 2.0)
 
-        // When the default squaring function is applied
-        let result = image.squared()
+        // When the default squaring strategy is applied
+        let result = SquaringStrategy.default.square(image)
 
         // Then the result should be a 500x500 square image with scale @2x
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -165,8 +165,8 @@ final class ImageSquaringTests: XCTestCase {
         // And a reference image
         let referenceImage = try XCTUnwrap(UIImage(named: "ImageSquaringDefaultBackgroundReferenceImage", in: .module, with: nil)).pngData()
 
-        // When the default squaring function is applied
-        let resultImage = image.squared()
+        // When the default squaring strategy is applied
+        let resultImage = SquaringStrategy.default.square(image)
 
         // Archive the reference image for future use
         attach(image: resultImage, attachmentName: "Default Background Image")
@@ -185,8 +185,8 @@ final class ImageSquaringTests: XCTestCase {
         // a custom `cropToFitTolerance` of `0.02` (image difference: `0.02`)
         let slightDifferenceImage = createImage(width: 100, height: 102)
 
-        // When the default squaring function is applied
-        let result = slightDifferenceImage.squared(cropToFitThreshold: 0.03)
+        // When the custom squaring function is applied
+        let result = SquaringStrategy.crop(behavior: .threshold(0.03)).square(slightDifferenceImage)
 
         // Then the result should aspect-fill and become 100x100
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -199,8 +199,8 @@ final class ImageSquaringTests: XCTestCase {
         // a custom `cropToFitTolerance` of `0.03` (image difference: `0.03`)
         let slightDifferenceImage = createImage(width: 100, height: 103)
 
-        // When the default squaring function is applied
-        let result = slightDifferenceImage.squared(cropToFitThreshold: 0.03)
+        // When the custom squaring function is applied
+        let result = SquaringStrategy.crop(behavior: .threshold(0.03)).square(slightDifferenceImage)
 
         // Then the result should aspect-fill and become 100x100
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -213,8 +213,8 @@ final class ImageSquaringTests: XCTestCase {
         // a custom `cropToFitTolerance` of `0.03` (image difference: `0.04`)
         let slightDifferenceImage = createImage(width: 100, height: 104)
 
-        // When the default squaring function is applied
-        let result = slightDifferenceImage.squared()
+        // When the custom squaring function is applied
+        let result = SquaringStrategy.crop(behavior: .threshold(0.03)).square(slightDifferenceImage)
 
         // Then the result should aspect-fit and become 102x102
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -222,13 +222,13 @@ final class ImageSquaringTests: XCTestCase {
         XCTAssertEqual(result.size.height, 104, "Height should match the larger side")
     }
 
-    func testCustomCropToFitToleranceWithMinorAspectDifferenceImageShouldReturnOriginalImage() {
+    func testNoCroppingWithMinorAspectDifferenceImageShouldReturnOriginalImage() {
         // Given an image with a minor size difference (100x103) where the difference exactly matches
         // a custom `cropToFitTolerance` set to `nil` (image difference: `0.03`)
         let slightDifferenceImage = createImage(width: 100, height: 103)
 
         // When the default squaring function is applied
-        let result = slightDifferenceImage.squared(cropToFitThreshold: nil)
+        let result = SquaringStrategy.none.square(slightDifferenceImage)
 
         // Then it should remain unchanged
         XCTAssertEqual(result, slightDifferenceImage, "UIImage objects should be identical")

--- a/Tests/GravatarTests/ImageSquaringTests.swift
+++ b/Tests/GravatarTests/ImageSquaringTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import Gravatar
 
 final class ImageSquaringTests: XCTestCase {
-    // MARK: Pixel Tests
+    // MARK: Default Image Squaring
 
     func testSquareImage() {
         // Given a square image
@@ -139,6 +139,16 @@ final class ImageSquaringTests: XCTestCase {
         XCTAssertEqual(result.size.height, 10000, "Height should match the taller side")
     }
 
+    func testZeroSizeImage() {
+        let zeroSizeImage = createImage(width: 0, height: 0)
+
+        let result = SquaringStrategy.default.square(zeroSizeImage)
+
+        XCTAssertTrue(result.isSquare(), "Image should be square")
+        XCTAssertEqual(result.size.width, 0)
+        XCTAssertEqual(result.size.height, 0)
+    }
+
     // MARK: - Scale Test
 
     func testImageSquaringWithScale2x() {
@@ -178,15 +188,16 @@ final class ImageSquaringTests: XCTestCase {
         XCTAssertEqual(resultImage.pngData(), referenceImage)
     }
 
-    // MARK: - Custom Cropping Tolerance
+    // MARK: - Custom EdgeRatio Threshold
 
-    func testMinorAspectDifferenceBelowCustomCropToFitThresholdImageShouldUseAspectFill() {
-        // Given an image with a minor size difference (100x102) where the difference exactly matches
-        // a custom `cropToFitTolerance` of `0.02` (image difference: `0.02`)
+    func testMinorAspectDifferenceAboveCustomEdgeRatioThresholdImageShouldUseAspectFill() {
+        // Given an image with a minor size difference (100x102) where the edge ratio (`0.9804`)
+        // is above the custom edgeRatio (`0.97`)
         let slightDifferenceImage = createImage(width: 100, height: 102)
+        let edgeRatio: CGFloat = 0.97
 
         // When the custom squaring function is applied
-        let result = SquaringStrategy.crop(behavior: .threshold(0.03)).square(slightDifferenceImage)
+        let result = SquaringStrategy.edgeRatioDeterminesFitOrFill(edgeRatio: edgeRatio).square(slightDifferenceImage)
 
         // Then the result should aspect-fill and become 100x100
         XCTAssertTrue(result.isSquare(), "Image should be square")
@@ -194,33 +205,82 @@ final class ImageSquaringTests: XCTestCase {
         XCTAssertEqual(result.size.height, 100, "Height should match the smaller side")
     }
 
-    func testMinorAspectDifferenceMatchesCustomCropToFitThresholdImageShouldUseAspectFill() {
-        // Given an image with a minor size difference (100x103) where the difference exactly matches
-        // a custom `cropToFitTolerance` of `0.03` (image difference: `0.03`)
-        let slightDifferenceImage = createImage(width: 100, height: 103)
-
-        // When the custom squaring function is applied
-        let result = SquaringStrategy.crop(behavior: .threshold(0.03)).square(slightDifferenceImage)
-
-        // Then the result should aspect-fill and become 100x100
-        XCTAssertTrue(result.isSquare(), "Image should be square")
-        XCTAssertEqual(result.size.width, 100, "Width should match the smaller side")
-        XCTAssertEqual(result.size.height, 100, "Height should match the smaller side")
-    }
-
-    func testMinorAspectDifferenceAboveCustomCropToFitThresholdImageShouldUseAspectFill() {
-        // Given an image with a minor size difference (100x104) where the difference is above
-        // a custom `cropToFitTolerance` of `0.03` (image difference: `0.04`)
+    func testMinorAspectDifferenceBelowCustomEdgeRatioThresholdImageShouldUseAspectFit() {
+        // Given an image with a minor size difference (100x104) where the edge ratio (`0.9615`)
+        // is below the custom edgeRatio (`0.97`)
         let slightDifferenceImage = createImage(width: 100, height: 104)
+        let edgeRatio: CGFloat = 0.97
 
         // When the custom squaring function is applied
-        let result = SquaringStrategy.crop(behavior: .threshold(0.03)).square(slightDifferenceImage)
+        let result = SquaringStrategy.edgeRatioDeterminesFitOrFill(edgeRatio: edgeRatio).square(slightDifferenceImage)
 
         // Then the result should aspect-fit and become 102x102
         XCTAssertTrue(result.isSquare(), "Image should be square")
         XCTAssertEqual(result.size.width, 104, "Width should match the larger side")
         XCTAssertEqual(result.size.height, 104, "Height should match the larger side")
     }
+
+    // MARK: - Aspect Fit Image Squaring
+
+    func testWideImageUsingAspectFitShouldBeSquared() {
+        let wideImage = createImage(width: 200, height: 100)
+
+        let result = SquaringStrategy.aspectFit.square(wideImage)
+
+        XCTAssertTrue(result.isSquare(), "Image should be square")
+        XCTAssertEqual(result.size.width, 200, "Width should match the longer side")
+        XCTAssertEqual(result.size.height, 200, "Height should match the longer side")
+    }
+
+    func testTallImageUsingAspectFitShouldBeSquared() {
+        let tallImage = createImage(width: 100, height: 200)
+
+        let result = SquaringStrategy.aspectFit.square(tallImage)
+
+        XCTAssertTrue(result.isSquare(), "Image should be square")
+        XCTAssertEqual(result.size.width, 200, "Width should match the longer side")
+        XCTAssertEqual(result.size.height, 200, "Height should match the longer side")
+    }
+
+    func testSquareImageUsingAspectFitShouldBeSquared() {
+        let squareImage = createImage(width: 100, height: 100)
+
+        let result = SquaringStrategy.aspectFit.square(squareImage)
+
+        XCTAssertEqual(result, squareImage, "UIImage objects should be identical")
+    }
+
+    // MARK: - Aspect Fill Image Squaring
+
+    func testWideImageUsingAspectFillShouldBeSquared() {
+        let wideImage = createImage(width: 200, height: 100)
+
+        let result = SquaringStrategy.aspectFill.square(wideImage)
+
+        XCTAssertTrue(result.isSquare(), "Image should be square")
+        XCTAssertEqual(result.size.width, 100, "Width should match the shorter side")
+        XCTAssertEqual(result.size.height, 100, "Height should match the shorter side")
+    }
+
+    func testTallImageUsingAspectFillShouldBeSquared() {
+        let tallImage = createImage(width: 100, height: 200)
+
+        let result = SquaringStrategy.aspectFill.square(tallImage)
+
+        XCTAssertTrue(result.isSquare(), "Image should be square")
+        XCTAssertEqual(result.size.width, 100, "Width should match the shorter side")
+        XCTAssertEqual(result.size.height, 100, "Height should match the shorter side")
+    }
+
+    func testSquareImageUsingAspectFillShouldBeSquared() {
+        let squareImage = createImage(width: 100, height: 100)
+
+        let result = SquaringStrategy.aspectFill.square(squareImage)
+
+        XCTAssertEqual(result, squareImage, "UIImage objects should be identical")
+    }
+
+    // MARK: - No Image Squaring
 
     func testNoCroppingWithMinorAspectDifferenceImageShouldReturnOriginalImage() {
         // Given an image with a minor size difference (100x103) where the difference exactly matches


### PR DESCRIPTION
Closes #

### Description

This refactors #419 to use a `SquaringStrategy` enum with associated values instead of a raw `CGFloat` "threshold" value.  It supports four different squaring strategies:

- `crop`: Use one of four cropping behavior to create a square image:
   - `aspectFill`
   - `aspectFit`
   - `threshold(CGFloat)`: Uses a threshold to decide whether to fill or fit
   - `default`: uses our default threshold to decide whether to fill or fit
- `custom`: Use a custom squaring strategy to create a square image
- `default`: Use the "default" cropping behavior to create a square image (which uses our default cropping threshold)
- `none`: do not attempt to square the image

The "custom" option may be overkill.  It would allow a third party to supply their own squaring logic.  I included just because it requires no extra effort to make it available.

The one reason I can think of where this "custom" option might be useful is if a developer wants to use a different default background color when filling in a square image.

### Testing Steps
