### PR TITLE
Fix "No image selected warning is shown during the first avatar upload is in progress"

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -25,7 +25,6 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
     @State private var shareSheetItem: AvatarShareItem?
     @State private var playgroundInputItem: PlaygroundInputItem?
     @State private var altTextEditorAvatar: AvatarImageModel?
-    @State private var shouldDisplayNoSelectedAvatarWarning: Bool = false
 
     var contentLayoutProvider: AvatarPickerContentLayoutProviding
     var customImageEditor: ImageEditorBlock<ImageEditor>?
@@ -166,12 +165,6 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
         .onChange(of: model.backendSelectedAvatarURL) { _ in
             notifyAvatarSelection()
         }
-        .onChange(of: model.selectedAvatarURL) { _ in
-            updateShouldDisplayNoSelectedAvatarWarning()
-        }
-        .onChange(of: model.grid.avatars.count) { _ in
-            updateShouldDisplayNoSelectedAvatarWarning()
-        }
         .sheet(item: $shareSheetItem) { item in
             ShareSheet(items: [item.fileURL])
                 .colorScheme(colorScheme)
@@ -203,10 +196,6 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
                 altTextEditorAvatar = nil
             }
         )
-    }
-
-    private func updateShouldDisplayNoSelectedAvatarWarning() {
-        shouldDisplayNoSelectedAvatarWarning = model.selectedAvatarURL == nil && model.grid.avatars.count > 0
     }
 
     private func header() -> some View {
@@ -458,14 +447,14 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
 
     @ViewBuilder
     private func noSelectedAvatarWarning() -> some View {
-        if shouldDisplayNoSelectedAvatarWarning {
+        if model.shouldDisplayNoSelectedAvatarWarning {
             Toast(toast: .init(
                 message: Localized.noImageSelectedMessage,
                 type: .warning,
                 shouldShowShadow: false
             )) { _ in
                 withAnimation {
-                    shouldDisplayNoSelectedAvatarWarning = false
+                    model.shouldDisplayNoSelectedAvatarWarning = false
                 }
             }
             .padding(.horizontal, Constants.horizontalPadding)

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Gravatar
 import SwiftUI
@@ -44,7 +45,9 @@ class AvatarPickerViewModel: ObservableObject {
     @Published private(set) var isAvatarsLoading: Bool = false
     @Published var avatarIdentifier: AvatarIdentifier?
     @Published var profileModel: AvatarPickerProfileView.Model?
+    @Published var shouldDisplayNoSelectedAvatarWarning: Bool = false
     @ObservedObject var toastManager: ToastManager = .init()
+    private var cancellables = Set<AnyCancellable>()
 
     init(
         email: Email,
@@ -59,6 +62,7 @@ class AvatarPickerViewModel: ObservableObject {
         self.profileService = profileService ?? ProfileService()
         self.avatarService = avatarService ?? AvatarService()
         self.imageDownloader = imageDownloader ?? ImageDownloadService()
+        setupCombine()
     }
 
     /// Internal init for previewing purposes. Do not make this public.
@@ -98,6 +102,23 @@ class AvatarPickerViewModel: ObservableObject {
                 break
             }
         }
+        setupCombine()
+    }
+
+    private func setupCombine() {
+        grid.$avatars
+            .map {
+                $0.filter { avatar in
+                    avatar.state == .loaded
+                }.count
+            }
+            .combineLatest($selectedAvatarURL)
+            .map { loadedAvatarCount, selectedAvatarURL in
+                // Determine if the warning should be displayed
+                selectedAvatarURL == nil && loadedAvatarCount > 0
+            }
+            .assign(to: \.shouldDisplayNoSelectedAvatarWarning, on: self)
+            .store(in: &cancellables)
     }
 
     func selectAvatar(with id: String) async -> Avatar? {

--- a/Tests/GravatarUITests/AvatarPickerViewModelTests.swift
+++ b/Tests/GravatarUITests/AvatarPickerViewModelTests.swift
@@ -63,6 +63,23 @@ final class AvatarPickerViewModelTests {
     }
 
     @Test
+    func testShouldDisplayNoSelectedAvatarWarning() async throws {
+        let avatarStates: [AvatarImageModel.State] = [.loading, .loaded]
+        for state in avatarStates {
+            let model = AvatarPickerViewModel(avatarImageModels: [
+                .init(id: "123", source: .remote(url: "https://example.com"), state: state, isSelected: false, rating: .g, altText: ""),
+            ])
+            #expect(model.shouldDisplayNoSelectedAvatarWarning == (state == .loaded))
+        }
+
+        let model = AvatarPickerViewModel(avatarImageModels: [
+            .init(id: "123", source: .remote(url: "https://example.com"), state: .loaded, isSelected: false, rating: .g, altText: ""),
+        ])
+        model.selectedAvatarURL = nil
+        #expect(model.shouldDisplayNoSelectedAvatarWarning == true)
+    }
+
+    @Test
     func testSelectAvatar() async throws {
         let toSelectID = "9862792c565394..."
         await model.refresh()


### PR DESCRIPTION
Closes #616

### Description

No image selected warning is being shown whether the image is `loaded` or `loading`. We should filter out the loading ones when deciding this.

While on it, I moved the logic to the view model and added some unit tests.

### Testing Steps

Follow the steps in https://github.com/Automattic/Gravatar-SDK-iOS/issues/616