### PR TITLE
Deprecate `ProfileViewConfiguration.avatarConfiguration.borderColor` in favor of `Palette.avatar.border`

### DIFF
--- a/Sources/GravatarUI/ProfileView/ProfileViewConfiguration.swift
+++ b/Sources/GravatarUI/ProfileView/ProfileViewConfiguration.swift
@@ -112,6 +112,11 @@ extension ProfileViewConfiguration {
         public var borderWidth: CGFloat = 1
         /// The border color of the avatar. If not set, the border color from the palette is used. See ``Palette`` . ``Palette/avatar`` .
         /// ``AvatarColors/border``.
+        @available(
+            *,
+            deprecated,
+            message: "Use 'Palette.avatar.border' instead. You can set your `ProfileViewConfiguration`'s `paletteCustomizer` property to customize any color in the palette, see `ProfileViewConfiguration.claimProfile(...)` implementation for an example usage."
+        )
         public var borderColor: UIColor? = nil
         /// Length of the avatar. If not set, a suitable length is chosen according to the ``ProfileViewConfiguration/Style``.
         public var avatarLength: CGFloat? = nil


### PR DESCRIPTION
Closes https://github.com/Automattic/Gravatar-SDK-iOS/issues/293

### Description

We have a way to customize any color in the palette with `PaletteCustomizer` which was introduced by https://github.com/Automattic/Gravatar-SDK-iOS/pull/292. ProfileViewConfiguration's borderColor was made redundant. And now that I look back, this deprecation should have been included in that PR.

One needs to do color customizations for both light/dark modes separately so ProfileViewConfiguration's borderColor wasn't best for the purpose anyway.

### Testing Steps

CI green.