### PR TITLE
Simplify SwiftFormat Invocations

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,11 +29,7 @@ steps:
         plugins:
           - docker#v5.12.0:
               image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
-              command: ["--lint", "Sources"]
-              workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
-          - docker#v5.12.0:
-              image: "ghcr.io/nicklockwood/swiftformat:$SWIFTFORMAT_VERSION"
-              command: ["--lint", "Tests"]
+              command: ["Sources", "Tests", "--lint"]
               workdir: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
         notify:
           - github_commit_status:

--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,10 @@ setup-secrets: bundle-install
 	bundle exec fastlane run configure_apply
 
 swiftformat: check-docker # Automatically find and fixes lint issues
-	@docker run --rm -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/nicklockwood/swiftformat:$(SWIFTFORMAT_VERSION) Sources
-	@docker run --rm -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/nicklockwood/swiftformat:$(SWIFTFORMAT_VERSION) Tests
+	@docker run --rm -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/nicklockwood/swiftformat:$(SWIFTFORMAT_VERSION) Sources Tests
 
 swiftformat-lint: check-docker
-	@docker run --rm -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/nicklockwood/swiftformat:$(SWIFTFORMAT_VERSION) --lint Sources
-	@docker run --rm -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/nicklockwood/swiftformat:$(SWIFTFORMAT_VERSION) --lint Tests
+	@docker run --rm -v $(shell pwd):$(shell pwd) -w $(shell pwd) ghcr.io/nicklockwood/swiftformat:$(SWIFTFORMAT_VERSION) Sources Tests --lint
 
 swiftlint: docker-swiftlint-builder swiftlint-run # Sets up the buildx builder and runs the swiftlint command
 


### PR DESCRIPTION
### Description

This just consolidates the two individual invocations of SwiftFormat (one for each path we check) into a single invocation.  When I originally refactored this, I couldn't get that to work, hence the two invocations.

The key here was moving `--lint` after the list of paths:

```shell
# Works
[docker command] --lint Sources

# Fails with error about arguments
[docker command] --lint Sources Tests

# Works
[docker command] Sources Tests --lint
```

### Testing Steps

- [ ] CI should be 🟢 
- [ ] `make swiftformat-lint` should REPORT issues in `Sources/` and `Tests`
- [ ] `make swiftformat` should FIX issues in `Sources/` and `Tests/`

The following code will trigger SwiftFormat:
```swift
if {
    true
}
else {
    false
}
```

Add that code to two source files:
- Any source file in `Sources/`
- Any source file in `Tests/`

1. Run `make swiftformat-lint`
   - [ ] OBSERVE that it reports both files with errors
2. Run `make swiftformat`
   - [ ] OBSERVE that SwiftFormat fixed that code block in both source files:

```swift
if {
    true
} else {
    false
}
```