### PR TITLE
Add one time force refresh ability for CachedAsyncImage and AvatarView

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
@@ -106,7 +106,7 @@ struct AvatarPickerProfileView: View {
                     .colorScheme(colorScheme)
                     .background(Color(UIColor.systemBackground))
             },
-            forceRefresh: $forceRefreshAvatar,
+            oneTimeForceRefresh: $forceRefreshAvatar,
             loadingView: {
                 ProgressView()
                     .progressViewStyle(CircularProgressViewStyle())

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -405,10 +405,6 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
     func notifyAvatarSelection() {
         // Trigger the inner avatar refresh
         model.forceRefreshAvatar = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            // Reset the flag with a small delay otherwise the system ignores the value change.
-            model.forceRefreshAvatar = false
-        }
         // Notify the main app
         avatarUpdatedHandler?()
     }

--- a/Sources/GravatarUI/SwiftUI/AvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 public struct AvatarView<LoadingView: View, Placeholder: View>: View {
     @ViewBuilder private let loadingView: (() -> LoadingView)?
     @Binding private var forceRefresh: Bool
+    @Binding private var oneTimeForceRefresh: Bool
     @State private var isLoading: Bool = false
     private var url: URL?
     private let placeholderView: (() -> Placeholder)?
@@ -19,6 +20,7 @@ public struct AvatarView<LoadingView: View, Placeholder: View>: View {
         cache: ImageCaching = ImageCache.shared,
         urlSession: URLSession = .shared,
         forceRefresh: Binding<Bool> = .constant(false),
+        oneTimeForceRefresh: Binding<Bool> = .constant(false),
         loadingView: (() -> LoadingView)?,
         transaction: Transaction = Transaction()
     ) where Placeholder == AnyView {
@@ -34,6 +36,7 @@ public struct AvatarView<LoadingView: View, Placeholder: View>: View {
         self.loadingView = loadingView
         self.urlSession = urlSession
         self._forceRefresh = forceRefresh
+        self._oneTimeForceRefresh = oneTimeForceRefresh
         self.transaction = transaction
     }
 
@@ -43,6 +46,7 @@ public struct AvatarView<LoadingView: View, Placeholder: View>: View {
         cache: ImageCaching = ImageCache.shared,
         urlSession: URLSession = .shared,
         forceRefresh: Binding<Bool> = .constant(false),
+        oneTimeForceRefresh: Binding<Bool> = .constant(false),
         loadingView: (() -> LoadingView)?,
         transaction: Transaction = Transaction()
     ) {
@@ -52,6 +56,7 @@ public struct AvatarView<LoadingView: View, Placeholder: View>: View {
         self.loadingView = loadingView
         self.urlSession = urlSession
         self._forceRefresh = forceRefresh
+        self._oneTimeForceRefresh = oneTimeForceRefresh
         self.transaction = transaction
     }
 
@@ -61,6 +66,7 @@ public struct AvatarView<LoadingView: View, Placeholder: View>: View {
             cache: cache,
             urlSession: urlSession,
             forceRefresh: $forceRefresh,
+            oneTimeForceRefresh: $oneTimeForceRefresh,
             transaction: transaction,
             isLoading: $isLoading
         ) { phase in


### PR DESCRIPTION
Closes Described here https://github.com/Automattic/Gravatar-SDK-iOS/pull/615#pullrequestreview-2562244320 (see "it does not refresh" part)

### Description

We need to force refresh the avatar just once when the avatar selection changes. Previously I did that by setting forceRefresh to `true` and then `false` with a little delay but sometimes the underlying system can ignore the `true` value somehow. So I added a new binding just for *one time* refreshing purpose, which is actually the real need here. This way we can set the flag back to `false` after the call is really done.

### Testing Steps

- Switch between avatars many times or delete the selected avatar
- Make sure the avatar in the QE's profile card gets updated