### PR TITLE
Fix CocoaPods Publishing Pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,6 +17,7 @@ steps:
     steps:
       - label: ":swift: SwiftLint"
         command: swiftlint
+        key: swiftlint
         notify:
           - github_commit_status:
               context: "SwiftLint"
@@ -24,6 +25,7 @@ steps:
           queue: "linter"
 
       - label: ":swift: SwiftFormat Linting"
+        key: swiftformat-lint
         plugins:
           - docker#v5.12.0:
               image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
@@ -80,7 +82,8 @@ steps:
     depends_on:
       - "test"
       - "validate"
-      - "lint"
+      - "swiftlint"
+      - "swiftformat-lint"
     if: build.tag != null
 
   ###################


### PR DESCRIPTION
Closes #

### Description

This fixes a mistake made in #634 , which removed `key: lint` from the `swiftlint` check.  This left the CocoaPods publishing step with a dependency on a step that no longer had that key, preventing it from running. 

### Testing Steps

Unfortunately, this will have to be tested the next time we add a tag to the repo.

For this PR, we will have to rely on code inspection:
- The added lines `depends_on` should exactly match the `key:` values for two linting steps
- Those two linting steps should be appropriate dependencies, whose succcess/failure we would want to depend on before publishing a CocoaPod