### PR TITLE
Optimize avatar thumbnail size

### DIFF
--- a/Sources/Gravatar/Network/AvatarType.swift
+++ b/Sources/Gravatar/Network/AvatarType.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public protocol AvatarType: Sendable {
     var url: String { get }
     var id: String { get }
@@ -10,6 +12,13 @@ extension Avatar: AvatarType {
 
     public var url: String {
         imageUrl
+    }
+
+    package func url(withSize size: String) -> String {
+        if let newURL = URLComponents(string: url)?.replacingQueryItem(name: "size", value: size).string {
+            return newURL
+        }
+        return url
     }
 
     package var isSelected: Bool {

--- a/Sources/Gravatar/URLComponents+Additions.swift
+++ b/Sources/Gravatar/URLComponents+Additions.swift
@@ -30,7 +30,8 @@ extension URLComponents {
         let newItem = URLQueryItem(name: name, value: value)
 
         if var queryItems = self.queryItems,
-           let sizeItemIndex = queryItems.firstIndex(where: { $0.name == name }) {
+           let sizeItemIndex = queryItems.firstIndex(where: { $0.name == name })
+        {
             // Replace the query item
             queryItems[sizeItemIndex] = newItem
             copy.queryItems = queryItems

--- a/Sources/Gravatar/URLComponents+Additions.swift
+++ b/Sources/Gravatar/URLComponents+Additions.swift
@@ -23,4 +23,22 @@ extension URLComponents {
 
         return copy
     }
+
+    /// Replaces the query item if it exists, otherwise adds a new one.
+    package func replacingQueryItem(name: String, value: String?) -> URLComponents {
+        var copy = self
+        let newItem = URLQueryItem(name: name, value: value)
+
+        if var queryItems = self.queryItems,
+           let sizeItemIndex = queryItems.firstIndex(where: { $0.name == name }) {
+            // Replace the query item
+            queryItems[sizeItemIndex] = newItem
+            copy.queryItems = queryItems
+        } else {
+            // Add the query item if it doesn't exist
+            copy.queryItems = (self.queryItems ?? []) + [newItem]
+        }
+
+        return copy
+    }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -190,7 +190,7 @@ class AvatarPickerViewModel: ObservableObject {
             )
             ImageCache.shared.setEntry(.ready(squareImage), for: avatar.url)
 
-            let newModel = AvatarImageModel(id: avatar.id, source: .remote(url: avatar.url))
+            let newModel = AvatarImageModel(with: avatar)
             grid.replaceModel(withID: localID, with: newModel)
 
             if avatar.isSelected {
@@ -354,7 +354,8 @@ extension UIImage {
 extension AvatarImageModel {
     init(with avatar: Avatar) {
         id = avatar.id
-        source = .remote(url: avatar.url)
+        let thumbnailSize = Int(ceil(AvatarGridConstants.maxAvatarWidth * UITraitCollection.current.displayScale))
+        source = .remote(url: avatar.url(withSize: String(thumbnailSize)))
         state = .loaded
         isSelected = avatar.isSelected
     }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -354,8 +354,8 @@ extension UIImage {
 extension AvatarImageModel {
     init(with avatar: Avatar) {
         id = avatar.id
-        let thumbnailSize = Int(ceil(AvatarGridConstants.maxAvatarWidth * UITraitCollection.current.displayScale))
-        source = .remote(url: avatar.url(withSize: String(thumbnailSize)))
+        let avatarGridItemSize = Int(AvatarGridConstants.maxAvatarWidth * UITraitCollection.current.displayScale)
+        source = .remote(url: avatar.url(withSize: String(avatarGridItemSize)))
         state = .loaded
         isSelected = avatar.isSelected
     }

--- a/Tests/GravatarTests/URLComponentsTests.swift
+++ b/Tests/GravatarTests/URLComponentsTests.swift
@@ -86,7 +86,7 @@ final class URLComponentsTests: XCTestCase {
         let newURL = urlComponents.replacingQueryItem(name: "c", value: "123").string
         XCTAssertEqual(newURL, "https://example.com/path?a=1&b=2&c=123")
     }
-    
+
     func testReplaceQueryItemWhenNoQueryItemExists() throws {
         let urlComponents = try XCTUnwrap(URLComponents(string: "https://example.com/path"))
         let newURL = urlComponents.replacingQueryItem(name: "a", value: "123").string

--- a/Tests/GravatarTests/URLComponentsTests.swift
+++ b/Tests/GravatarTests/URLComponentsTests.swift
@@ -74,6 +74,24 @@ final class URLComponentsTests: XCTestCase {
         let componentsWithoutQueryItems = componentsWithQueryItems?.settingQueryItems([], shouldEncodePlusChar: true)
         XCTAssertNil(componentsWithoutQueryItems?.queryItems, "QueryItems should be nil")
     }
+
+    func testReplaceQueryItemWhenItemAlreadyExists() throws {
+        let urlComponents = try XCTUnwrap(URLComponents(string: "https://example.com/path?a=1&b=2"))
+        let newURL = urlComponents.replacingQueryItem(name: "a", value: "123").string
+        XCTAssertEqual(newURL, "https://example.com/path?a=123&b=2")
+    }
+
+    func testReplaceQueryItemWithNewItem() throws {
+        let urlComponents = try XCTUnwrap(URLComponents(string: "https://example.com/path?a=1&b=2"))
+        let newURL = urlComponents.replacingQueryItem(name: "c", value: "123").string
+        XCTAssertEqual(newURL, "https://example.com/path?a=1&b=2&c=123")
+    }
+    
+    func testReplaceQueryItemWhenNoQueryItemExists() throws {
+        let urlComponents = try XCTUnwrap(URLComponents(string: "https://example.com/path"))
+        let newURL = urlComponents.replacingQueryItem(name: "a", value: "123").string
+        XCTAssertEqual(newURL, "https://example.com/path?a=123")
+    }
 }
 
 private struct TestQueryItems {


### PR DESCRIPTION
Closes #

### Description

Our avatar grid items are 512px by default(server returns that way), which is bigger than what we need for a thumbnail. 

https://2.gravatar.com/userimage/110207384/45d513e372aff2b7d882025b4b99e036?size=512

Max avatar size in the grid is 100x100pt. So its at most 3x100px. We can use `AvatarGridConstants.maxAvatarWidth` instead.

### Testing Steps

QE Avatars should load without a problem.