### PR TITLE
Add a default `ProfileViewDelegate` conformance to `ProfileViewController

### DIFF
--- a/Sources/GravatarUI/ProfileViewController/ProfileViewController.swift
+++ b/Sources/GravatarUI/ProfileViewController/ProfileViewController.swift
@@ -1,5 +1,6 @@
 import Combine
 import Gravatar
+import SafariServices
 import UIKit
 
 /// A view controller which displays a Profile View.
@@ -32,6 +33,12 @@ public class ProfileViewController: UIViewController {
         self.configuration = configuration
         self.profileIdentifier = profileIdentifier
         super.init(nibName: nil, bundle: nil)
+        if configuration.delegate == nil {
+            // Set delegate to `self` if no delegate was set.
+            var newConfig = configuration
+            newConfig.delegate = self
+            self.configuration = newConfig
+        }
     }
 
     override public func viewDidLoad() {
@@ -101,5 +108,24 @@ public class ProfileViewController: UIViewController {
 
     private func refresh(paletteType: PaletteType) {
         view.backgroundColor = paletteType.palette.background.primary
+    }
+}
+
+extension ProfileViewController: ProfileViewDelegate {
+    public func profileView(_ view: BaseProfileView, didTapOnAvatarWithID avatarID: Gravatar.AvatarIdentifier?) {
+        // No op.
+    }
+
+    public func profileView(_ view: BaseProfileView, didTapOnProfileButtonWithStyle style: ProfileButtonStyle, profileURL: URL?) {
+        guard let profileURL else { return }
+        let safari = SFSafariViewController(url: profileURL)
+        present(safari, animated: true)
+    }
+
+    public func profileView(_ view: BaseProfileView, didTapOnAccountButtonWithModel accountModel: AccountModel) {
+        guard let accountURL = accountModel.accountURL else { return }
+        let safari = SFSafariViewController(url: accountURL)
+
+        present(safari, animated: true)
     }
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/Gravatar-SDK-iOS/issues/383

### Description

The original issue was described as:

> SDK consumer that uses ProfileViewController is not able to pass a delegate to apply on click actions on a profile card.

But in fact, it is possible via `ProfileViewConfiguration`:

```
let config: ProfileViewConfiguration = ProfileViewConfiguration.large(palette: preferredPaletteType)
config.delelgate = self
let viewController = ProfileViewController(configuration: config, viewModel: .init(), profileIdentifier: ...)
...
```

So I think there was a confusion there. 

But I still wanted to add a default `ProfileViewDelegate` conformance for convenience.

### Testing Steps

Demo app > Profile View Controller
Type email 
Tap "Show profile bottom sheet"
Tap "View profile"
It should open the in-app Safari
Same for the social media icons
