### PR TITLE
Adds `rating: .x` to the avatar URL in the QE's profile card and some demo screens

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
@@ -197,7 +197,7 @@ final class DemoQuickEditorViewController: UIViewController {
             token: token
         )
         presenter.present(in: self, onAvatarUpdated: { [weak self] in
-            self?.profileSummaryView.loadAvatar(with: .email(email), options: [.forceRefresh])
+            self?.profileSummaryView.loadAvatar(with: .email(email), rating: .x, options: [.forceRefresh])
         } , onDismiss: { [weak self] in
             self?.updateLogoutButton()
         })

--- a/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
@@ -122,7 +122,7 @@ struct ProfileSummary: UIViewRepresentable {
     
     func updateUIView(_ uiView: GravatarUI.ProfileSummaryView, context: Context) {
         trigger.onTrigger = {
-            uiView.loadAvatar(with: avatarID, options: [.forceRefresh])
+            uiView.loadAvatar(with: avatarID, rating: .x, options: [.forceRefresh])
         }
 
         uiView.update(with: profileModel)

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
@@ -29,6 +29,7 @@ struct AvatarPickerProfileView: View {
             with: avatarID,
             options: .init(
                 preferredSize: .points(Constants.avatarLength),
+                rating: .x,
                 defaultAvatarOption: .status404
             )
         )?.url


### PR DESCRIPTION
Closes #646

### Description

Adds `rating: .x` to the avatar URL in the QE's profile card and some demo screens. This is to successfully demonstrate avatar changes otherwise the avatar endpoint returns 404 when the rating changes to something lower than "general".

### Testing Steps

Change ratings of avatars
Select those avatars
Observe: The avatar in the QE's profile card and the demo app reflects the change properly