### PR TITLE
Update podspecs to Swift 6.0

### DIFF
--- a/version.rb
+++ b/version.rb
@@ -3,6 +3,6 @@
 module Gravatar
   VERSION = '3.1.1'
   SWIFT_VERSIONS = [
-    '5.10'
+    '6.0'
   ].freeze
 end


### PR DESCRIPTION
Closes #

### Description

This updates the podspecs so that they specify Swift 6.0 as a minimum supported version.  This mirrors the changes in #610  and should have been included in that PR.

### Testing Steps

- [ ] CI should be 🟢 