### PR TITLE
Update the questionmark icon color in the alt text view

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AltTextEditorView.swift
@@ -163,8 +163,8 @@ struct AltTextEditorView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 18, height: 18)
-                .font(.footnote.weight(.light))
-                .foregroundColor(Color(UIColor.label))
+                .font(.footnote)
+                .foregroundColor(Color(UIColor.gravatarBlue))
         }
     }
 


### PR DESCRIPTION
Closes #

### Description

Updating the icon color as Gravatar blue (#1D4FC4) based on the internal conversation. I also updated the font weight since the previous one looked too thin for this color. Checked with our designer as well.

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/1e5ed810-dfea-48fb-ae68-133597695c16" width=300/></td>
    <td><img src="https://github.com/user-attachments/assets/fe43546d-db7e-429d-8350-005c420f90e7" width=300/></td>
  </tr>
</table>

### Testing Steps

Check the question mark icon ☝️ in both light and dark mode.
