### PR TITLE
Propagate color scheme to QE sheet

### DIFF
--- a/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
@@ -49,7 +49,7 @@ struct DemoProfileEditorView: View {
                                 onDismiss: {
                                     updateHasSession(with: email)
                                 }
-                        )
+                            ).environment(\.colorScheme, ColorScheme(selectedScheme) ?? .light)
                     }
                     else {
                         view
@@ -64,6 +64,7 @@ struct DemoProfileEditorView: View {
                                     updateHasSession(with: email)
                                 }
                             )
+                            .environment(\.colorScheme, ColorScheme(selectedScheme) ?? .light)
                     }
                 }
 
@@ -85,7 +86,7 @@ struct DemoProfileEditorView: View {
             updateHasSession(with: newValue)
             requestProfile()
         }
-        .environment(\.colorScheme, ColorScheme(selectedScheme) ?? .light)
+        
     }
 
     func requestProfile() {

--- a/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
@@ -8,7 +8,7 @@ struct DemoProfileEditorView: View {
     // You can make this `true` by default to easily test the picker
     @State private var isPresentingPicker: Bool = false
     @State private var hasSession: Bool = false
-    @State private var selectedScheme: UIUserInterfaceStyle = .unspecified
+    @AppStorage("demoColorScheme") private var selectedScheme: UIUserInterfaceStyle = .unspecified
     @Environment(\.oauthSession) var oauthSession
 
     @State private var profileConfiguration: ProfileViewConfiguration = .summary()
@@ -85,7 +85,7 @@ struct DemoProfileEditorView: View {
             updateHasSession(with: newValue)
             requestProfile()
         }
-        .preferredColorScheme(ColorScheme(selectedScheme))
+        .environment(\.colorScheme, ColorScheme(selectedScheme) ?? .light)
     }
 
     func requestProfile() {

--- a/Demo/Demo/Gravatar-Demo/SwiftUI/QEColorSchemePickerRow.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/QEColorSchemePickerRow.swift
@@ -10,6 +10,17 @@ struct QEColorSchemePickerRow: View {
         case dark
         case system
         
+        init(_ userInterfaceStyle: UIUserInterfaceStyle) {
+            switch userInterfaceStyle {
+            case .light:
+                self = .light
+            case .dark:
+                self = .dark
+            default:
+                self = .system
+            }
+        }
+
         var colorScheme: UIUserInterfaceStyle {
             switch self {
             case .light:
@@ -35,6 +46,9 @@ struct QEColorSchemePickerRow: View {
                 }
             }
             .pickerStyle(MenuPickerStyle())
+            .onAppear() {
+                self.options = Options(self.selectedScheme)
+            }
             .onChange(of: options) { newValue in
                 self.selectedScheme = newValue.colorScheme
             }

--- a/Sources/GravatarUI/SwiftUI/AvatarPickerModalPresentationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPickerModalPresentationModifier.swift
@@ -22,6 +22,7 @@ struct AvatarPickerModalPresentationModifier<ModalView: View>: ViewModifier, Mod
     @State private(set) var verticalSizeClass: UserInterfaceSizeClass?
     @State private var presentationDetents: Set<PresentationDetent>
     @State private var prioritizeScrollOverResize: Bool = false
+    @Environment(\.colorScheme) var colorScheme: ColorScheme
     let onDismiss: (() -> Void)?
     let modalView: ModalView
     var contentLayoutWithPresentation: AvatarPickerContentLayout
@@ -60,6 +61,7 @@ struct AvatarPickerModalPresentationModifier<ModalView: View>: ViewModifier, Mod
             }
             .sheet(isPresented: $isPresentedInner, onDismiss: onDismiss) {
                 modalView
+                    .preferredColorScheme(colorScheme)
                     .frame(minHeight: Constants.bottomSheetMinHeight)
                     .onPreferenceChange(InnerHeightPreferenceKey.self) { newHeight in
                         Task { @MainActor in

--- a/Sources/GravatarUI/SwiftUI/ModalPresentationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/ModalPresentationModifier.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ModalPresentationModifier<ModalView: View>: ViewModifier {
     @Binding var isPresented: Bool
+    @Environment(\.colorScheme) var colorScheme: ColorScheme
     let onDismiss: (() -> Void)?
     let modalView: ModalView
 
@@ -15,6 +16,7 @@ struct ModalPresentationModifier<ModalView: View>: ViewModifier {
         content
             .sheet(isPresented: $isPresented, onDismiss: onDismiss) {
                 modalView
+                    .preferredColorScheme(colorScheme)
             }
     }
 }


### PR DESCRIPTION
Closes #692

### Description

Seems like the preferredColorScheme doesn't propagate into the sheet. So we need to apply it to the View **inside** the sheet. We also need to pass it using `.environment(\.colorScheme, ...)` instead.

### Testing Steps

Follow the steps in #692