### PR TITLE
Fix URL Identifiable warning

### DIFF
--- a/Sources/GravatarUI/Base/IdentifiableURL.swift
+++ b/Sources/GravatarUI/Base/IdentifiableURL.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct IdentifiableURL: Identifiable {
+    let url: URL
+
+    init?(url: URL?) { // for convenience
+        guard let url else { return nil }
+        self.url = url
+    }
+
+    public var id: String {
+        url.absoluteString
+    }
+}

--- a/Sources/GravatarUI/Base/URL+Additions.swift
+++ b/Sources/GravatarUI/Base/URL+Additions.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-extension URL: Identifiable {
-    public var id: String {
-        absoluteString
-    }
-}

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileViewWrapper.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileViewWrapper.swift
@@ -8,7 +8,7 @@ struct AvatarPickerProfileViewWrapper: View {
     @Binding var forceRefreshAvatar: Bool
     @Binding var model: AvatarPickerProfileView.Model?
     @Binding var isLoading: Bool
-    @Binding var safariURL: URL?
+    @Binding var safariURL: IdentifiableURL?
 
     public var body: some View {
         VStack(alignment: .leading, content: {
@@ -18,7 +18,7 @@ struct AvatarPickerProfileViewWrapper: View {
                 model: $model,
                 isLoading: $isLoading
             ) {
-                safariURL = model?.profileURL
+                safariURL = IdentifiableURL(url: model?.profileURL)
             }.frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.init(
                     top: .DS.Padding.single,

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -13,7 +13,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
     @ObservedObject var model: AvatarPickerViewModel
     @Binding var isPresented: Bool
 
-    @State private var safariURL: URL?
+    @State private var safariURL: IdentifiableURL?
     @State private var uploadError: FailedUploadInfo?
     @State private var isUploadErrorDialogPresented: Bool = false
     @State private var avatarToDelete: AvatarImageModel?
@@ -148,7 +148,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
             },
             preferenceKey: InnerHeightPreferenceKey.self
         )
-        .presentSafariView(url: $safariURL, colorScheme: colorScheme)
+        .presentSafariView(identifiableURL: $safariURL, colorScheme: colorScheme)
         .onChange(of: model.backendSelectedAvatarURL) { _ in
             notifyAvatarSelection()
         }
@@ -436,7 +436,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
     }
 
     private func openProfileInSafari() {
-        safariURL = model.profileModel?.profileURL
+        safariURL = IdentifiableURL(url: model.profileModel?.profileURL)
     }
 
     @ViewBuilder

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
@@ -9,7 +9,7 @@ struct AltTextEditorView: View {
 
     @State var altText: String = ""
     @State var charCount: Int = 0
-    @State var safariURL: URL? = nil
+    @State var safariURL: IdentifiableURL? = nil
     @State var isLoading: Bool = false
     @ObservedObject var toastManager: ToastManager
 
@@ -87,7 +87,7 @@ struct AltTextEditorView: View {
             },
             preferenceKey: ConstantHeightPreferenceKey.self
         )
-        .presentSafariView(url: $safariURL, colorScheme: colorScheme)
+        .presentSafariView(identifiableURL: $safariURL, colorScheme: colorScheme)
         .onAppear {
             altText = avatar?.altText ?? ""
         }
@@ -157,7 +157,7 @@ struct AltTextEditorView: View {
 
     var altTextHelpButton: some View {
         Button(Localized.helpButtonTitle) {
-            safariURL = URL(string: "https://support.gravatar.com/profiles/avatars/#add-alt-text-to-avatars")
+            safariURL = IdentifiableURL(url: URL(string: "https://support.gravatar.com/profiles/avatars/#add-alt-text-to-avatars"))
         }.font(.footnote)
     }
 

--- a/Sources/GravatarUI/SwiftUI/GravatarNavigationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/GravatarNavigationModifier.swift
@@ -7,7 +7,7 @@ struct GravatarNavigationModifier<K: PreferenceKey>: ViewModifier where K.Value 
     var actionButtonDisabled: Bool
 
     @Environment(\.colorScheme) var colorScheme
-    @State private var safariURL: URL?
+    @State private var safariURL: IdentifiableURL?
 
     var onActionButtonPressed: (() -> Void)? = nil
     var onDoneButtonPressed: (() -> Void)? = nil
@@ -53,11 +53,11 @@ struct GravatarNavigationModifier<K: PreferenceKey>: ViewModifier where K.Value 
                     )
                 }
             }
-            .presentSafariView(url: $safariURL, colorScheme: colorScheme)
+            .presentSafariView(identifiableURL: $safariURL, colorScheme: colorScheme)
     }
 
     private func openProfileEditInSafari() {
-        guard let url = URL(string: "https://gravatar.com/profile") else { return }
+        guard let url = IdentifiableURL(url: URL(string: "https://gravatar.com/profile")) else { return }
         safariURL = url
     }
 }

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -26,7 +26,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
     @State private var fetchedToken: String?
     @State private var isAuthenticating: Bool = false
     @State private var oauthError: OAuthError?
-    @State private var safariURL: URL?
+    @State private var safariURL: IdentifiableURL?
     @Binding private var isPresented: Bool
     // Declare "@StateObject"s as private to prevent setting them from a
     // memberwise initializer, which can conflict with the storage
@@ -145,7 +145,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
             },
             preferenceKey: InnerHeightPreferenceKey.self
         )
-        .presentSafariView(url: $safariURL, colorScheme: colorScheme)
+        .presentSafariView(identifiableURL: $safariURL, colorScheme: colorScheme)
         .task(id: email) {
             await model.fetchProfile()
         }

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditorNoticeView.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditorNoticeView.swift
@@ -7,7 +7,7 @@ struct QuickEditorNoticeView: View {
     @Binding var token: String?
     @Binding var oauthError: OAuthError?
     @ObservedObject var model: AvatarPickerViewModel
-    @Binding var safariURL: URL?
+    @Binding var safariURL: IdentifiableURL?
     let proceedAction: @MainActor () -> Void
 
     var body: some View {

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -180,9 +180,9 @@ extension View {
         }
     }
 
-    func presentSafariView(url: Binding<URL?>, colorScheme: ColorScheme) -> some View {
-        self.sheet(item: url) { url in
-            SafariView(url: url)
+    func presentSafariView(identifiableURL: Binding<IdentifiableURL?>, colorScheme: ColorScheme) -> some View {
+        self.sheet(item: identifiableURL) { identifiableURL in
+            SafariView(url: identifiableURL.url)
                 .edgesIgnoringSafeArea(.all)
                 .colorScheme(colorScheme)
         }


### PR DESCRIPTION
Closes #

### Description

Fixes this warning:

<img width="879" alt="Screenshot 2025-01-08 at 14 49 14" src="https://github.com/user-attachments/assets/e1a0258b-18e9-4de0-b8c4-0956ae1b6dcc" />

The cleanest way to solve this warning seems to be avoiding defining such extensions for external types and defining your own wrappers that conform to `Identifiable`.

### Testing Steps

Open QE and test the links that open in-app Safari like the "View Profile" button or the Gravatar icon on the navigation bar.