### PR TITLE
Add the initial avatar action menu [...]

### DIFF
--- a/Sources/GravatarUI/Resources/Media.xcassets/more-horizontal.imageset/Contents.json
+++ b/Sources/GravatarUI/Resources/Media.xcassets/more-horizontal.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "more-horizontal.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/Sources/GravatarUI/Resources/Media.xcassets/more-horizontal.imageset/more-horizontal.svg
+++ b/Sources/GravatarUI/Resources/Media.xcassets/more-horizontal.imageset/more-horizontal.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 13H13V11H11V13ZM5 13H7V11H5V13ZM17 11V13H19V11H17Z" fill="#1E1E1E"/>
+</svg>

--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -1,3 +1,9 @@
+/* An option in the avatar menu that deletes the avatar */
+"AvatarAction.delete" = "Delete";
+
+/* An option in the avatar menu that shares the avatar */
+"AvatarAction.share" = "Share";
+
 /* Title of a message advising the user that something went wrong while trying to log in. */
 "AvatarPicker.ContentLoading.Failure.LogInError.title" = "Login required";
 

--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -1,8 +1,8 @@
 /* An option in the avatar menu that deletes the avatar */
-"AvatarAction.delete" = "Delete";
+"AvatarPicker.AvatarAction.delete" = "Delete";
 
 /* An option in the avatar menu that shares the avatar */
-"AvatarAction.share" = "Share";
+"AvatarPicker.AvatarAction.share" = "Share";
 
 /* Title of a message advising the user that something went wrong while trying to log in. */
 "AvatarPicker.ContentLoading.Failure.LogInError.title" = "Login required";

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarAction.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarAction.swift
@@ -1,0 +1,44 @@
+import Foundation
+import SwiftUI
+
+enum AvatarAction: String, CaseIterable, Identifiable {
+    case share
+    case delete
+
+    var id: String { rawValue }
+
+    var icon: Image {
+        switch self {
+        case .delete:
+            Image(systemName: "trash")
+        case .share:
+            Image(systemName: "square.and.arrow.up")
+        }
+    }
+
+    var localizedTitle: String {
+        switch self {
+        case .delete:
+            SDKLocalizedString(
+                "AvatarAction.delete",
+                value: "Delete",
+                comment: "An option in the avatar menu that deletes the avatar"
+            )
+        case .share:
+            SDKLocalizedString(
+                "AvatarAction.share",
+                value: "Share",
+                comment: "An option in the avatar menu that shares the avatar"
+            )
+        }
+    }
+
+    var role: ButtonRole? {
+        switch self {
+        case .delete:
+            .destructive
+        case .share:
+            nil
+        }
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarAction.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarAction.swift
@@ -20,13 +20,13 @@ enum AvatarAction: String, CaseIterable, Identifiable {
         switch self {
         case .delete:
             SDKLocalizedString(
-                "AvatarAction.delete",
+                "AvatarPicker.AvatarAction.delete",
                 value: "Delete",
                 comment: "An option in the avatar menu that deletes the avatar"
             )
         case .share:
             SDKLocalizedString(
-                "AvatarAction.share",
+                "AvatarPicker.AvatarAction.share",
                 value: "Share",
                 comment: "An option in the avatar menu that shares the avatar"
             )

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -291,6 +291,10 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
                 onFailedUploadTapped: { failedUploadInfo in
                     uploadError = failedUploadInfo
                     isUploadErrorDialogPresented = true
+                },
+                onAvatarActionTap: { avatar, action in
+                    // TODO: Replace
+                    print("Avatar action tapped: \(avatar.id), \(action.rawValue)")
                 }
             )
             .padding(.horizontal, Constants.horizontalPadding)
@@ -304,6 +308,10 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
                 onFailedUploadTapped: { failedUploadInfo in
                     uploadError = failedUploadInfo
                     isUploadErrorDialogPresented = true
+                },
+                onAvatarActionTap: { avatar, action in
+                    // TODO: Replace
+                    print("Avatar action tapped: \(avatar.id), \(action.rawValue)")
                 }
             )
             .padding(.top, .DS.Padding.medium)

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarGrid.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarGrid.swift
@@ -23,6 +23,7 @@ struct AvatarGrid<ImageEditor: ImageEditorView>: View {
     let onAvatarTap: (AvatarImageModel) -> Void
     let onImagePickerDidPickImage: (UIImage) -> Void
     let onFailedUploadTapped: (FailedUploadInfo) -> Void
+    let onAvatarActionTap: (AvatarImageModel, AvatarAction) -> Void
 
     var body: some View {
         LazyVGrid(columns: gridItems, spacing: AvatarGridConstants.avatarSpacing) {
@@ -45,7 +46,10 @@ struct AvatarGrid<ImageEditor: ImageEditorView>: View {
                         grid.selectedAvatar?.id == avatar.id
                     },
                     onAvatarTap: onAvatarTap,
-                    onFailedUploadTapped: onFailedUploadTapped
+                    onFailedUploadTapped: onFailedUploadTapped,
+                    onActionTap: { action in
+                        onAvatarActionTap(avatar, action)
+                    }
                 )
             }
         }
@@ -67,6 +71,8 @@ struct AvatarGrid<ImageEditor: ImageEditorView>: View {
         } onImagePickerDidPickImage: { image in
             grid.append(newAvatarModel(image))
         } onFailedUploadTapped: { _ in
+            // No op. inside the preview.
+        } onAvatarActionTap: { _, _ in
             // No op. inside the preview.
         }
         .padding()

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
@@ -68,7 +68,6 @@ struct AvatarPickerAvatarView: View {
         }
     }
 
-    @ViewBuilder
     func ellipsisView() -> some View {
         Image("more-horizontal", bundle: Bundle.module).renderingMode(.template)
             .tint(.white)
@@ -77,7 +76,6 @@ struct AvatarPickerAvatarView: View {
             .padding(CGFloat.DS.Padding.half)
     }
 
-    @ViewBuilder
     func actionsMenu() -> some View {
         Menu {
             ForEach(AvatarAction.allCases) { action in

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
@@ -13,6 +13,7 @@ struct AvatarPickerAvatarView: View {
     let shouldSelect: () -> Bool
     let onAvatarTap: (AvatarImageModel) -> Void
     let onFailedUploadTapped: (FailedUploadInfo) -> Void
+    let onActionTap: (AvatarAction) -> Void
 
     var body: some View {
         AvatarView(
@@ -54,10 +55,44 @@ struct AvatarPickerAvatarView: View {
                 }
                 .cornerRadius(AvatarGridConstants.avatarCornerRadius)
             case .loaded:
-                EmptyView()
+                VStack {
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        actionsMenu()
+                    }
+                }
             }
         }.onTapGesture {
             onAvatarTap(avatar)
+        }
+    }
+
+    @ViewBuilder
+    func ellipsisView() -> some View {
+        Image("more-horizontal", bundle: Bundle.module).renderingMode(.template)
+            .tint(.white)
+            .background(Color(uiColor: UIColor.gravatarBlack.withAlphaComponent(0.4)))
+            .cornerRadius(2)
+            .padding(CGFloat.DS.Padding.half)
+    }
+
+    @ViewBuilder
+    func actionsMenu() -> some View {
+        Menu {
+            ForEach(AvatarAction.allCases) { action in
+                Button(role: action.role) {
+                    onActionTap(action)
+                } label: {
+                    Label {
+                        Text(action.localizedTitle)
+                    } icon: {
+                        action.icon
+                    }
+                }
+            }
+        } label: {
+            ellipsisView()
         }
     }
 }
@@ -68,5 +103,6 @@ struct AvatarPickerAvatarView: View {
         false
     } onAvatarTap: { _ in
     } onFailedUploadTapped: { _ in
+    } onActionTap: { _ in
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/HorizontalAvatarGrid.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/HorizontalAvatarGrid.swift
@@ -9,6 +9,7 @@ struct HorizontalAvatarGrid: View {
 
     let onAvatarTap: (AvatarImageModel) -> Void
     let onFailedUploadTapped: (FailedUploadInfo) -> Void
+    let onAvatarActionTap: (AvatarImageModel, AvatarAction) -> Void
 
     var body: some View {
         ScrollView(.horizontal) {
@@ -22,7 +23,10 @@ struct HorizontalAvatarGrid: View {
                             grid.selectedAvatar?.id == avatar.id
                         },
                         onAvatarTap: onAvatarTap,
-                        onFailedUploadTapped: onFailedUploadTapped
+                        onFailedUploadTapped: onFailedUploadTapped,
+                        onActionTap: { action in
+                            onAvatarActionTap(avatar, action)
+                        }
                     )
                 }
             }
@@ -47,6 +51,8 @@ struct HorizontalAvatarGrid: View {
     return HorizontalAvatarGrid(grid: grid) { avatar in
         grid.selectAvatar(withID: avatar.id)
     } onFailedUploadTapped: { _ in
+        // No op. Inside the preview.
+    } onAvatarActionTap: { _, _ in
         // No op. Inside the preview.
     }
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/Gravatar-SDK-iOS/issues/536

### Description

Adds the menu with 2 sample items. At the moment the buttons don't do anything other than printing to the console.

<img src="https://github.com/user-attachments/assets/db7b6e90-3404-4ca8-b285-f57940b8b5be" width=300/>

### Testing Steps

The avatars should have the ... menu, and 2 menu items should appear.