### PR TITLE
New `updating` method for avatar model changes

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarGridModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarGridModel.swift
@@ -33,7 +33,7 @@ class AvatarGridModel: ObservableObject {
 
     func setState(to state: AvatarImageModel.State, onAvatarWithID id: String) {
         guard let imageModel = model(with: id) else { return }
-        let toggledModel = imageModel.updating(\.state, to: state).updating(\.altText, to: "")
+        let toggledModel = imageModel.updating { $0.state = state }
         replaceModel(withID: id, with: toggledModel)
     }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarGridModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarGridModel.swift
@@ -33,7 +33,7 @@ class AvatarGridModel: ObservableObject {
 
     func setState(to state: AvatarImageModel.State, onAvatarWithID id: String) {
         guard let imageModel = model(with: id) else { return }
-        let toggledModel = imageModel.updating { $0.state = state }
+        let toggledModel = imageModel.updating(\.state, to: state).updating(\.altText, to: "")
         replaceModel(withID: id, with: toggledModel)
     }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarGridModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarGridModel.swift
@@ -33,7 +33,7 @@ class AvatarGridModel: ObservableObject {
 
     func setState(to state: AvatarImageModel.State, onAvatarWithID id: String) {
         guard let imageModel = model(with: id) else { return }
-        let toggledModel = imageModel.settingStatus(to: state)
+        let toggledModel = imageModel.updating { $0.state = state }
         replaceModel(withID: id, with: toggledModel)
     }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarImageModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarImageModel.swift
@@ -57,9 +57,9 @@ struct AvatarImageModel: Hashable, Identifiable, Sendable {
         self.altText = altText
     }
 
-    func updating(_ callback: (inout Builder) -> Void) -> AvatarImageModel {
+    func updating<Value>(_ keyPath: WritableKeyPath<AvatarImageModel.Builder, Value>, to newValue: Value) -> AvatarImageModel {
         var builder = Builder(self)
-        callback(&builder)
+        builder[keyPath: keyPath] = newValue
         return builder.build()
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarImageModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarImageModel.swift
@@ -57,9 +57,9 @@ struct AvatarImageModel: Hashable, Identifiable, Sendable {
         self.altText = altText
     }
 
-    func updating<Value>(_ keyPath: WritableKeyPath<AvatarImageModel.Builder, Value>, to newValue: Value) -> AvatarImageModel {
+    func updating(_ callback: (inout Builder) -> Void) -> AvatarImageModel {
         var builder = Builder(self)
-        builder[keyPath: keyPath] = newValue
+        callback(&builder)
         return builder.build()
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarImageModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarImageModel.swift
@@ -48,7 +48,7 @@ struct AvatarImageModel: Hashable, Identifiable, Sendable {
         return image
     }
 
-    init(id: String, source: Source, state: State = .loaded, isSelected: Bool = false, rating: AvatarRating = .g, altText: String = "") {
+    init(id: String, source: Source, state: State, isSelected: Bool, rating: AvatarRating, altText: String) {
         self.id = id
         self.source = source
         self.state = state
@@ -59,5 +59,11 @@ struct AvatarImageModel: Hashable, Identifiable, Sendable {
 
     func settingStatus(to newStatus: State) -> AvatarImageModel {
         AvatarImageModel(id: id, source: source, state: newStatus, isSelected: isSelected, rating: rating, altText: altText)
+    }
+}
+
+extension AvatarImageModel {
+    static func preview_init(id: String, source: Source, state: State = .loaded, isSelected: Bool = false, rating: AvatarRating = .g) -> Self {
+        AvatarImageModel(id: id, source: source, state: state, isSelected: isSelected, rating: rating, altText: "")
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarImageModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarImageModel.swift
@@ -57,12 +57,39 @@ struct AvatarImageModel: Hashable, Identifiable, Sendable {
         self.altText = altText
     }
 
-    func settingStatus(to newStatus: State) -> AvatarImageModel {
-        AvatarImageModel(id: id, source: source, state: newStatus, isSelected: isSelected, rating: rating, altText: altText)
+    func updating(_ callback: (inout Builder) -> Void) -> AvatarImageModel {
+        var builder = Builder(self)
+        callback(&builder)
+        return builder.build()
     }
 }
 
 extension AvatarImageModel {
+    struct Builder {
+        var id: String
+        var source: Source
+        var isSelected: Bool
+        var state: State
+        var altText: String
+        var rating: AvatarRating
+
+        fileprivate init(_ model: AvatarImageModel) {
+            self.id = model.id
+            self.source = model.source
+            self.isSelected = model.isSelected
+            self.state = model.state
+            self.altText = model.altText
+            self.rating = model.rating
+        }
+
+        fileprivate func build() -> AvatarImageModel {
+            .init(id: id, source: source, state: state, isSelected: isSelected, rating: rating, altText: altText)
+        }
+    }
+}
+
+extension AvatarImageModel {
+    /// This is meant to be used in previews and unit tests only.
     static func preview_init(id: String, source: Source, state: State = .loaded, isSelected: Bool = false, rating: AvatarRating = .g) -> Self {
         AvatarImageModel(id: id, source: source, state: state, isSelected: isSelected, rating: rating, altText: "")
     }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -664,15 +664,15 @@ private enum AvatarPicker {
     }
 
     let avatarImageModels: [AvatarImageModel] = [
-        .init(id: "0", source: .local(image: UIImage()), state: .loading),
-        .init(id: "1", source: .remote(url: "https://gravatar.com/userimage/110207384/aa5f129a2ec75162cee9a1f0c472356a.jpeg?size=256")),
-        .init(id: "2", source: .remote(url: "https://gravatar.com/userimage/110207384/db73834576b01b69dd8da1e29877ca07.jpeg?size=256")),
-        .init(id: "3", source: .remote(url: "https://gravatar.com/userimage/110207384/3f7095bf2580265d1801d128c6410016.jpeg?size=256")),
-        .init(id: "4", source: .remote(url: "https://gravatar.com/userimage/110207384/fbbd335e57862e19267679f19b4f9db8.jpeg?size=256")),
-        .init(id: "5", source: .remote(url: "https://gravatar.com/userimage/110207384/96c6950d6d8ce8dd1177a77fe738101e.jpeg?size=256")),
-        .init(id: "6", source: .remote(url: "https://gravatar.com/userimage/110207384/4a4f9385b0a6fa5c00342557a098f480.jpeg?size=256")),
-        .init(id: "7", source: .local(image: UIImage()), state: .error(supportsRetry: true, errorMessage: "Something went wrong.")),
-        .init(id: "8", source: .local(image: UIImage()), state: .error(supportsRetry: false, errorMessage: "Something went wrong.")),
+        .preview_init(id: "0", source: .local(image: UIImage()), state: .loading),
+        .preview_init(id: "1", source: .remote(url: "https://gravatar.com/userimage/110207384/aa5f129a2ec75162cee9a1f0c472356a.jpeg?size=256")),
+        .preview_init(id: "2", source: .remote(url: "https://gravatar.com/userimage/110207384/db73834576b01b69dd8da1e29877ca07.jpeg?size=256")),
+        .preview_init(id: "3", source: .remote(url: "https://gravatar.com/userimage/110207384/3f7095bf2580265d1801d128c6410016.jpeg?size=256")),
+        .preview_init(id: "4", source: .remote(url: "https://gravatar.com/userimage/110207384/fbbd335e57862e19267679f19b4f9db8.jpeg?size=256")),
+        .preview_init(id: "5", source: .remote(url: "https://gravatar.com/userimage/110207384/96c6950d6d8ce8dd1177a77fe738101e.jpeg?size=256")),
+        .preview_init(id: "6", source: .remote(url: "https://gravatar.com/userimage/110207384/4a4f9385b0a6fa5c00342557a098f480.jpeg?size=256")),
+        .preview_init(id: "7", source: .local(image: UIImage()), state: .error(supportsRetry: true, errorMessage: "Something went wrong.")),
+        .preview_init(id: "8", source: .local(image: UIImage()), state: .error(supportsRetry: false, errorMessage: "Something went wrong.")),
     ]
     let selectedImageID = "5"
     let profileModel = PreviewModel()

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -207,7 +207,7 @@ class AvatarPickerViewModel: ObservableObject {
 
         let localID = UUID().uuidString
 
-        let localImageModel = AvatarImageModel(id: localID, source: .local(image: image), state: .loading, rating: .g)
+        let localImageModel = AvatarImageModel(id: localID, source: .local(image: image), state: .loading, isSelected: false, rating: .g, altText: "")
         grid.append(localImageModel)
 
         await doUpload(squareImage: image, localID: localID, accessToken: authToken)
@@ -287,11 +287,14 @@ class AvatarPickerViewModel: ObservableObject {
     }
 
     private func handleUploadError(imageID: String, squareImage: UIImage, supportsRetry: Bool, errorMessage: String) {
+        let storedModel = grid.model(with: imageID)
         let newModel = AvatarImageModel(
             id: imageID,
             source: .local(image: squareImage),
             state: .error(supportsRetry: supportsRetry, errorMessage: errorMessage),
-            rating: grid.model(with: imageID)?.rating ?? .g
+            isSelected: false,
+            rating: storedModel?.rating ?? .g,
+            altText: storedModel?.altText ?? ""
         )
         grid.replaceModel(withID: imageID, with: newModel)
     }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
@@ -159,7 +159,7 @@ extension AltTextEditorView {
 #Preview {
     struct AltTextPreview: View {
         @State var text = ""
-        let avatar = AvatarImageModel(
+        let avatar = AvatarImageModel.preview_init(
             id: "1",
             source: .remote(url: "https://gravatar.com/userimage/110207384/aa5f129a2ec75162cee9a1f0c472356a.jpeg?size=256")
         )

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarGrid.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarGrid.swift
@@ -58,7 +58,7 @@ struct AvatarGrid<ImageEditor: ImageEditorView>: View {
 
 #Preview {
     let newAvatarModel: @Sendable (UIImage?) -> AvatarImageModel = { image in
-        AvatarImageModel(id: UUID().uuidString, source: .local(image: image ?? UIImage()))
+        AvatarImageModel.preview_init(id: UUID().uuidString, source: .local(image: image ?? UIImage()))
     }
     let initialAvatarCell = newAvatarModel(nil)
     let grid = AvatarGridModel(

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
@@ -174,7 +174,7 @@ extension AvatarRating {
 }
 
 #Preview {
-    let avatar = AvatarImageModel(
+    let avatar = AvatarImageModel.preview_init(
         id: "1",
         source: .remote(url: "https://gravatar.com/userimage/110207384/aa5f129a2ec75162cee9a1f0c472356a.jpeg?size=256"),
         rating: .pg

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/HorizontalAvatarGrid.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/HorizontalAvatarGrid.swift
@@ -40,10 +40,10 @@ struct HorizontalAvatarGrid: View {
 #Preview {
     let grid = AvatarGridModel(
         avatars: [
-            .init(id: "1", source: .remote(url: "https://gravatar.com/userimage/110207384/aa5f129a2ec75162cee9a1f0c472356a.jpeg?size=256")),
-            .init(id: "2", source: .remote(url: "https://gravatar.com/userimage/110207384/db73834576b01b69dd8da1e29877ca07.jpeg?size=256")),
-            .init(id: "3", source: .remote(url: "https://gravatar.com/userimage/110207384/3f7095bf2580265d1801d128c6410016.jpeg?size=256")),
-            .init(id: "4", source: .remote(url: "https://gravatar.com/userimage/110207384/fbbd335e57862e19267679f19b4f9db8.jpeg?size=256")),
+            .preview_init(id: "1", source: .remote(url: "https://gravatar.com/userimage/110207384/aa5f129a2ec75162cee9a1f0c472356a.jpeg?size=256")),
+            .preview_init(id: "2", source: .remote(url: "https://gravatar.com/userimage/110207384/db73834576b01b69dd8da1e29877ca07.jpeg?size=256")),
+            .preview_init(id: "3", source: .remote(url: "https://gravatar.com/userimage/110207384/3f7095bf2580265d1801d128c6410016.jpeg?size=256")),
+            .preview_init(id: "4", source: .remote(url: "https://gravatar.com/userimage/110207384/fbbd335e57862e19267679f19b4f9db8.jpeg?size=256")),
         ]
     )
     grid.selectAvatar(grid.avatars.first)

--- a/Tests/GravatarUITests/AvatarGridModelTests.swift
+++ b/Tests/GravatarUITests/AvatarGridModelTests.swift
@@ -3,11 +3,11 @@ import TestHelpers
 import Testing
 
 let initialAvatars: [AvatarImageModel] = [
-    .init(id: "0", source: .remote(url: "https://example.com/1.jpg")),
-    .init(id: "1", source: .remote(url: "https://example.com/1.jpg"), isSelected: true),
-    .init(id: "2", source: .remote(url: "https://example.com/1.jpg")),
-    .init(id: "3", source: .remote(url: "https://example.com/1.jpg")),
-    .init(id: "4", source: .remote(url: "https://example.com/1.jpg")),
+    .preview_init(id: "0", source: .remote(url: "https://example.com/1.jpg")),
+    .preview_init(id: "1", source: .remote(url: "https://example.com/1.jpg"), isSelected: true),
+    .preview_init(id: "2", source: .remote(url: "https://example.com/1.jpg")),
+    .preview_init(id: "3", source: .remote(url: "https://example.com/1.jpg")),
+    .preview_init(id: "4", source: .remote(url: "https://example.com/1.jpg")),
 ]
 
 let initiallySelectedAvatarID = "1"
@@ -26,7 +26,7 @@ struct AvatarGridModelTests {
 
     @Test("Test append function")
     func testAvatarGridModelAppend() async throws {
-        let appendedAvatar = AvatarImageModel(id: "new", source: .remote(url: "https://example.com/1.jpg"))
+        let appendedAvatar = AvatarImageModel.preview_init(id: "new", source: .remote(url: "https://example.com/1.jpg"))
         model.append(appendedAvatar)
 
         #expect(model.index(of: "new") == 0)
@@ -102,7 +102,7 @@ struct AvatarGridModelTests {
 
     @Test("Test insert function")
     func testAvatarGridModelInsert() async throws {
-        let toInsert = AvatarImageModel(id: "new", source: .remote(url: "https://example.com"))
+        let toInsert = AvatarImageModel.preview_init(id: "new", source: .remote(url: "https://example.com"))
         model.insert(toInsert, at: 2)
 
         #expect(model.index(of: "new") == 2)

--- a/Tests/GravatarUITests/AvatarImageModelTests.swift
+++ b/Tests/GravatarUITests/AvatarImageModelTests.swift
@@ -24,7 +24,7 @@ struct AvatarImageModelTests {
         let model = AvatarImageModel.preview_init(id: "someID", source: .local(image: ImageHelper.testImage), state: .loading)
         #expect(model.state == .loading)
 
-        let loadedModel = model.settingStatus(to: .loaded)
+        let loadedModel = model.updating(\.state, to: .loaded)
         #expect(loadedModel.state == .loaded, "The state should be .loaded")
     }
 
@@ -33,7 +33,7 @@ struct AvatarImageModelTests {
         let model = AvatarImageModel.preview_init(id: "someID", source: .local(image: ImageHelper.testImage), state: .loading)
         #expect(model.state == .loading)
 
-        let loadedModel = model.settingStatus(to: .error(supportsRetry: true, errorMessage: "Some Error"))
+        let loadedModel = model.updating(\.state, to: .error(supportsRetry: true, errorMessage: "Some Error"))
         switch loadedModel.state {
         case .error:
             #expect(Bool(true))

--- a/Tests/GravatarUITests/AvatarImageModelTests.swift
+++ b/Tests/GravatarUITests/AvatarImageModelTests.swift
@@ -6,14 +6,14 @@ struct AvatarImageModelTests {
     @Test("Check URL exists")
     func testURLExists() async throws {
         let imageURL = "https://example.com/avatar.jpg"
-        let model = AvatarImageModel(id: "someID", source: .remote(url: imageURL))
+        let model = AvatarImageModel.preview_init(id: "someID", source: .remote(url: imageURL))
         #expect(model.url?.absoluteString == imageURL)
         #expect(model.localImage == nil)
     }
 
     @Test("Check local image exists")
     func testLocalImageExists() async throws {
-        let model = AvatarImageModel(id: "someID", source: .local(image: ImageHelper.testImage))
+        let model = AvatarImageModel.preview_init(id: "someID", source: .local(image: ImageHelper.testImage))
         #expect(model.localImage != nil)
         #expect(model.localUIImage != nil)
         #expect(model.url == nil)
@@ -21,7 +21,7 @@ struct AvatarImageModelTests {
 
     @Test("Check state change from loading to loaded")
     func testStateChangeLoadingLoaded() async throws {
-        let model = AvatarImageModel(id: "someID", source: .local(image: ImageHelper.testImage), state: .loading)
+        let model = AvatarImageModel.preview_init(id: "someID", source: .local(image: ImageHelper.testImage), state: .loading)
         #expect(model.state == .loading)
 
         let loadedModel = model.settingStatus(to: .loaded)
@@ -30,7 +30,7 @@ struct AvatarImageModelTests {
 
     @Test("Check state change from loading to error")
     func testStateChangeLoadingError() async throws {
-        let model = AvatarImageModel(id: "someID", source: .local(image: ImageHelper.testImage), state: .loading)
+        let model = AvatarImageModel.preview_init(id: "someID", source: .local(image: ImageHelper.testImage), state: .loading)
         #expect(model.state == .loading)
 
         let loadedModel = model.settingStatus(to: .error(supportsRetry: true, errorMessage: "Some Error"))

--- a/Tests/GravatarUITests/AvatarImageModelTests.swift
+++ b/Tests/GravatarUITests/AvatarImageModelTests.swift
@@ -24,7 +24,7 @@ struct AvatarImageModelTests {
         let model = AvatarImageModel.preview_init(id: "someID", source: .local(image: ImageHelper.testImage), state: .loading)
         #expect(model.state == .loading)
 
-        let loadedModel = model.updating(\.state, to: .loaded)
+        let loadedModel = model.updating { $0.state = .loaded }
         #expect(loadedModel.state == .loaded, "The state should be .loaded")
     }
 
@@ -33,7 +33,7 @@ struct AvatarImageModelTests {
         let model = AvatarImageModel.preview_init(id: "someID", source: .local(image: ImageHelper.testImage), state: .loading)
         #expect(model.state == .loading)
 
-        let loadedModel = model.updating(\.state, to: .error(supportsRetry: true, errorMessage: "Some Error"))
+        let loadedModel = model.updating { $0.state = .error(supportsRetry: true, errorMessage: "Some Error") }
         switch loadedModel.state {
         case .error:
             #expect(Bool(true))


### PR DESCRIPTION
Closes #

### Description

This is an alternative to the current way of updating a field in the avatar model.

- Removing the defaults from `AvatarImageModel` init. (this might be enough already to avoid possible issues)
- Creating a helper static method for previews and unit tests (to make initialization shorter). Not a must but some help.
  - I'd like to make this one accessible only by the preview, but I didn't find a way to do this.
- Creating a new way to create a new model updating just one or a handful of fields. 
  - I like this one since we don't need to make the struct or their fields mutable. But it's not a must.

### Testing Steps
