### PR TITLE
Add docker check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ docker-swiftlint-builder: # Create and use the Buildx builder because the SwiftL
 	fi
 
 swiftlint-run: # Docker command to run swiftlint
-	docker run --platform linux/amd64 -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/realm/swiftlint:$(SWIFTLINT_VERSION)
+	docker run --rm --platform linux/amd64 -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/realm/swiftlint:$(SWIFTLINT_VERSION)
 
 swiftlint-version:
 	@if [ -z "$(SWIFTLINT_VERSION)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,6 @@ update-example-snapshots:
 	cd ./Sources/GravatarUI/GravatarUI.docc/Resources/ProfileExamples && \
 	for filePath in *; do name=$${filePath%.*}; mv $$filePath $${name//-dark/~dark}@2x$${filePath#$$name}; done
 
-install-and-generate: $(OPENAPI_GENERATOR_CLONE_DIR) # Clones and setup the openapi-generator.
-	"$(OPENAPI_GENERATOR_CLONE_DIR)"/run-in-docker.sh mvn package
-	make generate
-
 generate: $(OPENAPI_GENERATED_DIR) # Generates the open-api model
 	sed -i '' 's|components/schemas/Rating|components/schemas/AvatarRating|g' $(OPENAPI_DIR)/openapi.yaml
 	sed -i '' 's| Rating:| AvatarRating:|g' $(OPENAPI_DIR)/openapi.yaml

--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,8 @@ generate: check-docker $(OPENAPI_GENERATED_DIR) # Generates the open-api model
     echo "DONE! 🎉"
 
 check-docker:
-	@command -v docker >/dev/null 2>&1 || { echo "Error: Docker is not installed or not in PATH"; exit 1; }
-	@docker info >/dev/null 2>&1 || { echo "Error: Docker is installed but not running or accessible by the current user"; exit 1; }
+	@command -v docker >/dev/null 2>&1 || { echo "Error: Docker is not installed or not in PATH"; false; }
+	@docker info >/dev/null 2>&1 || { echo "Error: Docker is installed but not running or accessible by the current user"; false; }
 
 generate-strings: bundle-install
 	bundle exec fastlane generate_strings

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ docker-swiftlint-builder: # Create and use the Buildx builder because the SwiftL
 	fi
 
 swiftlint-run: # Docker command to run swiftlint
-	docker run --rm --platform linux/amd64 -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/realm/swiftlint:$(SWIFTLINT_VERSION)
+	@docker run --rm --platform linux/amd64 -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/realm/swiftlint:$(SWIFTLINT_VERSION)
 
 swiftlint-version:
 	@if [ -z "$(SWIFTLINT_VERSION)" ]; then \


### PR DESCRIPTION
Closes #

### Description

This fixes a few minor bugs with the new docker implementations of SwiftLint and SwiftFormat:
- Ensures that all `docker run` commands use the `--rm` flag, which removes the container when the run stops
- Checks for a functional docker installation before using docker, throws a descriptive error if there is a problem with the Docker installation

### Testing Steps

#### Check that all docker containers are removed when they stop
1. Ensure that Docker is running locally
2. Run `docker ps -aq | wc -l`
   - This will return the number of docker containers (running or stopped)
3. Run `make lint` multiple times
4. Run `docker ps -aq | wc -l` again
   - [ ] OBSERVE: the number of containers has not changed

#### Docker is installed but not running
1. Stop docker on your workstation
6. Run `docker info` to ensure that docker is not running
   - `ERROR: Cannot connect to the Docker daemon...`
7. Run `make lint`
   - [ ] OBSERVE: lint generates the following error:
```shell
$ make lint
Error: Docker is installed but not running or accessible by the current user
make[1]: *** [check-docker] Error 1
make: *** [lint] Error 2
```

#### Docker is not in PATH (simulating not installed)
1. Stop docker on your workstation
2.  Run `docker info` to ensure that docker is not running
   - `ERROR: Cannot connect to the Docker daemon...`
3. Find the `docker` binary and temporarily move it out of your path
```shell
# Find the path to the docker binary
$ which docker
/usr/local/bin/docker

# Rename the docker binary (may require sudo)
$ sudo mv /usr/local/bin/docker /usr/local/bin/docker-original
```

8. Run `make init`
   - [ ] OBSERVE: lint generates a different error:
```shell
$ make lint
Error: Docker is not installed or not in PATH
make[1]: *** [check-docker] Error 1
make: *** [lint] Error 2
```

9. Restore the docker binary
```shell
$ sudo mv /usr/local/bin/docker-original /usr/local/bin/docker
```