### PR TITLE
Add a new toast type "warning"

### DIFF
--- a/Sources/GravatarUI/DesignSystem/UIColor+DesignSystem.swift
+++ b/Sources/GravatarUI/DesignSystem/UIColor+DesignSystem.swift
@@ -44,6 +44,10 @@ extension UIColor {
     static let bovineGray: UIColor = .rgba(80, 87, 94)
     static let errorBackgroundRed: UIColor = .rgba(244, 162, 162)
     static let alertRed: UIColor = .rgba(204, 24, 24)
+    static let chocolateBrown: UIColor = .rgba(73, 31, 0)
+    static let harvestYellow: UIColor = .rgba(225, 183, 123)
+    static let yellowishWhite: UIColor = .rgba(254, 248, 238)
+    static let butterscotchYellow: UIColor = rgba(240, 184, 73)
 
     static func rgba(_ red: CGFloat, _ green: CGFloat, _ blue: CGFloat, alpha: CGFloat = 1.0) -> UIColor {
         UIColor(red: red / 255, green: green / 255, blue: blue / 255, alpha: alpha)

--- a/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
@@ -1,3 +1,4 @@
+import Gravatar
 import SwiftUI
 
 struct Toast: View {
@@ -6,6 +7,12 @@ struct Toast: View {
         static let backgroundDark: Color = .init(uiColor: .rgba(225, 225, 225))
         static let errorBackgroundLight: Color = .init(uiColor: UIColor.errorBackgroundRed)
         static let errorLineRed: Color = .init(uiColor: UIColor.alertRed)
+        static let warningBackgroundLight: Color = .init(uiColor: .yellowishWhite)
+        static let warningLineLight: Color = .init(uiColor: .butterscotchYellow)
+        static let warningTextLight: Color = .init(uiColor: .gravatarBlack)
+        static let warningBackgroundDark: Color = .init(uiColor: .chocolateBrown)
+        static let warningLineDark: Color = .init(uiColor: .harvestYellow)
+        static let warningTextDark: Color = .init(uiColor: .harvestYellow)
     }
 
     @Environment(\.colorScheme) var colorScheme: ColorScheme
@@ -31,8 +38,8 @@ struct Toast: View {
         .background(backgroundColor)
         .overlay(
             Rectangle()
-                .frame(width: toast.type == .error ? 4 : 0, height: nil, alignment: .leading)
-                .foregroundColor(Color.red), alignment: .leading
+                .frame(width: toast.type != .info ? 4 : 0, height: nil, alignment: .leading)
+                .foregroundColor(lineColor), alignment: .leading
         )
         .cornerRadius(4)
         .foregroundColor(foregroundColor)
@@ -44,6 +51,8 @@ struct Toast: View {
         switch toast.type {
         case .info:
             colorScheme == .dark ? Constants.backgroundDark : Constants.backgroundLight
+        case .warning:
+            colorScheme == .dark ? Constants.warningBackgroundDark : Constants.warningBackgroundLight
         case .error:
             colorScheme == .dark ? Constants.errorBackgroundLight : Constants.errorBackgroundLight
         }
@@ -53,8 +62,21 @@ struct Toast: View {
         switch toast.type {
         case .info:
             Color(UIColor.systemBackground)
+        case .warning:
+            colorScheme == .dark ? Constants.warningTextDark : Constants.warningTextLight
         case .error:
             colorScheme == .dark ? Color(UIColor.gravatarBlack) : Color(UIColor.gravatarBlack)
+        }
+    }
+
+    var lineColor: Color {
+        switch toast.type {
+        case .info:
+            .clear
+        case .warning:
+            colorScheme == .dark ? Constants.warningLineDark : Constants.warningLineLight
+        case .error:
+            Constants.errorLineRed
         }
     }
 }
@@ -69,10 +91,18 @@ struct Toast: View {
         }
 
         Toast(toast: .init(
+            message: "No image selected. Please select one or the default will be used.",
+            type: .warning,
+            stackingBehavior: .avoidStackingWithSameMessage
+        )) { _ in
+        }
+
+        Toast(toast: .init(
             message: "Something went wrong.",
             type: .error,
             stackingBehavior: .alwaysStack
         )) { _ in
         }
     }
+    .padding()
 }

--- a/Sources/GravatarUI/SwiftUI/Toast/ToastManager.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/ToastManager.swift
@@ -41,6 +41,7 @@ class ToastManager: ObservableObject {
 
 enum ToastType: Int {
     case info
+    case warning
     case error
 }
 


### PR DESCRIPTION
First part of #582 

### Description

Adds a new variation to the toast view which will be used for the `no selected avatar` warning. 

The one in the middle is new:

<img width="300" alt="Screenshot 2024-12-02 at 10 20 25" src="https://github.com/user-attachments/assets/7d7e0e06-e66f-48f9-846a-788b3c3e88ee">

<img width="300" alt="Screenshot 2024-12-02 at 10 20 37" src="https://github.com/user-attachments/assets/bf79b2f5-d590-4a18-8399-6bcf618385af">

### Testing Steps

You can refer to `Toast` preview.
