### PR TITLE
Profile cards SwiftUI wrapper - small demo views changes

### DIFF
--- a/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
@@ -11,14 +11,8 @@ struct DemoProfileEditorView: View {
     @State private var selectedScheme: UIUserInterfaceStyle = .unspecified
     @Environment(\.oauthSession) var oauthSession
 
-    @State private var profileConfiguration: ProfileViewConfiguration = Self.initialConfiguration()
+    @State private var profileConfiguration: ProfileViewConfiguration = .summary()
     @State private var oneTimeAvatarForceRefresh: Bool = false
-
-    private static func initialConfiguration() -> ProfileViewConfiguration {
-        var config: ProfileViewConfiguration = .summary()
-        config.padding = .init(top: 8, left: 0, bottom: 8, right: 0)
-        return config
-    }
 
     var body: some View {
         VStack(spacing: 20) {
@@ -28,7 +22,8 @@ struct DemoProfileEditorView: View {
                     .textInputAutocapitalization(.never)
                     .keyboardType(.emailAddress)
                     .disableAutocorrection(true)
-                Divider()
+                    .textFieldStyle(.roundedBorder)
+
                 ProfileViewRepresentable(configuration: $profileConfiguration, oneTimeAvatarForceRefresh: $oneTimeAvatarForceRefresh)
                 if #available(iOS 16.0, *) {
                     QEContentLayoutPickerRow(contentLayoutOptions: $contentLayoutOptions)
@@ -81,6 +76,7 @@ struct DemoProfileEditorView: View {
 
             Spacer()
         }
+        .background(Color(UIColor.systemGroupedBackground))
         .onAppear() {
             updateHasSession(with: email)
             requestProfile()

--- a/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileView.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileView.swift
@@ -18,7 +18,7 @@ struct DemoProfileView: View {
                     .textInputAutocapitalization(.never)
                     .keyboardType(.emailAddress)
                     .disableAutocorrection(true)
-                Divider()
+                    .textFieldStyle(.roundedBorder)
                 ProfileViewRepresentable(
                     configuration: $profileConfiguration,
                     oneTimeAvatarForceRefresh: .constant(false)
@@ -66,7 +66,7 @@ struct DemoProfileView: View {
             self.profileConfiguration.delegate = self.profileDelegate
             requestProfile()
         }
-        .background(Color(UIColor.systemBackground))
+        .background(Color(UIColor.systemGroupedBackground))
         .sheet(item: $safariURL) { identifiableURL in
             SafariView(url: identifiableURL.url)
                 .edgesIgnoringSafeArea(.all)
@@ -139,10 +139,8 @@ fileprivate class ProfileDelegate: NSObject, ObservableObject, ProfileViewDelega
 }
 
 fileprivate extension ProfileViewConfiguration {
-    
     func customize(delegate: ProfileViewDelegate?) -> ProfileViewConfiguration {
         var config = self
-        config.padding = .zero
         config.avatarConfiguration.activityIndicatorType = .activity
         config.delegate = delegate
         return config


### PR DESCRIPTION
### Description

Small changes over https://github.com/Automattic/Gravatar-SDK-iOS/pull/678

The idea is to use the default padding, and making the Profile Card bounds visible by changing the screen background color.

<img src="https://github.com/user-attachments/assets/421cdaff-ba14-4c09-931f-e5a30698e555" width="40%">
<img src="https://github.com/user-attachments/assets/0d587475-1132-4966-b34e-f4c67d49a334" width="40%">

