### PR TITLE
Fix color scheme on the alt text view

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -174,6 +174,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
             model: $altTextEditorAvatar,
             email: model.email,
             toastManager: model.toastManager,
+            colorScheme: colorScheme,
             onSave: { modifiedModel in
                 if await model.update(altText: modifiedModel.altText, for: modifiedModel) {
                     altTextEditorAvatar = nil

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -101,6 +101,7 @@ extension View {
         model: Binding<AvatarImageModel?>,
         email: Email,
         toastManager: ToastManager,
+        colorScheme: ColorScheme,
         onSave: @escaping (AvatarImageModel) async -> Void,
         onCancel: @escaping () -> Void
     ) -> some View {
@@ -108,6 +109,7 @@ extension View {
             NavigationView {
                 AltTextEditorView(avatar: model, email: email, toastManager: toastManager, onSave: onSave, onCancel: onCancel)
             }
+            .colorScheme(colorScheme)
         }
 
         if #available(iOS 16.0, *) {


### PR DESCRIPTION
Closes #

### Description

The alt text view doesn't adapt to the passed color scheme option. This PR fixes that.

### Testing Steps

Demo app > Quick Editor > Dark > Show Quick Editor > ... menu Alt text option
Verify that the alt text entry view opens in dark mode.
