### PR TITLE
QE: Add the new authorized profile endpoint to fetch the profile

### DIFF
--- a/Sources/Gravatar/Network/Services/ProfileService.swift
+++ b/Sources/Gravatar/Network/Services/ProfileService.swift
@@ -2,6 +2,7 @@ import Foundation
 
 private let baseURL = URL(string: "https://api.gravatar.com/v3/profiles/")!
 private let avatarsBaseURLComponents = URLComponents(string: "https://api.gravatar.com/v3/me/avatars")!
+private let meProfileURL = URL(string: "https://api.gravatar.com/v3/me/profile")!
 
 private func selectAvatarBaseURL(with avatarID: String) -> URL? {
     URL(string: "https://api.gravatar.com/v3/me/avatars/\(avatarID)/email")
@@ -28,6 +29,13 @@ public struct ProfileService: ProfileFetching, Sendable {
     public func fetch(with profileID: ProfileIdentifier) async throws -> Profile {
         let url = baseURL.appending(pathComponent: profileID.id)
         let request = await URLRequest(url: url).authorized()
+        return try await fetch(with: request)
+    }
+
+    /// Fetches profile information for the authenticated user. Profile is created if it doesn't exist yet.
+    package func fetchOwnProfile(with token: String) async throws -> Profile {
+        var request = URLRequest(url: meProfileURL).settingAuthorizationHeaderField(with: token)
+        request.httpMethod = "GET"
         return try await fetch(with: request)
     }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -39,7 +39,6 @@ class AvatarPickerViewModel: ObservableObject {
     @Published var shouldDisplayNoSelectedAvatarWarning: Bool = false
     @ObservedObject var toastManager: ToastManager = .init()
     private var cancellables = Set<AnyCancellable>()
-    private(set) var compensatingFetchProfileTask: Task<Void, Never>? // for unit testing
 
     init(
         email: Email,
@@ -110,36 +109,6 @@ class AvatarPickerViewModel: ObservableObject {
                 selectedAvatarURL == nil && loadedAvatarCount > 0
             }
             .assign(to: \.shouldDisplayNoSelectedAvatarWarning, on: self)
-            .store(in: &cancellables)
-
-        $profileResult
-            .combineLatest($gridResponseStatus)
-            .map { profileResult, gridResponseStatus in
-                let isProfileStatus404 = switch profileResult {
-                case .failure(APIError.responseError(let .invalidHTTPStatusCode(response, _))) where response.statusCode == HTTPStatus.notFound.rawValue:
-                    true
-                default:
-                    false
-                }
-
-                let isGridResponseSuccess = switch gridResponseStatus {
-                case .success:
-                    true
-                default:
-                    false
-                }
-                return isProfileStatus404 && isGridResponseSuccess
-            }
-            .filter { $0 == true }
-            .removeDuplicates()
-            .sink { [weak self] _ in
-                self?.compensatingFetchProfileTask = Task {
-                    // Profile does not exist but `/v3/me/avatars` is success. This means it's a new account. Backend creates a new
-                    // profile during the first GET `/v3/me/avatars` of a new user. So we refresh the profile to fetch it.
-                    // Happens only when the token is passed externally.
-                    await self?.fetchProfile()
-                }
-            }
             .store(in: &cancellables)
 
         $profileResult.sink { [weak self] profileResult in

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -244,9 +244,10 @@ class AvatarPickerViewModel: ObservableObject {
     }
 
     func fetchProfile() async {
+        guard let authToken else { return }
         do {
             isProfileLoading = true
-            let profile = try await profileService.fetch(with: .email(email))
+            let profile = try await profileService.fetchOwnProfile(with: authToken)
             profileResult = .success(profile)
             isProfileLoading = false
         } catch {

--- a/Tests/GravatarUITests/AvatarPickerViewModelTests.swift
+++ b/Tests/GravatarUITests/AvatarPickerViewModelTests.swift
@@ -381,28 +381,11 @@ final class AvatarPickerViewModelTests {
         #expect(updatedAvatar.altText == newAltText)
     }
 
-    @Test
-    func testNewAccountProfileRefresh() async throws {
-        let session = URLSessionAvatarPickerMockNewAccount()
-        model = Self.createModel(session: session)
-        await model.refresh()
-        let task = try #require(model.compensatingFetchProfileTask, "No profile task found")
-        // `await confirmation { ... }` doesn't await the unstructured `Task` so we need to await it.
-        // For context: https://forums.swift.org/t/testing-closure-based-asynchronous-apis/73705/9
-        await task.value
-        let isProfileFetched = switch model.profileResult {
-        case .success:
-            true
-        default:
-            false
-        }
-        #expect(isProfileFetched)
-    }
-
     @Test(
         "Handle avatar alt text change: Failure",
         arguments: [HTTPStatus.unauthorized, .forbidden]
     )
+
     func testUpdateAltTextError(httpStatus: HTTPStatus) async throws {
         model = Self.createModel(session: URLSessionAvatarPickerMock(returnErrorCode: httpStatus.rawValue))
         await model.refresh()
@@ -557,30 +540,4 @@ extension Data? {
         guard let self else { return false }
         return (try? decoder.decode(T.self, from: self)) != nil
     }
-}
-
-// Simulates profile creation at the BE side on the very first avatar request.
-actor URLSessionAvatarPickerMockNewAccount: URLSessionProtocol {
-    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        if request.isProfilesRequest {
-            if profileRequestCount == 0 {
-                profileRequestCount += 1
-                // profile is missing on the first call
-                return ("{\"error\":\"error\"".data(using: .utf8)!, HTTPURLResponse.errorResponse(code: 404))
-            } else {
-                return (Bundle.fullProfileJsonData, HTTPURLResponse.successResponse()) // Profile data
-            }
-        } else if request.isAvatarsRequest == true {
-            return (Bundle.getAvatarsJsonData, HTTPURLResponse.successResponse()) // Avatars data
-        }
-        throw TestURLSessionError(message: "Unexpected request")
-    }
-
-    func upload(for request: URLRequest, from bodyData: Data) async throws -> (Data, URLResponse) {
-        (Bundle.postAvatarUploadJsonData, HTTPURLResponse.successResponse())
-    }
-
-    private var profileRequestCount: Int = 0
-
-    init() {}
 }

--- a/Tests/GravatarUITests/AvatarPickerViewModelTests.swift
+++ b/Tests/GravatarUITests/AvatarPickerViewModelTests.swift
@@ -478,7 +478,7 @@ final class URLSessionAvatarPickerMock: URLSessionProtocol {
 
 extension URLRequest {
     private enum RequestType: String {
-        case profiles
+        case profiles = "/me/profile"
         case avatars
     }
 


### PR DESCRIPTION
Closes #672 

### Description

With this new endpoint, when a new user in the Jetpack apps opens QE for the first time, the profile card will be properly loaded because the identity will be created. So I am also reverting [this change](https://github.com/Automattic/Gravatar-SDK-iOS/pull/615).

### Testing Steps

Same test steps with https://github.com/Automattic/Gravatar-SDK-iOS/pull/615
Note: [www.emailondeck.com](http://www.emailondeck.com/) doesn't work anymore but you can create a new email by adding `+` at your Gmail address before `@` like `myexistingaccount+@gmail.com`.