### PR TITLE
Replace "What is alt text?" with questionmark icon

### DIFF
--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -1,9 +1,6 @@
 /* Title for Cancel button. */
 "AltText.Editor.cancelButtonTitle" = "Cancel";
 
-/* Title for Help button which opens a view explaining what alt text is. */
-"AltText.Editor.helpButtonTitle" = "What is alt text?";
-
 /* Placeholder text for Alt Text editor text field. */
 "AltText.Editor.placeholder" = "Write alt text...";
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
@@ -156,9 +156,16 @@ struct AltTextEditorView: View {
     }
 
     var altTextHelpButton: some View {
-        Button(Localized.helpButtonTitle) {
+        Button {
             safariURL = IdentifiableURL(url: URL(string: "https://support.gravatar.com/profiles/avatars/#add-alt-text-to-avatars"))
-        }.font(.footnote)
+        } label: {
+            Image(systemName: "questionmark.circle")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 18, height: 18)
+                .font(.footnote.weight(.light))
+                .foregroundColor(Color(UIColor.label))
+        }
     }
 
     var imageView: some View {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
@@ -211,11 +211,6 @@ extension AltTextEditorView {
             value: "Cancel",
             comment: "Title for Cancel button."
         )
-        static let helpButtonTitle = SDKLocalizedString(
-            "AltText.Editor.helpButtonTitle",
-            value: "What is alt text?",
-            comment: "Title for Help button which opens a view explaining what alt text is."
-        )
     }
 }
 


### PR DESCRIPTION
Closes #

### Description

Applying the new design https://www.figma.com/design/xgXj4jig9m0DYfKjFq6swG/QE-Native-Experience?t=HQVMpuwGustjB1HW-0

<img src="https://github.com/user-attachments/assets/8bc88673-334f-4f29-8f7e-2d35752f7ed4" width=300/>

### Testing Steps

QE -> Avatar ... menu > alt text > ? icon