### PR TITLE
Notify 3rd party when the selected avatar has been deleted

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarGridModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarGridModel.swift
@@ -69,6 +69,9 @@ class AvatarGridModel: ObservableObject {
     func deleteModel(_ id: String) -> Int {
         let index = avatars.firstIndex { $0.id == id }!
         avatars.removeAll { $0.id == id }
+        if selectedAvatar?.id == id {
+            selectedAvatar = nil
+        }
         return index
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -131,7 +131,10 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
                             // The animation won't run during the action-sheet dismissal
                             // This delay will allow the avatar deletion animation to run.
                             try? await Task.sleep(nanoseconds: 10_000_000)
-                            await model.delete(avatar)
+                            let isDeletingSelected = model.grid.selectedAvatar == avatar
+                            if await model.delete(avatar), isDeletingSelected {
+                                notifyAvatarSelection()
+                            }
                         }
                     } label: {
                         Label(Localized.deletionConfirmationButtonTitle, systemImage: "trash")

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -362,8 +362,8 @@ class AvatarPickerViewModel: ObservableObject {
         of avatar: AvatarImageModel,
         token: String,
         deletingAvatarIndex: Int,
-        previouslySelectedAvatar: AvatarImageModel?) async -> Bool
-    {
+        previouslySelectedAvatar: AvatarImageModel?
+    ) async -> Bool {
         do {
             try await avatarService.delete(avatarID: avatar.id, accessToken: token)
             return true


### PR DESCRIPTION
Closes #

### Description

This PR fixes an issue where the sdk user didn't receive a notification when the selected avatar has been deleted.

![CleanShot 2024-11-28 at 11 30 02](https://github.com/user-attachments/assets/8a092747-9783-428b-b07d-9f5922c48d98)


### Testing Steps

- Run the demo app
- Open the Quick Editor demo
- Select an avatar
- Delete de selected avatar
  - Check that the profile card avatar changes to empty
  - Check that the 3rd party's avatar card (behind the QE) changes to empty.
 
