### PR TITLE
Extra profile refresh for the new users

### DIFF
--- a/Demo/Gravatar-Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Gravatar-Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dddfee60d726ac68a5cd796dea6619c69dcce5cc55b1b6d7d75bb308b96243a1",
+  "originHash" : "ef380bfd827500bb40ef65e62058cb22bbebbf217402a19c327d4201d142ba21",
   "pins" : [
     {
       "identity" : "swift-snapshot-testing",
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
         "version" : "509.0.2"
-      }
-    },
-    {
-      "identity" : "swiftformat",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/nicklockwood/SwiftFormat",
-      "state" : {
-        "revision" : "86ed20990585f478c0daf309af645c2a528b59d8",
-        "version" : "0.54.6"
       }
     }
   ],

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -274,6 +274,14 @@ class AvatarPickerViewModel: ObservableObject {
                 grid.selectAvatar(withID: avatar.id)
                 self.selectedAvatarURL = URL(string: avatar.url)
                 self.backendSelectedAvatarURL = URL(string: avatar.url)
+                switch profileResult {
+                case .failure:
+                    // Serverside creates a new profile on the first successful
+                    // avatar upload so we refresh the profile.
+                    await fetchProfile()
+                default:
+                    break
+                }
             }
         } catch ImageUploadError.responseError(reason: let .invalidHTTPStatusCode(response, errorPayload))
             where response.statusCode == HTTPStatus.badRequest.rawValue || response.statusCode == HTTPStatus.payloadTooLarge.rawValue

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -274,14 +274,6 @@ class AvatarPickerViewModel: ObservableObject {
                 grid.selectAvatar(withID: avatar.id)
                 self.selectedAvatarURL = URL(string: avatar.url)
                 self.backendSelectedAvatarURL = URL(string: avatar.url)
-                switch profileResult {
-                case .failure:
-                    // Serverside creates a new profile on the first successful
-                    // avatar upload so we refresh the profile.
-                    await fetchProfile()
-                default:
-                    break
-                }
             }
         } catch ImageUploadError.responseError(reason: let .invalidHTTPStatusCode(response, errorPayload))
             where response.statusCode == HTTPStatus.badRequest.rawValue || response.statusCode == HTTPStatus.payloadTooLarge.rawValue

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -135,7 +135,7 @@ class AvatarPickerViewModel: ObservableObject {
             .removeDuplicates()
             .sink { [weak self] _ in
                 self?.compensatingFetchProfileTask = Task {
-                    // Profile does not exists but `/v3/me/avatars` is success. This means it's a new account. Backend creates a new
+                    // Profile does not exist but `/v3/me/avatars` is success. This means it's a new account. Backend creates a new
                     // profile during the first GET `/v3/me/avatars` of a new user. So we refresh the profile to fetch it.
                     // Happens only when the token is passed externally.
                     await self?.fetchProfile()

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -29,24 +29,7 @@ class AvatarPickerViewModel: ObservableObject {
     @Published private(set) var backendSelectedAvatarURL: URL?
     @Published private(set) var gridResponseStatus: Result<Void, Error>?
     @Published private(set) var grid: AvatarGridModel = .init(avatars: [])
-
-    private var profileResult: Result<ProfileSummaryModel, Error>? {
-        didSet {
-            switch profileResult {
-            case .success(let value):
-                profileModel = .init(
-                    displayName: value.displayName,
-                    location: value.location,
-                    profileURL: value.profileURL,
-                    pronunciation: value.pronunciation,
-                    pronouns: value.pronouns
-                )
-            default:
-                profileModel = nil
-            }
-        }
-    }
-
+    @Published private(set) var profileResult: Result<ProfileSummaryModel, Error>?
     @Published var isProfileLoading: Bool = false
     @Published private(set) var isAvatarsLoading: Bool = false
     @Published var avatarIdentifier: AvatarIdentifier?
@@ -128,6 +111,50 @@ class AvatarPickerViewModel: ObservableObject {
             }
             .assign(to: \.shouldDisplayNoSelectedAvatarWarning, on: self)
             .store(in: &cancellables)
+
+        $profileResult
+            .combineLatest($gridResponseStatus)
+            .filter { profileResult, gridResponseStatus in
+                let isProfileStatus404 = switch profileResult {
+                case .failure(APIError.responseError(let .invalidHTTPStatusCode(response, _))) where response.statusCode == HTTPStatus.notFound.rawValue:
+                    true
+                default:
+                    false
+                }
+
+                let isGridResponseSuccess = switch gridResponseStatus {
+                case .success:
+                    true
+                default:
+                    false
+                }
+
+                return isProfileStatus404 && isGridResponseSuccess
+            }
+            .sink { [weak self] _, _ in
+                Task {
+                    // Profile does not exists but `/v3/me/avatars` is success. This means it's a new account. Backend creates a profile
+                    // during the first GET `/v3/me/avatars` of a new user. So we refresh the profile to fetch it.
+                    await self?.fetchProfile()
+                }
+            }
+            .store(in: &cancellables)
+
+        $profileResult.sink { [weak self] profileResult in
+            switch profileResult {
+            case .success(let value):
+                self?.profileModel = .init(
+                    displayName: value.displayName,
+                    location: value.location,
+                    profileURL: value.profileURL,
+                    pronunciation: value.pronunciation,
+                    pronouns: value.pronouns
+                )
+            default:
+                self?.profileModel = nil
+            }
+        }
+        .store(in: &cancellables)
     }
 
     func selectAvatar(with id: String) async -> Avatar? {


### PR DESCRIPTION
Closes https://github.com/Automattic/Gravatar-SDK-iOS/issues/612

### Description

Fixes the issue described in https://github.com/Automattic/Gravatar-SDK-iOS/issues/612
This is to avoid the initial blank state of the profile view that a new user sees. When a user creates an account via `WordPress.com` they don't have a Gravatar profile yet so the Quick Editor shows blank fields initially. The Gravatar profile is created at the backend during the first avatars fetching, but we never refresh the client so the profile view remains blank and shows grey placeholders. This PR fixes that issue. 

The issue is not too bad so I was on the fence of fixing/leaving it. Doing this only because I believe that the solution is not risky, it only adds an extra profile fetch call. But let me know if you think otherwise. 

### Testing Steps

Easiest way to test is using the Jetpack app

Check out WordPress-iOS `trunk`
Point the Gravatar dependency to this branch' latest commit
Run the Jetpack app
You can use a temp inbox like [www.emailondeck.com](http://www.emailondeck.com/) to create an email
Logout and create a new user
Go to your inbox, verify the email (open the email verification link in incognito mode to isolate from your existing .com session otherwise it may not work)
Go to Me > My Profile > Add profile photo
Observe: The profile view does NOT show grey placeholder fields, instead, it shows the user's username and "View profile ->" button.

