### PR TITLE
Responding to deny button app on web oauth

### DIFF
--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
@@ -87,6 +87,8 @@ public struct OAuthSession: Sendable {
             postNotification(.authorizationFinished)
             return true
         } catch OAuthError.couldNotParseAccessCode {
+            await shared.authenticationSession.cancel()
+            postNotification(.authorizationFinished)
             return false // The URL was not a Gravatar callback URL with a token.
         } catch {
             await shared.authenticationSession.cancel()


### PR DESCRIPTION
Closes #

### Description

This small PRs fixes an issue where tapping on the DENY button on the web oauth did nothing.

![CleanShot 2025-01-06 at 16 28 41](https://github.com/user-attachments/assets/c2f14e3e-5cdf-492d-b5f4-87eb60006fbf)

### Testing Steps

- Run the demo app
- Go to `QuickEditor`
- Log out if needed
- `Show Quick Editor`
- Continue with OAuth.
- On the web view, tap on `Deny`
  - Check that the web view dismisses and the UI comes back to the corresponding state.
   