### PR TITLE
Alt text UX changes

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -656,7 +656,7 @@ private enum AvatarPicker {
 #Preview("Existing elements") {
     struct PreviewModel: ProfileSummaryModel {
         var avatarIdentifier: Gravatar.AvatarIdentifier? {
-            .email("xxx@gmail.com")
+            .email("some@email.com")
         }
 
         var displayName: String {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -193,6 +193,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
         .altTextSheet(
             model: $altTextEditorAvatar,
             email: model.email,
+            toastManager: model.toastManager,
             onSave: { modifiedModel in
                 if await model.update(altText: modifiedModel.altText, for: modifiedModel) {
                     altTextEditorAvatar = nil

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -194,9 +194,8 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
             model: $altTextEditorAvatar,
             email: model.email,
             onSave: { modifiedModel in
-                altTextEditorAvatar = nil
-                Task {
-                    await model.update(altText: modifiedModel.altText, for: modifiedModel)
+                if await model.update(altText: modifiedModel.altText, for: modifiedModel) {
+                    altTextEditorAvatar = nil
                 }
             },
             onCancel: {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -8,12 +8,8 @@ class AvatarPickerViewModel: ObservableObject {
     private let avatarService: AvatarService
     private let imageDownloader: ImageDownloader
 
-    private(set) var email: Email? {
+    private(set) var email: Email {
         didSet {
-            guard let email else {
-                avatarIdentifier = nil
-                return
-            }
             avatarIdentifier = .email(email)
         }
     }
@@ -82,13 +78,19 @@ class AvatarPickerViewModel: ObservableObject {
             self.selectedAvatarResult = .success(selectedImageID)
         }
 
+        self.email = .init("some@email.com")
+
         grid.setAvatars(avatarImageModels)
         grid.selectAvatar(withID: selectedImageID)
         gridResponseStatus = .success(())
 
         if let profileModel {
             self.profileResult = .success(profileModel)
-            self.profileModel = .init(displayName: profileModel.displayName, location: profileModel.location, profileURL: profileModel.profileURL)
+            self.profileModel = .init(
+                displayName: profileModel.displayName,
+                location: profileModel.location,
+                profileURL: profileModel.profileURL
+            )
             switch profileModel.avatarIdentifier {
             case .email(let email):
                 self.email = email
@@ -100,7 +102,6 @@ class AvatarPickerViewModel: ObservableObject {
 
     func selectAvatar(with id: String) async -> Avatar? {
         guard
-            let email,
             let authToken,
             grid.selectedAvatar?.id != id,
             grid.model(with: id)?.state == .loaded
@@ -167,7 +168,7 @@ class AvatarPickerViewModel: ObservableObject {
     }
 
     func fetchAvatars() async {
-        guard let authToken, let email else { return }
+        guard let authToken else { return }
 
         do {
             isAvatarsLoading = true
@@ -186,7 +187,6 @@ class AvatarPickerViewModel: ObservableObject {
     }
 
     func fetchProfile() async {
-        guard let email else { return }
         do {
             isProfileLoading = true
             let profile = try await profileService.fetch(with: .email(email))
@@ -229,7 +229,6 @@ class AvatarPickerViewModel: ObservableObject {
     }
 
     private func doUpload(squareImage: UIImage, localID: String, accessToken: String) async {
-        guard let email else { return }
         do {
             let avatar = try await avatarService.upload(
                 squareImage,

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -344,8 +344,7 @@ class AvatarPickerViewModel: ObservableObject {
     func update(altText: String, for avatar: AvatarImageModel) async -> Bool {
         guard let token = self.authToken else { return false }
         do {
-            let updatedAvatar = try await avatarService.update(altText: altText, avatarID: .hashID(avatar.id), accessToken: token)
-            toastManager.showToast(Localized.avatarAltTextSuccess + "\n\n \"\(altText)\"")
+            let updatedAvatar = try await avatarService.update(altText: altText, avatarID: .hashID(avatar.id + "2"), accessToken: token)
             withAnimation {
                 grid.replaceModel(withID: avatar.id, with: .init(with: updatedAvatar))
             }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -344,7 +344,7 @@ class AvatarPickerViewModel: ObservableObject {
     func update(altText: String, for avatar: AvatarImageModel) async -> Bool {
         guard let token = self.authToken else { return false }
         do {
-            let updatedAvatar = try await avatarService.update(altText: altText, avatarID: .hashID(avatar.id + "2"), accessToken: token)
+            let updatedAvatar = try await avatarService.update(altText: altText, avatarID: .hashID(avatar.id), accessToken: token)
             withAnimation {
                 grid.replaceModel(withID: avatar.id, with: .init(with: updatedAvatar))
             }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
@@ -23,9 +23,37 @@ struct AltTextEditorView: View {
     let onCancel: () -> Void
 
     var body: some View {
-        VStack {
-            if let email {
-                EmailText(email: email)
+        GeometryReader { geometry in
+            ZStack {
+                ScrollView {
+                    VStack {
+                        if let email {
+                            EmailText(email: email)
+                        }
+                        VStack(alignment: .leading) {
+                            HStack {
+                                titleText
+                                Spacer()
+                                altTextHelpButton
+                            }
+                            ZStack(alignment: .bottomTrailing) {
+                                HStack(alignment: .top) {
+                                    imageView
+                                    altTextField
+                                }
+                                if shouldShowCharCount {
+                                    characterCountText
+                                }
+                            }
+                            Spacer()
+                            actionButton
+                        }
+                        .padding()
+                        .avatarPickerBorder(colorScheme: .light)
+                    }
+                    .padding(.bottom)
+                    .padding(.horizontal)
+                }
             }
             VStack(alignment: .leading) {
                 HStack {
@@ -48,7 +76,6 @@ struct AltTextEditorView: View {
             .avatarPickerBorder(colorScheme: .light)
             Spacer()
         }
-        .padding()
         .gravatarNavigation(
             doneButtonTitle: Localized.cancelButtonTitle,
             actionButtonDisabled: false,

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
@@ -10,7 +10,7 @@ struct AltTextEditorView: View {
     @State var charCount: Int = 0
     @State var safariURL: URL? = nil
     @State var isLoading: Bool = false
-    @ObservedObject var toastManager: ToastManager = .init()
+    @ObservedObject var toastManager: ToastManager
 
     @FocusState var focused: Bool
 
@@ -122,7 +122,7 @@ struct AltTextEditorView: View {
 
     var characterCountText: some View {
         Text("\(Constants.characterLimit - altText.count)")
-            .font(.callout)
+            .font(.footnote)
             .monospacedDigit()
             .foregroundColor(altText.count >= Constants.characterLimit ? .red : .secondary)
     }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
@@ -12,7 +12,6 @@ struct AltTextEditorView: View {
     @State var isLoading: Bool = false
     @ObservedObject var toastManager: ToastManager = .init()
 
-
     @FocusState var focused: Bool
 
     let onSave: (AvatarImageModel) async -> Void

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct AltTextEditorView: View {
     let avatar: AvatarImageModel?
-    let email: Email?
+    let email: Email
 
     var shouldShowCharCount: Bool {
         altText.count > 0
@@ -25,9 +25,7 @@ struct AltTextEditorView: View {
         // GeometryReader also has the same effect. For now we want the content to scroll when the content grows.
         ScrollView {
             VStack {
-                if let email {
-                    EmailText(email: email)
-                }
+                EmailText(email: email)
                 VStack(alignment: .leading) {
                     HStack {
                         titleText

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
@@ -20,7 +20,7 @@ struct AltTextEditorView: View {
 
     var body: some View {
         // Scroll view helps detaching the height of the child view from the height of the parent view.
-        // This avoids a UI problem while scrolling down the sheet whith the keyboard being present.
+        // This avoids a UI problem while scrolling down the sheet with the keyboard being present.
         // GeometryReader also has the same effect. For now we want the content to scroll when the content grows.
         ScrollView {
             ZStack {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
@@ -70,17 +70,19 @@ struct AltTextEditorView: View {
     var altTextField: some View {
         ZStack(alignment: .topLeading) {
             TextEditor(text: Binding(
-                get: {
-                    String(altText.prefix(Constants.characterLimit))
-                },
-                set: { newValue in
-                    altText = String(newValue.prefix(Constants.characterLimit))
+                get: { altText.normalizedAltText },
+                set: { newAltText in
+                    if newAltText.contains("\n") {
+                        focused = false
+                    }
+                    altText = newAltText.normalizedAltText
                 }
             ))
             .multilineTextAlignment(.leading)
             .frame(height: 100)
             .font(.footnote)
             .focused($focused)
+            .submitLabel(.done)
             .onAppear { focused = true }
             if altText.count == 0 {
                 Text(Localized.altTextPlaceholder)
@@ -189,6 +191,13 @@ extension AltTextEditorView {
         fileprivate static let imageSize: CGFloat = 96
         fileprivate static let minLength: CGFloat = 96
         fileprivate static let characterLimit: Int = 100
+    }
+}
+
+extension String {
+    fileprivate var normalizedAltText: String {
+        String(self.prefix(AltTextEditorView.Constants.characterLimit))
+            .replacingOccurrences(of: "\n", with: "")
     }
 }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/CTAButtonView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/CTAButtonView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CTAButtonView: View {
     let title: String
+    @Environment(\.isEnabled) var isEnabled
 
     public init(_ title: String) {
         self.title = title
@@ -14,13 +15,19 @@ struct CTAButtonView: View {
             .foregroundColor(.white)
             .padding(.vertical, .DS.Padding.split)
             .padding(.horizontal, .DS.Padding.double)
-            .background(RoundedRectangle(cornerRadius: 4).fill(Color(uiColor: .gravatarBlue)))
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color(uiColor: isEnabled ? .gravatarBlue : UIColor.systemFill))
+            )
     }
 }
 
 #Preview {
     CTAButtonView("I am a button")
         .padding()
+    CTAButtonView("I am a disabled button")
+        .padding()
+        .disabled(true)
 }
 
 #Preview("Dark mode") {

--- a/Sources/GravatarUI/SwiftUI/GravatarNavigationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/GravatarNavigationModifier.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct GravatarNavigationModifier<K: PreferenceKey>: ViewModifier where K.Value == CGFloat {
     var title: String?
     var doneButtonTitle: String?
+    var doneButtonDisabled: Bool
     var actionButtonDisabled: Bool
 
     @Environment(\.colorScheme) var colorScheme
@@ -38,6 +39,7 @@ struct GravatarNavigationModifier<K: PreferenceKey>: ViewModifier where K.Value 
                         Text(doneButtonTitle ?? GravatarNavigationModifierConstants.Localized.doneButtonTitle)
                             .tint(Color(UIColor.gravatarBlue))
                     }
+                    .disabled(doneButtonDisabled)
                 }
             }
             .background {
@@ -76,8 +78,8 @@ extension View {
     func gravatarNavigation<K>(
         title: String? = nil,
         doneButtonTitle: String? = nil,
+        doneButtonDisabled: Bool = false,
         actionButtonDisabled: Bool,
-        shouldEmitInnerHeight: Bool = true,
         onActionButtonPressed: (() -> Void)? = nil,
         onDoneButtonPressed: (() -> Void)? = nil,
         preferenceKey: K.Type
@@ -86,6 +88,7 @@ extension View {
             GravatarNavigationModifier<K>(
                 title: title,
                 doneButtonTitle: doneButtonTitle,
+                doneButtonDisabled: doneButtonDisabled,
                 actionButtonDisabled: actionButtonDisabled,
                 onActionButtonPressed: onActionButtonPressed,
                 onDoneButtonPressed: onDoneButtonPressed,

--- a/Sources/GravatarUI/SwiftUI/ModalPresentationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/ModalPresentationModifier.swift
@@ -18,3 +18,23 @@ struct ModalPresentationModifier<ModalView: View>: ViewModifier {
             }
     }
 }
+
+struct ModalItemPresentationModifier<ModalView: View, T>: ViewModifier where T: Identifiable {
+    @Binding var item: T?
+
+    let onDismiss: (() -> Void)?
+    let modalViewBuilder: (T) -> ModalView
+
+    init(item: Binding<T?>, onDismiss: (() -> Void)? = nil, @ViewBuilder modalView: @escaping (T) -> ModalView) {
+        self._item = item
+        self.onDismiss = onDismiss
+        self.modalViewBuilder = modalView
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(item: $item) { item in
+                modalViewBuilder(item)
+            }
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -100,7 +100,7 @@ extension View {
     func altTextSheet(
         model: Binding<AvatarImageModel?>,
         email: Email,
-        onSave: @escaping (AvatarImageModel) -> Void,
+        onSave: @escaping (AvatarImageModel) async -> Void,
         onCancel: @escaping () -> Void
     ) -> some View {
 

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -100,13 +100,14 @@ extension View {
     func altTextSheet(
         model: Binding<AvatarImageModel?>,
         email: Email,
+        toastManager: ToastManager,
         onSave: @escaping (AvatarImageModel) async -> Void,
         onCancel: @escaping () -> Void
     ) -> some View {
 
         func altTextEditor(with model: AvatarImageModel) -> some View {
             NavigationView {
-                AltTextEditorView(avatar: model, email: email, onSave: onSave, onCancel: onCancel)
+                AltTextEditorView(avatar: model, email: email, toastManager: toastManager, onSave: onSave, onCancel: onCancel)
             }
         }
 

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -99,24 +99,25 @@ extension View {
 
     func altTextSheet(
         model: Binding<AvatarImageModel?>,
-        email: Email?,
+        email: Email,
         onSave: @escaping (AvatarImageModel) -> Void,
         onCancel: @escaping () -> Void
     ) -> some View {
-        let altTextEditor = NavigationView {
-            AltTextEditorView(avatar: model.wrappedValue, email: email, onSave: onSave, onCancel: onCancel)
+
+        func altTextEditor(with model: AvatarImageModel) -> some View {
+            NavigationView {
+                AltTextEditorView(avatar: model, email: email, onSave: onSave, onCancel: onCancel)
+            }
         }
+
         if #available(iOS 16.0, *) {
-            return self.sheet(item: model, onDismiss: onCancel) { _ in
-                altTextEditor.presentationDetents([.height(AltTextEditorView.Constants.sheetHeight)])
+            return self.sheet(item: model, onDismiss: onCancel) { selectedModel in
+                altTextEditor(with: selectedModel).presentationDetents([.height(AltTextEditorView.Constants.sheetHeight)])
             }
         } else {
             return modifier(
-                ModalPresentationModifier(
-                    isPresented: Binding(
-                        get: { model.wrappedValue != nil },
-                        set: { if !$0 { model.wrappedValue = nil }}
-                    ),
+                ModalItemPresentationModifier(
+                    item: model,
                     onDismiss: onCancel,
                     modalView: altTextEditor
                 )

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -104,7 +104,6 @@ extension View {
         onSave: @escaping (AvatarImageModel) async -> Void,
         onCancel: @escaping () -> Void
     ) -> some View {
-
         func altTextEditor(with model: AvatarImageModel) -> some View {
             NavigationView {
                 AltTextEditorView(avatar: model, email: email, toastManager: toastManager, onSave: onSave, onCancel: onCancel)

--- a/Tests/GravatarUITests/AvatarPickerViewModelTests.swift
+++ b/Tests/GravatarUITests/AvatarPickerViewModelTests.swift
@@ -271,14 +271,9 @@ final class AvatarPickerViewModelTests {
         let newAltText = "Updated Alt Text"
         await model.refresh()
         let avatar = model.grid.avatars[0]
-
-        await confirmToasts { message, type in
-            #expect(message?.contains(AvatarPickerViewModel.Localized.avatarAltTextSuccess) == true)
-            #expect(type == .info)
-        } trigger: {
-            let success = await model.update(altText: newAltText, for: avatar)
-            #expect(success)
-        }
+        let success = await model.update(altText: newAltText, for: avatar)
+        
+        #expect(success)
 
         let updatedAvatar = model.grid.avatars[0]
         #expect(updatedAvatar.altText == newAltText)

--- a/Tests/GravatarUITests/AvatarPickerViewModelTests.swift
+++ b/Tests/GravatarUITests/AvatarPickerViewModelTests.swift
@@ -357,7 +357,7 @@ final class AvatarPickerViewModelTests {
         await model.refresh()
         let avatar = model.grid.avatars[0]
         let success = await model.update(altText: newAltText, for: avatar)
-        
+
         #expect(success)
 
         let updatedAvatar = model.grid.avatars[0]


### PR DESCRIPTION
Closes #

### Description

Implementing requested changes to the Alt Text editor experience:

- Switch the Save button to a loading indicator while the request is running.
- Keep the alt text screen open until the request returns.
- Close the alt text screen on success (without toast)
- Show an error toast on failure
- Keyboard return button is `Done` button and closes the keyboard.
- No new lines allowed on the Text view.

Not done on this PR:
- Avoid the text from overlapping when text size is big.

![CleanShot 2024-12-19 at 11 51 49](https://github.com/user-attachments/assets/54861cae-327d-4b43-8574-5922d423cb76)

![CleanShot 2024-12-19 at 11 53 41](https://github.com/user-attachments/assets/888c22c9-5348-491a-9ae0-1a173c22fb2a)

### Testing Steps

- Run the Quick Editor screen from the demo app.
- Edit the Alt Text from an avatar.
  - Check that the changes mentioned on description work as expected 
