### PR TITLE
QE: Avatar Rating

### DIFF
--- a/Sources/Gravatar/Network/Services/ProfileService.swift
+++ b/Sources/Gravatar/Network/Services/ProfileService.swift
@@ -70,9 +70,7 @@ public struct ProfileService: ProfileFetching, Sendable {
         for avatar: AvatarIdentifier,
         token: String
     ) async throws -> Avatar {
-        guard let url = avatarsBaseURLComponents
-            .settingQueryItems([.init(name: "rating", value: rating.rawValue)]).url?
-            .appendingPathComponent(avatar.id)
+        guard let url = avatarsBaseURLComponents.url?.appendingPathComponent(avatar.id)
         else {
             throw APIError.requestError(reason: .urlInitializationFailed)
         }

--- a/Sources/Gravatar/Network/Services/ProfileService.swift
+++ b/Sources/Gravatar/Network/Services/ProfileService.swift
@@ -71,7 +71,7 @@ public struct ProfileService: ProfileFetching, Sendable {
         token: String
     ) async throws -> Avatar {
         guard let url = avatarsBaseURLComponents
-            .settingQueryItems([.init(name: "raiting", value: rating.rawValue)]).url?
+            .settingQueryItems([.init(name: "rating", value: rating.rawValue)]).url?
             .appendingPathComponent(avatar.id)
         else {
             throw APIError.requestError(reason: .urlInitializationFailed)

--- a/Sources/Gravatar/Network/Services/ProfileService.swift
+++ b/Sources/Gravatar/Network/Services/ProfileService.swift
@@ -3,8 +3,12 @@ import Foundation
 private let baseURL = URL(string: "https://api.gravatar.com/v3/profiles/")!
 private let avatarsBaseURLComponents = URLComponents(string: "https://api.gravatar.com/v3/me/avatars")!
 
+private func avatarBaseURL(with avatarID: String) -> URL? {
+    URL(string: "https://api.gravatar.com/v3/me/avatars/\(avatarID)")
+}
+
 private func selectAvatarBaseURL(with avatarID: String) -> URL? {
-    URL(string: "https://api.gravatar.com/v3/me/avatars/\(avatarID)/email")
+    avatarBaseURL(with: avatarID)?.appendingPathComponent("email")
 }
 
 /// A service to perform Profile related tasks.
@@ -53,6 +57,32 @@ public struct ProfileService: ProfileFetching, Sendable {
             var request = URLRequest(url: url).settingAuthorizationHeaderField(with: token)
             request.httpMethod = "POST"
             request.httpBody = try SelectAvatarBody(emailHash: profileID.id).data
+            let (data, _) = try await client.data(with: request)
+            return try data.decode()
+        } catch {
+            throw error.apiError()
+        }
+    }
+
+    @discardableResult
+    package func setRating(
+        _ rating: AvatarRating,
+        for avatar: AvatarIdentifier,
+        token: String
+    ) async throws -> Avatar {
+        guard let url = avatarsBaseURLComponents
+            .settingQueryItems([.init(name: "raiting", value: rating.rawValue)]).url?
+            .appendingPathComponent(avatar.id)
+        else {
+            throw APIError.requestError(reason: .urlInitializationFailed)
+        }
+
+        do {
+            var request = URLRequest(url: url).settingAuthorizationHeaderField(with: token)
+            request.httpMethod = "PATCH"
+
+            let requestBody = try JSONEncoder().encode(UpdateAvatarRequest(rating: rating))
+            request.httpBody = requestBody
             let (data, _) = try await client.data(with: request)
             return try data.decode()
         } catch {

--- a/Sources/Gravatar/OpenApi/Generated/Avatar.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Avatar.swift
@@ -3,11 +3,19 @@ import Foundation
 /// An avatar that the user has already uploaded to their Gravatar account.
 ///
 package struct Avatar: Codable, Hashable, Sendable {
+    package enum Rating: String, Codable, CaseIterable, Sendable {
+        case g = "G"
+        case pg = "PG"
+        case r = "R"
+        case x = "X"
+    }
+
     /// Unique identifier for the image.
     package private(set) var imageId: String
     /// Image URL
     package private(set) var imageUrl: String
-    package private(set) var rating: AvatarRating
+    /// Rating associated with the image.
+    package private(set) var rating: Rating
     /// Alternative text description of the image.
     package private(set) var altText: String
     /// Whether the image is currently selected as the provided selected email's avatar.
@@ -15,7 +23,7 @@ package struct Avatar: Codable, Hashable, Sendable {
     /// Date and time when the image was last updated.
     package private(set) var updatedDate: Date
 
-    package init(imageId: String, imageUrl: String, rating: AvatarRating, altText: String, selected: Bool? = nil, updatedDate: Date) {
+    package init(imageId: String, imageUrl: String, rating: Rating, altText: String, selected: Bool? = nil, updatedDate: Date) {
         self.imageId = imageId
         self.imageUrl = imageUrl
         self.rating = rating

--- a/Sources/Gravatar/OpenApi/Generated/Avatar.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Avatar.swift
@@ -3,19 +3,11 @@ import Foundation
 /// An avatar that the user has already uploaded to their Gravatar account.
 ///
 package struct Avatar: Codable, Hashable, Sendable {
-    package enum Rating: String, Codable, CaseIterable, Sendable {
-        case g = "G"
-        case pg = "PG"
-        case r = "R"
-        case x = "X"
-    }
-
     /// Unique identifier for the image.
     package private(set) var imageId: String
     /// Image URL
     package private(set) var imageUrl: String
-    /// Rating associated with the image.
-    package private(set) var rating: Rating
+    package private(set) var rating: AvatarRating
     /// Alternative text description of the image.
     package private(set) var altText: String
     /// Whether the image is currently selected as the provided selected email's avatar.
@@ -23,7 +15,7 @@ package struct Avatar: Codable, Hashable, Sendable {
     /// Date and time when the image was last updated.
     package private(set) var updatedDate: Date
 
-    package init(imageId: String, imageUrl: String, rating: Rating, altText: String, selected: Bool? = nil, updatedDate: Date) {
+    package init(imageId: String, imageUrl: String, rating: AvatarRating, altText: String, selected: Bool? = nil, updatedDate: Date) {
         self.imageId = imageId
         self.imageUrl = imageUrl
         self.rating = rating

--- a/Sources/GravatarUI/Avatar+AvatarRating.swift
+++ b/Sources/GravatarUI/Avatar+AvatarRating.swift
@@ -1,0 +1,13 @@
+extension Avatar {
+    /// Transforms `Avatar.Rating` into `AvatarRating`
+    /// This is only necessary while we maintain both enums.  For our next major realease, `Avatar` will use the `AvatarRating` enum
+    /// rather than defining its own.
+    var avatarRating: AvatarRating {
+        switch self.rating {
+        case .g: .g
+        case .pg: .pg
+        case .r: .r
+        case .x: .x
+        }
+    }
+}

--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -1,5 +1,20 @@
+/* Rating that indicates that the avatar is suitable for everyone */
+"Avatar.Rating.G.subtitle" = "General";
+
+/* Rating that indicates that the avatar may not be suitable for children */
+"Avatar.Rating.PG.subtitle" = "Parental Guidance";
+
+/* Rating that indicates that the avatar may not be suitable for children */
+"Avatar.Rating.R.subtitle" = "Restricted";
+
+/* Rating that indicates that the avatar is obviously and extremely unsuitable for children */
+"Avatar.Rating.X.subtitle" = "Extreme";
+
 /* An option in the avatar menu that deletes the avatar */
 "AvatarPicker.AvatarAction.delete" = "Delete";
+
+/* An option in the avatar menu that shows the current rating, and allows the user to change that rating. The rating is used to indicate the appropriateness of an avatar for different audiences, and follows the US system of Motion Picture ratings: G, PG, R, and X. */
+"AvatarPicker.AvatarAction.rate" = "Rating: %@";
 
 /* An option in the avatar menu that shares the avatar */
 "AvatarPicker.AvatarAction.share" = "Share...";
@@ -81,6 +96,12 @@
 
 /* This error message shows when the user attempts to delete an avatar and fails. */
 "AvatarPickerViewModel.Delete.Error" = "Oops, there was an error deleting the image.";
+
+/* This error message shows when the user attempts to change the rating of an avatar and fails. */
+"AvatarPickerViewModel.Rating.Error" = "Oops, something didn't quite work out while trying to rate your avatar.";
+
+/* This confirmation message shows when the user picks a different avatar rating and the change was applied successfully. */
+"AvatarPickerViewModel.RatingUpdate.Success" = "Avatar rating was changed successfully.";
 
 /* This error message shows when the user attempts to share an avatar and fails. */
 "AvatarPickerViewModel.Share.Fail" = "Oops, something didn't quite work out while trying to share your avatar.";

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarAction.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarAction.swift
@@ -1,23 +1,20 @@
 import Foundation
 import SwiftUI
 
-enum AvatarAction: String, CaseIterable, Identifiable {
+enum AvatarAction: Identifiable {
     case share
     case delete
+    case rating(AvatarRating)
     case playground
 
-    static var allCases: [AvatarAction] {
-        var cases: [AvatarAction] = []
-        if #available(iOS 18.2, *) {
-            if EnvironmentValues().supportsImagePlayground {
-                cases.append(.playground)
-            }
+    var id: String {
+        switch self {
+        case .share: "share"
+        case .delete: "delete"
+        case .rating(let rating): rating.rawValue
+        case .playground: "playground"
         }
-        cases.append(contentsOf: [.share, .delete])
-        return cases
     }
-
-    var id: String { rawValue }
 
     var icon: Image {
         switch self {
@@ -27,6 +24,8 @@ enum AvatarAction: String, CaseIterable, Identifiable {
             Image(systemName: "square.and.arrow.up")
         case .playground:
             Image(systemName: "apple.image.playground")
+        case .rating:
+            Image(systemName: "eye")
         }
     }
 
@@ -50,6 +49,15 @@ enum AvatarAction: String, CaseIterable, Identifiable {
                 value: "Playground",
                 comment: "An option to show the image playground"
             )
+        case .rating(let rating):
+            String(
+                format: SDKLocalizedString(
+                    "AvatarPicker.AvatarAction.rate",
+                    value: "Rating: %@",
+                    comment: "An option in the avatar menu that shows the current rating, and allows the user to change that rating. The rating is used to indicate the appropriateness of an avatar for different audiences, and follows the US system of Motion Picture ratings: G, PG, R, and X."
+                ),
+                rating.rawValue
+            )
         }
     }
 
@@ -57,7 +65,7 @@ enum AvatarAction: String, CaseIterable, Identifiable {
         switch self {
         case .delete:
             .destructive
-        case .share, .playground:
+        case .share, .rating, .playground:
             nil
         }
     }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarAction.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarAction.swift
@@ -25,7 +25,7 @@ enum AvatarAction: Identifiable {
         case .playground:
             Image(systemName: "apple.image.playground")
         case .rating:
-            Image(systemName: "eye")
+            Image(systemName: "star.leadinghalf.filled")
         }
     }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarImageModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarImageModel.swift
@@ -17,6 +17,7 @@ struct AvatarImageModel: Hashable, Identifiable, Sendable {
     let source: Source
     let isSelected: Bool
     let state: State
+    let rating: AvatarRating
 
     var url: URL? {
         guard case .remote(let url) = source else {
@@ -46,14 +47,15 @@ struct AvatarImageModel: Hashable, Identifiable, Sendable {
         return image
     }
 
-    init(id: String, source: Source, state: State = .loaded, isSelected: Bool = false) {
+    init(id: String, source: Source, state: State = .loaded, isSelected: Bool = false, rating: AvatarRating = .g) {
         self.id = id
         self.source = source
         self.state = state
         self.isSelected = isSelected
+        self.rating = rating
     }
 
     func settingStatus(to newStatus: State) -> AvatarImageModel {
-        AvatarImageModel(id: id, source: source, state: newStatus, isSelected: isSelected)
+        AvatarImageModel(id: id, source: source, state: newStatus, isSelected: isSelected, rating: rating)
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -383,6 +383,10 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
                     playgroundInputItem = PlaygroundInputItem(id: avatar.id, image: Image(uiImage: image))
                 }
             }
+        case .rating(let rating):
+            Task {
+                await model.setRating(rating, for: avatar)
+            }
         }
     }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -349,6 +349,7 @@ class AvatarPickerViewModel: ObservableObject {
             )
             withAnimation {
                 grid.replaceModel(withID: avatar.id, with: .init(with: updatedAvatar))
+                toastManager.showToast(Localized.avatarRatingUpdateSuccess, type: .info)
             }
         } catch APIError.responseError(let reason) where reason.urlSessionErrorLocalizedDescription != nil {
             handleError(message: reason.urlSessionErrorLocalizedDescription ?? Localized.avatarRatingError)
@@ -442,6 +443,11 @@ extension AvatarPickerViewModel {
             "AvatarPickerViewModel.Share.Fail",
             value: "Oops, something didn't quite work out while trying to share your avatar.",
             comment: "This error message shows when the user attempts to share an avatar and fails."
+        )
+        static let avatarRatingUpdateSuccess = SDKLocalizedString(
+            "AvatarPickerViewModel.RatingUpdate.Success",
+            value: "Avatar rating was changed successfully",
+            comment: "This confirmation message shows when the user picks a different avatar rating and the change was applied successfully."
         )
         static let avatarRatingError = SDKLocalizedString(
             "AvatarPickerViewModel.Rating.Error",

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -207,7 +207,7 @@ class AvatarPickerViewModel: ObservableObject {
 
         let localID = UUID().uuidString
 
-        let localImageModel = AvatarImageModel(id: localID, source: .local(image: image), state: .loading)
+        let localImageModel = AvatarImageModel(id: localID, source: .local(image: image), state: .loading, rating: .g)
         grid.append(localImageModel)
 
         await doUpload(squareImage: image, localID: localID, accessToken: authToken)
@@ -290,7 +290,8 @@ class AvatarPickerViewModel: ObservableObject {
         let newModel = AvatarImageModel(
             id: imageID,
             source: .local(image: squareImage),
-            state: .error(supportsRetry: supportsRetry, errorMessage: errorMessage)
+            state: .error(supportsRetry: supportsRetry, errorMessage: errorMessage),
+            rating: grid.model(with: imageID)?.rating ?? .g
         )
         grid.replaceModel(withID: imageID, with: newModel)
     }
@@ -335,6 +336,21 @@ class AvatarPickerViewModel: ObservableObject {
         // We need to await them otherwise network requests can be cancelled.
         await avatars
         await profile
+    }
+
+    func setRating(_ rating: AvatarRating, for avatar: AvatarImageModel) async {
+        guard let authToken else { return }
+
+        do {
+            let updatedAvatar = try await profileService.setRating(
+                rating,
+                for: .hashID(avatar.id),
+                token: authToken
+            )
+            grid.replaceModel(withID: avatar.id, with: .init(with: updatedAvatar))
+        } catch {
+            // TODO: Handle error
+        }
     }
 
     func delete(_ avatar: AvatarImageModel) async -> Bool {
@@ -440,5 +456,6 @@ extension AvatarImageModel {
         source = .remote(url: avatar.url(withSize: String(avatarGridItemSize)))
         state = .loaded
         isSelected = avatar.isSelected
+        rating = avatar.rating
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -348,8 +348,14 @@ class AvatarPickerViewModel: ObservableObject {
                 token: authToken
             )
             grid.replaceModel(withID: avatar.id, with: .init(with: updatedAvatar))
+        } catch APIError.responseError(let reason) where reason.urlSessionErrorLocalizedDescription != nil {
+            handleError(message: reason.urlSessionErrorLocalizedDescription ?? Localized.avatarRatingError)
         } catch {
-            // TODO: Handle error
+            handleError(message: Localized.avatarRatingError)
+        }
+
+        func handleError(message: String) {
+            toastManager.showToast(message, type: .error)
         }
     }
 
@@ -434,6 +440,11 @@ extension AvatarPickerViewModel {
             "AvatarPickerViewModel.Share.Fail",
             value: "Oops, something didn't quite work out while trying to share your avatar.",
             comment: "This error message shows when the user attempts to share an avatar and fails."
+        )
+        static let avatarRatingError = SDKLocalizedString(
+            "AvatarPickerViewModel.Rating.Error",
+            value: "Oops, something didn't quite work out while trying to rate your avatar.",
+            comment: "This error message shows when the user attempts to change the rating of an avatar and fails."
         )
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -446,7 +446,7 @@ extension AvatarPickerViewModel {
         )
         static let avatarRatingUpdateSuccess = SDKLocalizedString(
             "AvatarPickerViewModel.RatingUpdate.Success",
-            value: "Avatar rating was changed successfully",
+            value: "Avatar rating was changed successfully.",
             comment: "This confirmation message shows when the user picks a different avatar rating and the change was applied successfully."
         )
         static let avatarRatingError = SDKLocalizedString(

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -347,7 +347,9 @@ class AvatarPickerViewModel: ObservableObject {
                 for: .hashID(avatar.id),
                 token: authToken
             )
-            grid.replaceModel(withID: avatar.id, with: .init(with: updatedAvatar))
+            withAnimation {
+                grid.replaceModel(withID: avatar.id, with: .init(with: updatedAvatar))
+            }
         } catch APIError.responseError(let reason) where reason.urlSessionErrorLocalizedDescription != nil {
             handleError(message: reason.urlSessionErrorLocalizedDescription ?? Localized.avatarRatingError)
         } catch {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -456,6 +456,6 @@ extension AvatarImageModel {
         source = .remote(url: avatar.url(withSize: String(avatarGridItemSize)))
         state = .loaded
         isSelected = avatar.isSelected
-        rating = avatar.rating
+        rating = avatar.avatarRating
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
@@ -166,7 +166,7 @@ extension AvatarRating {
             SDKLocalizedString(
                 "Avatar.Rating.X.subtitle",
                 value: "Extreme",
-                comment: "Rating that indicates that the avatar is obviously and extremely suitable for children"
+                comment: "Rating that indicates that the avatar is obviously and extremely unsuitable for children"
             )
         }
     }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
@@ -91,7 +91,7 @@ struct AvatarPickerAvatarView: View {
             Section {
                 Menu {
                     ForEach(AvatarRating.allCases, id: \.self) { rating in
-                        button(for: .rating(rating))
+                        button(for: .rating(rating), isSelected: rating == avatar.rating)
                     }
                 } label: {
                     label(forAction: AvatarAction.rating(avatar.rating))
@@ -105,35 +105,38 @@ struct AvatarPickerAvatarView: View {
         }
     }
 
-    func button(for action: AvatarAction) -> some View {
-        Group {
+    private func button(
+        for action: AvatarAction,
+        isSelected selected: Bool = false,
+        systemImageWhenSelected systemImage: String = "checkmark"
+    ) -> some View {
+        Button(role: action.role) {
+            onActionTap(action)
+        } label: {
             switch action {
             case .rating(let rating):
-                Button(role: action.role) {
-                    onActionTap(action)
-                } label: {
-                    let buttonTitle = "\(rating.rawValue) (\(rating.localizedSubtitle))"
-                    if rating == avatar.rating {
-                        Label(buttonTitle, systemImage: "checkmark")
-                    } else {
-                        Text(buttonTitle)
-                    }
+                let buttonTitle = "\(rating.rawValue) (\(rating.localizedSubtitle))"
+
+                if selected {
+                    label(forAction: action, title: buttonTitle, systemImage: systemImage)
+                } else {
+                    Text(buttonTitle)
                 }
             case .delete, .playground, .share:
-                Button(role: action.role) {
-                    onActionTap(action)
-                } label: {
-                    label(forAction: action)
-                }
+                label(forAction: action)
             }
         }
     }
 
-    func label(forAction action: AvatarAction) -> Label<Text, Image> {
+    private func label(forAction action: AvatarAction, title: String? = nil, systemImage: String) -> Label<Text, Image> {
+        label(forAction: action, title: title, image: Image(systemName: systemImage))
+    }
+
+    private func label(forAction action: AvatarAction, title: String? = nil, image: Image? = nil) -> Label<Text, Image> {
         Label {
-            Text(action.localizedTitle)
+            Text(title ?? action.localizedTitle)
         } icon: {
-            action.icon
+            image ?? action.icon
         }
     }
 }

--- a/Sources/TestHelpers/Bundle+ResourceBundle.swift
+++ b/Sources/TestHelpers/Bundle+ResourceBundle.swift
@@ -44,6 +44,10 @@ extension Bundle {
         testsBundle.jsonData(forResource: "avatarUploadResponse")
     }
 
+    public static var setRatingJsonData: Data {
+        testsBundle.jsonData(forResource: "avatarSetRatingResponse")
+    }
+
     public static var getAvatarsJsonData: Data {
         testsBundle.jsonData(forResource: "avatarsResponse")
     }

--- a/Sources/TestHelpers/Resources/avatarSetRatingResponse.json
+++ b/Sources/TestHelpers/Resources/avatarSetRatingResponse.json
@@ -1,0 +1,7 @@
+{
+    "image_id": "6f3eac1c67f970f2a0c2ea8",
+    "image_url": "https://2.gravatar.com/userimage/133992/9862792c5653946c?size=512",
+    "rating": "G",
+    "updated_date": "2024-09-19T11:46:04Z",
+    "alt_text": "John Appleseed's avatar"
+}

--- a/Sources/TestHelpers/Resources/avatarSetRatingResponse.json
+++ b/Sources/TestHelpers/Resources/avatarSetRatingResponse.json
@@ -1,7 +1,7 @@
 {
-    "image_id": "6f3eac1c67f970f2a0c2ea8",
-    "image_url": "https://2.gravatar.com/userimage/133992/9862792c5653946c?size=512",
-    "rating": "G",
-    "updated_date": "2024-09-19T11:46:04Z",
-    "alt_text": "John Appleseed's avatar"
+  "image_id": "991a7b71cf9f34...",
+  "image_url": "https://2.gravatar.com/userimage/1/991a7b71cf934ea2...?size=512",
+  "rating": "PG",
+  "updated_date": "2024-09-18T10:17:53Z",
+  "alt_text": "John Appleseed's avatar"
 }

--- a/Tests/GravatarTests/ProfileServiceTests.swift
+++ b/Tests/GravatarTests/ProfileServiceTests.swift
@@ -70,4 +70,31 @@ final class ProfileServiceTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
+
+    func testSetRatingReturnsAvatar() async throws {
+        let data = Bundle.setRatingJsonData
+        let session = URLSessionMock(returnData: data, response: .successResponse())
+        let service = ProfileService(urlSession: session)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let referenceAvatar = try decoder.decode(Avatar.self, from: data)
+        let avatar = try await service.setRating(.g, for: .email("test@example.com"), token: "faketoken")
+
+        XCTAssertEqual(avatar, referenceAvatar)
+    }
+
+    func testSetRatingHandlesError() async {
+        let session = URLSessionMock(returnData: Data(), response: .errorResponse(code: 403))
+        let service = ProfileService(urlSession: session)
+
+        do {
+            try await service.setRating(.g, for: .email("test@example.com"), token: "faketoken")
+        } catch APIError.responseError(reason: .invalidHTTPStatusCode(let response, _)) {
+            XCTAssertEqual(response.statusCode, 403)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
 }

--- a/Tests/GravatarUITests/AvatarPickerViewModelTests.swift
+++ b/Tests/GravatarUITests/AvatarPickerViewModelTests.swift
@@ -274,10 +274,6 @@ final class URLSessionAvatarPickerMock: URLSessionProtocol {
         case avatars
     }
 
-    enum QueryType: String {
-        case rating
-    }
-
     init(returnErrorCode: Int? = nil) {
         self.returnErrorCode = returnErrorCode
     }
@@ -313,7 +309,10 @@ final class URLSessionAvatarPickerMock: URLSessionProtocol {
     private func isSetAvatarRatingRequest(_ request: URLRequest) -> Bool {
         guard request.httpMethod == "PATCH",
               request.url?.absoluteString.contains(RequestType.avatars.rawValue) == true,
-              request.url?.query?.contains(QueryType.rating.rawValue) == true
+              let bodyData = request.httpBody,
+              let updateAvatarRequestBody = try? JSONDecoder().decode(UpdateAvatarRequest.self, from: bodyData),
+              updateAvatarRequestBody.rating != nil
+
         else {
             return false
         }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -738,7 +738,7 @@ paths:
         '403':
           description: Insufficient Scope
           $ref: '#/components/responses/insufficient_scope'
-  /me/avatars/{imageHash}:
+  /me/avatars/{imageId}:
     delete:
       summary: Delete avatar
       description: Deletes a specific avatar for the authenticated user.
@@ -748,14 +748,14 @@ paths:
       security:
         - oauth: []
       parameters:
-        - name: imageHash
+        - name: imageId
           in: path
           required: true
-          description: The hash of the avatar to delete.
+          description: The ID of the avatar to delete.
           schema:
             type: string
       responses:
-        '200':
+        '204':
           description: Avatar deleted successfully
         '401':
           description: Not Authorized
@@ -763,8 +763,6 @@ paths:
         '403':
           description: Insufficient Scope
           $ref: '#/components/responses/insufficient_scope'
-        '404':
-          description: Avatar not found
     patch:
       summary: Update avatar data
       description: Updates the avatar data for a given avatar for the authenticated user.
@@ -795,10 +793,10 @@ paths:
                       providing globally unique avatars.
               required: []
       parameters:
-        - name: imageHash
+        - name: imageId
           in: path
           required: true
-          description: The hash of the avatar to update.
+          description: The ID of the avatar to update.
           schema:
             type: string
       responses:
@@ -814,8 +812,6 @@ paths:
         '403':
           description: Insufficient Scope
           $ref: '#/components/responses/insufficient_scope'
-        '404':
-          description: Avatar not found
   /me/avatars/{imageId}/email:
     post:
       summary: Set avatar for the hashed email
@@ -849,7 +845,7 @@ paths:
       security:
         - oauth: []
       responses:
-        '200':
+        '204':
           description: Avatar successfully set
         '401':
           description: Not Authorized

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -54,13 +54,7 @@ components:
             - >-
               https://gravatar.com/userimage/252014526/d38bele5a98a2bbc40df69172a2a8348.jpeg
         rating:
-          type: string
-          description: Rating associated with the image.
-          enum:
-            - G
-            - PG
-            - R
-            - X
+          $ref: '#/components/schemas/AvatarRating'
         alt_text:
           type: string
           description: Alternative text description of the image.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -54,7 +54,13 @@ components:
             - >-
               https://gravatar.com/userimage/252014526/d38bele5a98a2bbc40df69172a2a8348.jpeg
         rating:
-          $ref: '#/components/schemas/AvatarRating'
+          type: string
+          description: Rating associated with the image.
+          enum:
+            - G
+            - PG
+            - R
+            - X
         alt_text:
           type: string
           description: Alternative text description of the image.


### PR DESCRIPTION
Closes #546 #548 

### Description

Adds support for viewing and changing the rating of an avatar in the Quick Editor.

### Testing Steps

1. Run the Demo app
2. Choose SwiftUI Demos --> Profile editor with oauth --> Tap `Open Profile Editor with OAuth flow`
3. Tap the action menu `...`
   - OBSERVE:
      - [x] The `Rating` menu appears in the menu
      - [x] The `Rating` menu shows the current rating for the image: `Rating: PG`
      - [x] The `Rating` menu has a icon of a half-filled star ⭐ 
4. Tap the `Rating` menu to show the sub-menu
   - OBSERVE:
      - [x] All rating options are visible, with descriptions (`G (General)`)
      - [x] The selected rating has a checkmark (✔️)
5. Choose a different rating
   - OBSERVE:
      - [x] The rating for the image changes on the device
      - [x] The rating for the image changes on web

Try:
- different layouts
- dark/light
- iPad