### PR TITLE
Refactor Pipeline to use Github Notify

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,6 +44,9 @@ steps:
         retry:
           manual:
             permit_on_passed: true
+        notify:
+          - github_commit_status:
+              context: "Danger - PR Check"
         agents:
           queue: linter
 
@@ -56,6 +59,9 @@ steps:
       install_swiftpm_dependencies --use-spm
       validate_swift_package
     plugins: [$CI_TOOLKIT]
+    notify:
+      - github_commit_status:
+          context: "Build and Test Swift Package"
 
   ###################
   # Validate Podspec
@@ -65,6 +71,9 @@ steps:
     command: |
       .buildkite/commands/validate-pods.sh
     plugins: [$CI_TOOLKIT]
+    notify:
+      - github_commit_status:
+          context: "Validate Podspecs"
 
   #######################
   # Publish the Podspecs (if we're building a tag)
@@ -85,7 +94,7 @@ steps:
   ###################
   # Prototype Builds of Demo Projects
   ###################
-  - group: ":appcenter: Prototype Builds"
+  - group: ":appcenter: Prototype Build"
     steps:
       - label: "🛠️ Build Demo"
         key: build_demo
@@ -98,9 +107,15 @@ steps:
         artifact_paths:
           - ".build/artifacts/*.ipa"
           - ".build/artifacts/*.dSYM.zip"
+        notify:
+          - github_commit_status:
+              context: "Build Prototype"
 
       - label: "⬆️ Upload Demo to App Center"
         depends_on: build_demo
         plugins: [$CI_TOOLKIT]
         command: .buildkite/commands/upload-to-appcenter.sh
         if: build.pull_request.id != null
+        notify:
+          - github_commit_status:
+              context: "Publish Prototype"


### PR DESCRIPTION
Closes #

### Description
We have our Buildkite pipeline configured to produce GitHub checks using the name of each step:

![image](https://github.com/user-attachments/assets/db9c131c-c194-4005-8b45-103b0cca0a32)

To make these easier to read. we can use a `notify` block in Buildkite to report GitHub checks:

![image](https://github.com/user-attachments/assets/a8be8bbd-747b-4592-8c99-16e85107b6e3)
![image](https://github.com/user-attachments/assets/997feabe-8518-4379-baf9-281253d368c3)
![image](https://github.com/user-attachments/assets/fb77b800-a9a0-4a0a-a693-6b7f34a298aa)

Here's the process we would follow:
1. Merge this PR to `trunk` (each pipeline step will appear twice, once with the auto-generated check name and once with our custom check)
2. Update the "Required" checks to use the new check names
3. Coordinate with @Automattic/apps-infrastructure to update our pipeline configuration to stop sending automated check

### Testing Steps

- [ ] CI should be 🟢 
- [ ] All pipeline steps that we are interested in appear with the new format
   - [ ] Build and Test Swift Package
   - [ ] SwiftLint
   - [ ] SwiftFormat Lint
   - [ ] Validate Podspec
   - [ ] Build Prototype
   - [ ] Publish Prototype
   - [ ] Danger - PR Check