### PR TITLE
Fix "Multiple images are selected when the same image is uploaded"

### DIFF
--- a/Sources/Gravatar/Resources/SDKInfo.plist
+++ b/Sources/Gravatar/Resources/SDKInfo.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.0</string>
+	<string>3.1.1</string>
 </dict>
 </plist>

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarGridModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarGridModel.swift
@@ -25,6 +25,16 @@ class AvatarGridModel: ObservableObject {
     func replaceModel(withID id: String, with model: AvatarImageModel) {
         guard let index = index(of: id) else { return }
         avatars[index] = model
+        removeDuplicates(of: model, atIndex: index)
+    }
+
+    /// Keep the model at `index`, remove the rest that has the same `id`.
+    private func removeDuplicates(of model: AvatarImageModel, atIndex index: Int) {
+        for (indexIter, modelIter) in avatars.enumerated() {
+            if modelIter.id == model.id && indexIter != index {
+                avatars.remove(at: indexIter)
+            }
+        }
     }
 
     func removeModel(_ id: String) {

--- a/Tests/GravatarUITests/AvatarGridModelTests.swift
+++ b/Tests/GravatarUITests/AvatarGridModelTests.swift
@@ -107,4 +107,24 @@ struct AvatarGridModelTests {
 
         #expect(model.index(of: "new") == 2)
     }
+
+    @Test("Test replace function")
+    func testAvatarGridModelReplace() async throws {
+        let toReplace = AvatarImageModel(id: "new", source: .remote(url: "https://example.com"))
+        model.replaceModel(withID: "0", with: toReplace)
+
+        #expect(model.index(of: "new") == 0)
+    }
+
+    @Test("Test replace with an existing ID")
+    func testAvatarGridModelReplaceWithExistingID() async throws {
+        // An element with ID "4" already exists in the model
+        let toReplace = AvatarImageModel(id: "4", source: .remote(url: "https://example.com"))
+        // Replace an existing element with a new element whose ID is "4".
+        model.replaceModel(withID: "0", with: toReplace)
+        // Check how many items are present with ID == "4"
+        let avatarCount = model.avatars.filter { $0.id == "4" }.count
+        #expect(avatarCount == 1)
+        #expect(model.index(of: "4") == 0)
+    }
 }

--- a/version.rb
+++ b/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Gravatar
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
   SWIFT_VERSIONS = [
     '5.10'
   ].freeze


### PR DESCRIPTION
Closes #618

### Description

Backend generates avatar ids based on the image file's hash. When we upload the same image multiple times it has the same id (not always though, I can sometimes upload the same image twice because a different hash is generated somehow). So we should remove the other duplicate one. This also matches behavior with android and web.

### Testing Steps

Upload the same image multiple times
Select it
Only 1 image should be selected
