### PR TITLE
Avoiding overlapping of alt text with the counter text

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
@@ -5,6 +5,7 @@ struct AltTextEditorView: View {
     let email: Email
 
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
 
     @State var altText: String = ""
     @State var charCount: Int = 0
@@ -16,6 +17,35 @@ struct AltTextEditorView: View {
 
     let onSave: (AvatarImageModel) async -> Void
     let onCancel: () -> Void
+
+    var counterPadding: CGFloat {
+        switch dynamicTypeSize {
+        case let size where size <= .large: 0
+        case let size where size < .xxxLarge: -10
+        case let size where size >= .xxxLarge: -18
+        default: 0
+        }
+    }
+
+    var normalSizeTextEditorLayout: some View {
+        ZStack(alignment: .bottomTrailing) {
+            HStack(alignment: .top) {
+                imageView
+                altTextField
+            }
+            characterCountText.padding(.bottom, counterPadding)
+        }.padding(.bottom, 12)
+    }
+
+    var accessibilitySizeTextEditorLayout: some View {
+        VStack(alignment: .trailing) {
+            HStack(alignment: .top) {
+                imageView
+                altTextField
+            }
+            characterCountText.padding(.top, -6).padding(.bottom, -4)
+        }
+    }
 
     var body: some View {
         // Scroll view helps detaching the height of the child view from the height of the parent view.
@@ -31,17 +61,14 @@ struct AltTextEditorView: View {
                             Spacer()
                             altTextHelpButton
                         }
-                        ZStack(alignment: .bottomTrailing) {
-                            HStack(alignment: .top) {
-                                imageView
-                                altTextField
-                            }
-                            characterCountText
+                        if dynamicTypeSize >= .accessibility1 {
+                            accessibilitySizeTextEditorLayout
+                        } else {
+                            normalSizeTextEditorLayout
                         }
-                        Spacer()
+
                         actionButton
                             .disabled(isLoading)
-                            .padding(.top)
                     }
                     .padding()
                     .avatarPickerBorder(colorScheme: .light)
@@ -78,7 +105,7 @@ struct AltTextEditorView: View {
                 }
             ))
             .multilineTextAlignment(.leading)
-            .frame(height: 100)
+            .frame(height: dynamicTypeSize >= .accessibility1 ? 120 : Constants.minLength)
             .font(.footnote)
             .focused($focused)
             .submitLabel(.done)
@@ -125,6 +152,7 @@ struct AltTextEditorView: View {
             .font(.footnote)
             .monospacedDigit()
             .foregroundColor(altText.count >= Constants.characterLimit ? .red : .secondary)
+            .padding(.trailing, 4)
     }
 
     var altTextHelpButton: some View {


### PR DESCRIPTION
Closes #

### Description

This is an attempt to avoid the overlapping of the alt-text string with the counter string.

These screenshot has been taken on an iPhone SE, which offers the smallest width for content.

---
When the dynamic type is normal, a bit bigger, or any smaller; there's no chance for the content to overlap with the counter, so the layout remains the same.

![CleanShot 2024-12-20 at 17 17 00@2x](https://github.com/user-attachments/assets/2684bdcd-40d3-4f78-bc64-b875172b21da)
---
For larger dynamic type sizes which are not accessibility sizes, overlapping is super rare, happening when the alt text is long (using close to all characters), and with the last word wrapping right at the end of the last line. 

In this case we move the counter floating down, using most of the space between the text view and the action button. No other part of the layout is affected.

![CleanShot 2024-12-20 at 16 55 01@2x](https://github.com/user-attachments/assets/45340fd6-ab41-48a6-95f6-87367a9721f2)
---

For accessibility sizes, overlapping is quite unavoidable, so we move the counter label completely out from the text view, placed in a layout in between the text view and the button. We also increase the text view height to improve readability of the text. This is not the best ui-wise, but is a simple way to avoid the overlapping while keeping the feature usable.

![CleanShot 2024-12-20 at 16 55 34@2x](https://github.com/user-attachments/assets/36e6c7d3-db5d-4c77-a06f-905bf0b1b4f3)


### Testing Steps

- Run the demo app.
- Open the Quick Editor example page.
- Open the alt text editor from any of the avatars.
  - Check that the UI looks as in the screenshots.
- Change dynamic type sizes to bigger ones.
  - Check that the counter won't overlap the text, and they are both always readable   
