### PR TITLE
Adding QE profile card accessibility label and hint

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -465,6 +465,22 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
         .padding(.top, AvatarPicker.Constants.profileViewTopSpacing / 2)
         .padding(.bottom, AvatarPicker.Constants.vStackVerticalSpacing)
         .padding(.horizontal, AvatarPicker.Constants.horizontalPadding)
+        .accessibilityRepresentation {
+            if let profileModel = model.profileModel {
+                Button("", action: {  })
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(
+                        profileModel.displayName
+                        + (profileModel.location.isEmpty ? "" : ". \(profileModel.location)")
+                    )
+                    .accessibilityHint(Localized.Accessibility.profileCardHint)
+                    .accessibilityAction {
+                        openProfileInSafari()
+                    }
+            } else {
+                EmptyView()
+            }
+        }
     }
 }
 
@@ -599,6 +615,14 @@ enum AvatarPicker {
                     )
                 }
             }
+        }
+
+        enum Accessibility {
+            static let profileCardHint = SDKLocalizedString(
+                "AvatarPicker.Accessibility.Hint",
+                value: "Double tap to open the full profile on a web view",
+                comment: "Accessibility label spoken outloud by VoiceOver when the profile card is selected"
+            )
         }
     }
 }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -467,11 +467,11 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
         .padding(.horizontal, AvatarPicker.Constants.horizontalPadding)
         .accessibilityRepresentation {
             if let profileModel = model.profileModel {
-                Button("", action: {  })
+                Button("", action: {})
                     .accessibilityElement(children: .ignore)
                     .accessibilityLabel(
                         profileModel.displayName
-                        + (profileModel.location.isEmpty ? "" : ". \(profileModel.location)")
+                            + (profileModel.location.isEmpty ? "" : ". \(profileModel.location)")
                     )
                     .accessibilityHint(Localized.Accessibility.profileCardHint)
                     .accessibilityAction {


### PR DESCRIPTION
Closes #675 

### Description

This PR adds accessibility grouping and labeling to the profile card in the quick editor.

Voice Over will recognize the profile card as one button element, reading the user name, location, and hinting its action of opening the profile in a web view.

<img src="https://github.com/user-attachments/assets/6005d8b0-4f87-4be8-a1a6-099b22486379" width="40%">

### Testing Steps

- Run the demo app
- Display the Quick Editor
- Enable Voice Over
- Navigate to the avatar card.
- Check that:
  - Voice Over reads user name and location.
  - Voice Over identify the element as a button.
  - Voice Over Hints the button action.
  - Double tapping on the card will open the profile in a web view.
