### PR TITLE
Set the ASWebAuthenticationSession to prefer an ephemeral authorization session

### DIFF
--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OldAuthenticationSession.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OldAuthenticationSession.swift
@@ -32,6 +32,7 @@ final class OldAuthenticationSession: NSObject, Sendable {
             Task { @MainActor in
                 await sessionStorage.save(session)
                 session.presentationContextProvider = self
+                session.prefersEphemeralWebBrowserSession = true
                 session.start()
             }
         }


### PR DESCRIPTION
Closes #[682](https://github.com/Automattic/Gravatar-SDK-iOS/issues/682)

### Description

This change sets the ASWebAuthenticationSession to prefer an ephemeral authorization session. This prevents the WebView from retaining the user's information if they sign out, their session token is deleted, and a new user signs in to the application.

### Testing Steps
1. In the demo app, tap Quick Editor
2. Enter an email in the text field
3. Tap Show Quick Editor
4. Go through the authentication process
5. Tap Logout
6. Enter a different email in the text field
7. Tap Show Quick Editor
8. The correct email should now display in the WebView

https://github.com/user-attachments/assets/061fc686-2e5f-42b0-9165-84b22f0195e9

