### PR TITLE
Show no selected avatar warning

### DIFF
--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -64,6 +64,9 @@
 /* Title appearing in the header of a view that allows users to manage their avatars */
 "AvatarPicker.Header.title" = "Avatars";
 
+/* Message displayed when no image is selected */
+"AvatarPicker.NoImageSelected.message" = "No image selected. Please select one or the default will be used.";
+
 /* Error message to show when the upload fails because the image is too big. */
 "AvatarPicker.Upload.Error.ImageTooBig.Error" = "The provided image exceeds the maximum size: 10MB";
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
@@ -72,7 +72,12 @@ struct AvatarPickerProfileView: View {
     func avatarView() -> some View {
         AvatarView(
             url: avatarURL,
-            placeholder: nil,
+            placeholderView: {
+                Image("empty-profile-avatar", bundle: .module)
+                    .renderingMode(.template)
+                    .foregroundColor(avatarTint)
+                    .background(Color(UIColor.systemBackground))
+            },
             loadingView: {
                 ProgressView()
                     .progressViewStyle(CircularProgressViewStyle())
@@ -82,7 +87,31 @@ struct AvatarPickerProfileView: View {
         .frame(width: Constants.avatarLength, height: Constants.avatarLength)
         .background(placeholderColorManager.placeholderColor)
         .aspectRatio(1, contentMode: .fill)
-        .shape(Circle())
+        .shape(Circle(), borderColor: avatarBorderColor, borderWidth: 1)
+    }
+
+    private var paletteType: PaletteType? {
+        switch colorScheme {
+        case .light:
+            .light
+        case .dark:
+            .dark
+        @unknown default:
+            nil
+        }
+    }
+
+    private var avatarTint: Color {
+        let color: UIColor = colorScheme == .dark ? .bovineGray : .porpoiseGray
+        return Color(uiColor: color)
+    }
+
+    private var avatarBorderColor: Color {
+        if let color = paletteType?.palette.avatar.border {
+            Color(uiColor: color)
+        } else {
+            avatarTint
+        }
     }
 }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
@@ -19,7 +19,9 @@ struct AvatarPickerAvatarView: View {
         ZStack(alignment: .bottomTrailing) {
             AvatarView(
                 url: avatar.url,
-                placeholder: avatar.localImage,
+                placeholderView: {
+                    avatar.localImage?.resizable()
+                },
                 loadingView: {
                     ProgressView()
                         .progressViewStyle(CircularProgressViewStyle())

--- a/Sources/GravatarUI/SwiftUI/AvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarView.swift
@@ -12,7 +12,7 @@ public struct AvatarView<LoadingView: View, Placeholder: View>: View {
     private let urlSession: URLSession
     private let transaction: Transaction
 
-    @available(*, deprecated, message: "Use the initializer with `placeholder: (() -> Placeholder)?` instead.")
+    @available(*, deprecated, message: "Use the initializer with `placeholderView: (() -> Placeholder)?` instead.")
     public init(
         url: URL?,
         placeholder: Image?,

--- a/Sources/GravatarUI/SwiftUI/AvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarView.swift
@@ -82,13 +82,9 @@ public struct AvatarView<LoadingView: View, Placeholder: View>: View {
         case .success(let image):
             image.resizable()
         case .failure, .empty:
-            if let placeholderView {
-                placeholderView()
-            }
+            placeholderView?()
         @unknown default:
-            if let placeholderView {
-                placeholderView()
-            }
+            placeholderView?()
         }
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarView.swift
@@ -2,16 +2,17 @@ import Gravatar
 import SwiftUI
 
 @MainActor
-public struct AvatarView<LoadingView: View>: View {
+public struct AvatarView<LoadingView: View, Placeholder: View>: View {
     @ViewBuilder private let loadingView: (() -> LoadingView)?
     @Binding private var forceRefresh: Bool
     @State private var isLoading: Bool = false
     private var url: URL?
-    private let placeholder: Image?
+    private let placeholderView: (() -> Placeholder)?
     private let cache: ImageCaching
     private let urlSession: URLSession
     private let transaction: Transaction
 
+    @available(*, deprecated, message: "Use the initializer with `placeholder: (() -> Placeholder)?` instead.")
     public init(
         url: URL?,
         placeholder: Image?,
@@ -20,9 +21,33 @@ public struct AvatarView<LoadingView: View>: View {
         forceRefresh: Binding<Bool> = .constant(false),
         loadingView: (() -> LoadingView)?,
         transaction: Transaction = Transaction()
+    ) where Placeholder == AnyView {
+        self.url = url
+        if let placeholder {
+            self.placeholderView = {
+                AnyView(placeholder.resizable())
+            }
+        } else {
+            self.placeholderView = nil
+        }
+        self.cache = cache
+        self.loadingView = loadingView
+        self.urlSession = urlSession
+        self._forceRefresh = forceRefresh
+        self.transaction = transaction
+    }
+
+    public init(
+        url: URL?,
+        placeholderView: (() -> Placeholder)? = nil,
+        cache: ImageCaching = ImageCache.shared,
+        urlSession: URLSession = .shared,
+        forceRefresh: Binding<Bool> = .constant(false),
+        loadingView: (() -> LoadingView)?,
+        transaction: Transaction = Transaction()
     ) {
         self.url = url
-        self.placeholder = placeholder
+        self.placeholderView = placeholderView
         self.cache = cache
         self.loadingView = loadingView
         self.urlSession = urlSession
@@ -57,9 +82,13 @@ public struct AvatarView<LoadingView: View>: View {
         case .success(let image):
             image.resizable()
         case .failure, .empty:
-            placeholder?.resizable()
+            if let placeholderView {
+                placeholderView()
+            }
         @unknown default:
-            placeholder?.resizable()
+            if let placeholderView {
+                placeholderView()
+            }
         }
     }
 }

--- a/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/Toast.swift
@@ -43,7 +43,9 @@ struct Toast: View {
         )
         .cornerRadius(4)
         .foregroundColor(foregroundColor)
-        .shadow(radius: 3, y: 3)
+        .if(toast.shouldShowShadow, transform: { view in
+            view.shadow(radius: 3, y: 3)
+        })
         .zIndex(1)
     }
 

--- a/Sources/GravatarUI/SwiftUI/Toast/ToastManager.swift
+++ b/Sources/GravatarUI/SwiftUI/Toast/ToastManager.swift
@@ -57,4 +57,12 @@ struct ToastItem: Identifiable, Equatable {
     let message: String
     let type: ToastType
     let stackingBehavior: ToastStackingBehavior
+    let shouldShowShadow: Bool
+
+    init(message: String, type: ToastType, stackingBehavior: ToastStackingBehavior = .avoidStackingWithSameMessage, shouldShowShadow: Bool = true) {
+        self.message = message
+        self.type = type
+        self.stackingBehavior = stackingBehavior
+        self.shouldShowShadow = shouldShowShadow
+    }
 }

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -142,4 +142,13 @@ extension View {
             self
         }
     }
+
+    @ViewBuilder
+    func `if`(_ condition: Bool, transform: (Self) -> some View) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
 }


### PR DESCRIPTION
Closes #582 

### Description

Adding a warning for the state where no avatar is selected even though there are avatars.

Designer's note from figma:

> I believe it should be dismissible. And we can show it again once they open the Editor or if the normal pattern for triggering the error happens again.

So I made it so that it is dismiss-able but it will re-appear if the number of avatars changes as `> 0` and the selected avatar changes as `nil`.

 <tr>
    <td><img src="https://github.com/user-attachments/assets/881d3f16-02ca-45b3-ae9c-047145f67c77" width=300/></td>
    <td><img src="https://github.com/user-attachments/assets/d8f7a9a0-f832-4429-bd1d-c2a200420a82" width=300/></td>
  </tr>
</table>


I also set a placeholder to the profile view. It was lacking and not looking good. I used the same style we used for the UIKit profile view claim profile state.

### Testing Steps

Demo app > Quick Editor 
Delete your selected avatar and you should see the warning
Close/open the Quick Editor and you should still see the warning
Close the warning by tapping `X`
Close/open the Quick Editor and you should see the warning
Upload a new avatar
The new avatar automatically becomes _the_ avatar and the warning goes away.

What else? Feel free to get creative about testing this one.