### PR TITLE
Moving SwiftLint and SwiftFormat to Docker

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,18 +21,18 @@ steps:
     agents:
       queue: "linter"
 
-  # - label: ":swift: SwiftFormat Linting"
-  #   plugins:
-  #     - docker#v5.12.0:
-  #         image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
-  #         command: ["--lint", "Sources"]
-  #         workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
-  #     - docker#v5.12.0:
-  #         image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
-  #         command: ["--lint", "Tests"]
-  #         workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
-  #   agents:
-  #     queue: "default"
+  - label: ":swift: SwiftFormat Linting"
+    plugins:
+      - docker#v5.12.0:
+          image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
+          command: ["--lint", "Sources"]
+          workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+      - docker#v5.12.0:
+          image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
+          command: ["--lint", "Tests"]
+          workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+    agents:
+      queue: "default"
 
   - label: ☢️ Danger - PR Check
     command: danger

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,8 +18,6 @@ steps:
     plugins:
       - docker#v5.12.0:
           image: "ghcr.io/realm/swiftlint:$SWIFTLINT_VERSION"
-          volumes:
-            - "${BUILDKITE_BUILD_CHECKOUT_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}"
           workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
     agents:
       queue: "default"
@@ -29,14 +27,10 @@ steps:
       - docker#v5.12.0:
           image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
           command: ["--lint", "Sources"]
-          volumes:
-            - "${BUILDKITE_BUILD_CHECKOUT_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}"
           workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
       - docker#v5.12.0:
           image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
           command: ["--lint", "Tests"]
-          volumes:
-            - "${BUILDKITE_BUILD_CHECKOUT_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}"
           workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
     agents:
       queue: "default"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,6 +33,9 @@ steps:
               image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
               command: ["--lint", "Tests"]
               workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+        notify:
+          - github_commit_status:
+              context: "SwiftFormat Linting"
         agents:
           queue: "default"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,6 @@ agents:
   queue: "mac"
 env:
   IMAGE_ID: $IMAGE_ID
-  SWIFTLINT_VERSION: $SWIFTLINT_VERSION
   SWIFTFORMAT_VERSION: $SWIFTFORMAT_VERSION
 
 steps:
@@ -15,12 +14,12 @@ steps:
   # Lint Source files
   #################
   - label: ":swift: SwiftLint"
-    plugins:
-      - docker#v5.12.0:
-          image: "ghcr.io/realm/swiftlint:$SWIFTLINT_VERSION"
-          workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+    command: swiftlint
+    notify:
+      - github_commit_status:
+          context: "SwiftLint"
     agents:
-      queue: "default"
+      queue: "linter"
 
   - label: ":swift: SwiftFormat Linting"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,16 +7,39 @@ agents:
   queue: "mac"
 env:
   IMAGE_ID: $IMAGE_ID
+  SWIFTLINT_VERSION: $SWIFTLINT_VERSION
+  SWIFTFORMAT_VERSION: $SWIFTFORMAT_VERSION
 
 steps:
   #################
   # Lint Source files
   #################
-  - label: "🕵️ Lint"
-    key: "lint"
-    command: |
-      echo "--- 🛠 Linting"
-      make lint
+  - label: ":swift: SwiftLint"
+    plugins:
+      - docker#v5.12.0:
+          image: "ghcr.io/realm/swiftlint:$SWIFTLINT_VERSION"
+          volumes:
+            - "${BUILDKITE_BUILD_CHECKOUT_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}"
+          workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+    agents:
+      queue: "default"
+
+  - label: ":swift: SwiftFormat Linting"
+    plugins:
+      - docker#v5.12.0:
+          image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
+          command: ["--lint", "Sources"]
+          volumes:
+            - "${BUILDKITE_BUILD_CHECKOUT_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}"
+          workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+      - docker#v5.12.0:
+          image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
+          command: ["--lint", "Tests"]
+          volumes:
+            - "${BUILDKITE_BUILD_CHECKOUT_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}"
+          workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+    agents:
+      queue: "default"
 
   - label: ☢️ Danger - PR Check
     command: danger

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,18 +21,18 @@ steps:
     agents:
       queue: "linter"
 
-  - label: ":swift: SwiftFormat Linting"
-    plugins:
-      - docker#v5.12.0:
-          image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
-          command: ["--lint", "Sources"]
-          workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
-      - docker#v5.12.0:
-          image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
-          command: ["--lint", "Tests"]
-          workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
-    agents:
-      queue: "default"
+  # - label: ":swift: SwiftFormat Linting"
+  #   plugins:
+  #     - docker#v5.12.0:
+  #         image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
+  #         command: ["--lint", "Sources"]
+  #         workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+  #     - docker#v5.12.0:
+  #         image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
+  #         command: ["--lint", "Tests"]
+  #         workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+  #   agents:
+  #     queue: "default"
 
   - label: ☢️ Danger - PR Check
     command: danger

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,36 +13,38 @@ steps:
   #################
   # Lint Source files
   #################
-  - label: ":swift: SwiftLint"
-    command: swiftlint
-    notify:
-      - github_commit_status:
-          context: "SwiftLint"
-    agents:
-      queue: "linter"
+  - group: "Linters"
+    steps:
+      - label: ":swift: SwiftLint"
+        command: swiftlint
+        notify:
+          - github_commit_status:
+              context: "SwiftLint"
+        agents:
+          queue: "linter"
 
-  - label: ":swift: SwiftFormat Linting"
-    plugins:
-      - docker#v5.12.0:
-          image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
-          command: ["--lint", "Sources"]
-          workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
-      - docker#v5.12.0:
-          image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
-          command: ["--lint", "Tests"]
-          workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
-    agents:
-      queue: "default"
+      - label: ":swift: SwiftFormat Linting"
+        plugins:
+          - docker#v5.12.0:
+              image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
+              command: ["--lint", "Sources"]
+              workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+          - docker#v5.12.0:
+              image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
+              command: ["--lint", "Tests"]
+              workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+        agents:
+          queue: "default"
 
-  - label: ☢️ Danger - PR Check
-    command: danger
-    key: danger
-    if: build.pull_request.id != null
-    retry:
-      manual:
-        permit_on_passed: true
-    agents:
-      queue: linter
+      - label: ☢️ Danger - PR Check
+        command: danger
+        key: danger
+        if: build.pull_request.id != null
+        retry:
+          manual:
+            permit_on_passed: true
+        agents:
+          queue: linter
 
   #################
   # Build and Test

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -7,5 +7,4 @@ export IMAGE_ID="xcode-16.2-macos-14.7.1-v1"
 
 export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.2.2"
 
-export SWIFTLINT_VERSION="0.58.0"
 export SWIFTFORMAT_VERSION="0.54.5"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -6,3 +6,6 @@
 export IMAGE_ID="xcode-16.2-macos-14.7.1-v1"
 
 export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.2.2"
+
+export SWIFTLINT_VERSION="0.58.0"
+export SWIFTFORMAT_VERSION="0.54.5"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -7,4 +7,4 @@ export IMAGE_ID="xcode-16.2-macos-14.7.1-v1"
 
 export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.2.2"
 
-export SWIFTFORMAT_VERSION="0.54.5"
+export SWIFTFORMAT_VERSION=$( awk '/^--minversion/ { print $2 }' .swiftformat )

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,3 +1,6 @@
+## SwiftFormat version
+--minversion 0.54.5
+
 ## Swift version
 
 # Some rules are applicable only to newer versions of Swift.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-swiftlint_version: 0.58.0
+swiftlint_version: 0.57.1
 only_rules: # Rules to run
   - custom_rules
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,4 @@
+swiftlint_version: 0.58.0
 only_rules: # Rules to run
   - custom_rules
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,20 @@
+only_rules: # Rules to run
+  - custom_rules
+
+# If true, SwiftLint will treat all warnings as errors.
+strict: true
+
+included:
+  - Sources
+  - Tests
+
+custom_rules:
+  no_ns_localized_string:
+    included:
+      - "Sources/.*\\.swift"
+    name: "No NSLocalizedString"
+    regex: "NSLocalizedString\\("
+    match_kinds:
+      - identifier
+    message: "Use `SDKLocalizedString()` instead of `NSLocalizedString()`."
+    severity: error

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 SWIFTFORMAT_CACHE = ~/Library/Caches/com.charcoaldesign.swiftformat
 
 # SwiftLint
-SWIFTLINT_VERSION ?= 0.58.0
+SWIFTLINT_VERSION := $(shell awk -F': ' '/^swiftlint_version: / {print $$2}' .swiftlint.yml)
 SWIFTLINT_DOCKER_BUILDER_NAME = swiftlint_builder
 
 # SwiftFormat
@@ -90,7 +90,14 @@ docker-swiftlint-builder: # Create and use the Buildx builder because the SwiftL
 	fi
 
 swiftlint-run: # Docker command to run swiftlint
-	@docker run --platform linux/amd64 -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/realm/swiftlint:$(SWIFTLINT_VERSION)
+	docker run --platform linux/amd64 -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/realm/swiftlint:$(SWIFTLINT_VERSION)
+
+swiftlint-version:
+	@if [ -z "$(SWIFTLINT_VERSION)" ]; then \
+		echo "SwiftLint version not found in .swiftlint.yml"; \
+	else \
+		echo "SwiftLint version: $(SWIFTLINT_VERSION)"; \
+	fi
 
 lint: # Use swiftformat to warn about format issues
 	@make swiftlint

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,12 @@
 #
 #   % make help
 
-# Cache
-# No spaces allowed
-SWIFTFORMAT_CACHE = ~/Library/Caches/com.charcoaldesign.swiftformat
-
 # SwiftLint
 SWIFTLINT_VERSION := $(shell awk -F': ' '/^swiftlint_version: / {print $$2}' .swiftlint.yml)
 SWIFTLINT_DOCKER_BUILDER_NAME = swiftlint_builder
 
 # SwiftFormat
-SWIFTFORMAT_VERSION ?= 0.54.5
+SWIFTFORMAT_VERSION := $(shell awk '/^--minversion/ { print $$2 }' .swiftformat)
 
 # The following values can be changed here, or passed on the command line.
 OPENAPI_GENERATOR_DOCKER_IMAGE ?= openapitools/openapi-generator-cli

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ SWIFTFORMAT_CACHE = ~/Library/Caches/com.charcoaldesign.swiftformat
 SWIFTLINT_VERSION ?= 0.58.0
 SWIFTLINT_DOCKER_BUILDER_NAME = swiftlint_builder
 
+# SwiftFormat
+SWIFTFORMAT_VERSION ?= 0.54.5
 
 # The following values can be changed here, or passed on the command line.
 OPENAPI_GENERATOR_DOCKER_IMAGE ?= openapitools/openapi-generator-cli
@@ -71,10 +73,12 @@ setup-secrets: bundle-install
 	bundle exec fastlane run configure_apply
 
 swiftformat: # Automatically find and fixes lint issues
-	swift package plugin \
-		--allow-writing-to-package-directory \
-		--allow-writing-to-directory $(SWIFTFORMAT_CACHE) \
-		swiftformat
+	@docker run --rm -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/nicklockwood/swiftformat:$(SWIFTFORMAT_VERSION) Sources
+	@docker run --rm -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/nicklockwood/swiftformat:$(SWIFTFORMAT_VERSION) Tests
+
+swiftformat-lint:
+	@docker run --rm -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/nicklockwood/swiftformat:$(SWIFTFORMAT_VERSION) --lint Sources
+	@docker run --rm -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/nicklockwood/swiftformat:$(SWIFTFORMAT_VERSION) --lint Tests
 
 swiftlint: docker-swiftlint-builder swiftlint-run # Sets up the buildx builder and runs the swiftlint command
 
@@ -90,11 +94,7 @@ swiftlint-run: # Docker command to run swiftlint
 
 lint: # Use swiftformat to warn about format issues
 	@make swiftlint
-	swift package plugin \
-		--allow-writing-to-package-directory \
-		--allow-writing-to-directory $(SWIFTFORMAT_CACHE) \
-		swiftformat \
-		--lint
+	@make swiftformat-lint
 
 validate-pod: bundle-install
 	# For some reason this fixes a failure in `lib lint`

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dddfee60d726ac68a5cd796dea6619c69dcce5cc55b1b6d7d75bb308b96243a1",
+  "originHash" : "ef380bfd827500bb40ef65e62058cb22bbebbf217402a19c327d4201d142ba21",
   "pins" : [
     {
       "identity" : "swift-snapshot-testing",
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
         "version" : "510.0.2"
-      }
-    },
-    {
-      "identity" : "swiftformat",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/nicklockwood/SwiftFormat",
-      "state" : {
-        "revision" : "ab6844edb79a7b88dc6320e6cee0a0db7674dac3",
-        "version" : "0.54.5"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,6 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.54.5"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.6"),
     ],
     targets: [


### PR DESCRIPTION
Closes #636 
Closes #622 

### Description

This removes SwiftFormat as a dependency of the Package.swift.  It also re-introduces SwiftLint linting.

It accomplisheses these objects using the same technique.  In both cases, we now use Docker images to run these:
- The Makefile tasks have been updated to use Docker
- CI has been updated to use Docker
   - SwiftLint actually uses a custom `linter` agent which bundles SwiftLint using Docker

### Updating the "Required" Status Checks after merging
Back when SwiftLint ran at build time, we didn't need a dedicated `SwiftLint` step, since we were already building the package.

Now that it needs to be called explicitly, we have a new required step in our CI builds.  This will mean updating our "required" checks:

1. When this PR is ready to merge, we will update the "required" checks:
   - Remove the old `buildkite/gravatar-sdk-ios/lint` required check
   - Add the new `SwiftLint` and `SwiftFormat linting` checks as required
2. After this PR has merged to `trunk`, all branches with PR's targeting `trunk` will need to merge this change in.  Until they do, they won't be able to run these updated "required" checks, and they won't be mergable. 

### Making GitHub Checks more readable
I've taken this opportunity to use `notify` blocks in these new steps for SwiftLint and SwiftFormat:

```yaml
    steps:
      - label: ":swift: SwiftLint"
        command: swiftlint
        notify:
          - github_commit_status:
              context: "SwiftLint"
        agents:
          queue: "linter"
```

This produces a much cleaner, more readable name for these checks in the GitHub Checks section of a PR:
![Screenshot 2025-01-15 at 4 28 00 PM](https://github.com/user-attachments/assets/242b9b36-d3df-4a52-85e6-c37a3d982c0d)

In a future PR, we can use the same technique to replace the rest of the `buildkite/gravatar-sdk-ios/*` checks with more readable names.

### Limitations
In the past, SwiftLint ran at build time.  This produced linting errors in line with Xcode.  It may be possible to re-introduce this capability in the future.  But it will be tricky.  The Xcode build phase script would need a guarantee that it could find the `docker` binary, etc.

### pre-commit hook
In a separate PR, we can explore a pre-commit hook that runs both SwiftLint and SwiftFormat.

### Testing Steps
You will need Docker installed and running on your Mac for these steps:

- [ ] CI won't be gree until we update the required checks (see above)
- [ ] CI should pass the following new checks:
   - SwiftLint
   - SwiftFormat Linting
- Test `make swiftlint`
   1. Add an `NSLocalizedString()` in one of the `Gravatar` or `GravatarUI` targets
   2. Run `make swiftlint`
      - [x] OBSERVE that the first time you run this, docker downloads the required image
      - [x] OBSERVE that subsequent invocations don't download the image again
      - [x] OBSERVE that SwiftLint throws an error for you `NSLocalizedString()`
   3. Remove your change and run `make swiftlint` again
      - [x] OBSERVE that SwiftLint runs cleanly
- Test `make swiftformat`
   - Make a formatting change to a source file in `Gravatar` or `GravatarUI`.  For example, find an `if/else` block, and move the brackets:
```diff
if something {
    // do something
-} else {
+}
+else {
    // do something else
}
```
   - Run `make swiftformat`
   - [x] OBSERVE that your formatting change is fixed
- Test `make swiftformat-lint`
   - Repeat the steps above, only use the command `make swiftformat-lint`
   - [x] OBSERVE that the command throws an error due to your formatting change:
```
ImageUploadService.swift:24:1: error: (elseOnSameLine) Place else, catch or while keyword in accordance with current style (same or next line).
```