### PR TITLE
Initialize fetchedToken with the keychain item

### DIFF
--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -71,7 +71,11 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
             } else {
                 noticeView()
             }
-        }.onReceive(authorizationFinishedNotification) { _ in
+        }
+        .onAppear() {
+            fetchedToken = oauthSession.sessionToken(with: email)?.token
+        }
+        .onReceive(authorizationFinishedNotification) { _ in
             onAuthenticationFinished()
         }.onReceive(authorizationErrorNotification) { notification in
             guard let error = notification.object as? OAuthError else { return }

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -72,7 +72,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
                 noticeView()
             }
         }
-        .onAppear() {
+        .onAppear {
             fetchedToken = oauthSession.sessionToken(with: email)?.token
         }
         .onReceive(authorizationFinishedNotification) { _ in


### PR DESCRIPTION
Closes #625 #579

### Description

Removing the app doesn’t clear the keychain entry for that email so oauthSession.hasValidSession(with: email) returns true which causes it to skip the oauth flow.

The source of truth about tokens is the Keychain but SwiftUI uses `@State` variables to shape and refresh the UI. `fetchedToken` needs to be initialized from the keychain so the UI can adapt accordingly.

### Testing Steps

Refer to #625 and #579 for testing steps.