### PR TITLE
Remove unused lane that duplicated existing one

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -120,15 +120,9 @@ platform :ios do
     #
     # Which suggest the authenticated session from the first call was not carried over to the second.
     configure_code_signing(
-      bundle_ids: [
-        bundle_id_prototype_build!
-      ],
+      bundle_ids: [bundle_id_prototype_build!],
       readonly: readonly
     )
-  end
-
-  lane :configure_code_signing_prototype_build do |readonly: true|
-    configure_code_signing(bundle_ids: [bundle_id_prototype_build!], readonly: readonly)
   end
 end
 


### PR DESCRIPTION
### Description

I landed here while regenerating the Enterprise provisioning profiles after creating a new distribution certificate. Internal reference pdnsEh-1ZG-p2

I was looking at the code and noticed a lane that looked unused (no `git grep` matches`) and that had the same implementation of another one, which is instead in use in the codebase.

### Testing Steps

N.A. This only removes a duplicated lane.

Having said that, a successful prototype build will show that the code that was touched is still working.