### PR TITLE
Remove the 800ms delay on avatarUpdatedHandler

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -399,15 +399,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
     }
 
     func notifyAvatarSelection() {
-        if let avatarUpdatedHandler {
-            // Delay to wait until the server has updated the selected avatar before updating the UI.
-            // Without the delay the cache busting remains insufficient to capture the new avatar.
-            // With less than 800 ms, we can still see the issue.
-            // Hopefully, we can remove this delay soon.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-                avatarUpdatedHandler()
-            }
-        }
+        avatarUpdatedHandler?()
     }
 
     private func content() -> some View {


### PR DESCRIPTION
Closes #587 

### Description

There has been some improvements on the server-side so we can remove the delay now. 

### Testing Steps

Demo app > Quick editor
Switch between avatars
Observe: The avatar change is reflected to the profile view at the background screen.