### PR TITLE
QE: Add new public method to enable ephemeral web browser session

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
@@ -77,6 +77,13 @@ final class DemoQuickEditorViewController: UIViewController {
         return view
     }()
 
+    private lazy var prefersEphemeralSessionToggle: SwitchWithLabel = {
+        let view = SwitchWithLabel(labelText: "Prefers ephemeral browser session")
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.switchView.addTarget(self, action: #selector(togglePrefersEphemeralSession), for: .valueChanged)
+        return view
+    }()
+
     lazy var layoutButton: UIButton = {
         let button = UIButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -170,6 +177,7 @@ final class DemoQuickEditorViewController: UIViewController {
             colorSchemeLabel,
             schemeToggle,
             imageEditorToggle,
+            prefersEphemeralSessionToggle,
             layoutButton,
             logoutButton,
             showButton
@@ -227,6 +235,12 @@ final class DemoQuickEditorViewController: UIViewController {
                 self?.updateLogoutButton()
             }
         )
+    }
+    
+    @objc func togglePrefersEphemeralSession() {
+        Task {
+            await OAuthSession.setPrefersEphemeralWebBrowserSession(prefersEphemeralSessionToggle.isOn)
+        }
     }
 }
 

--- a/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
@@ -16,6 +16,7 @@ struct DemoProfileEditorView: View {
     @State private var oneTimeAvatarForceRefresh: Bool = false
     @State private var isSecure: Bool = true
     @State var enableCustomImageCropper: Bool = false
+    @State var prefersEphemeralWebBrowserSession: Bool = false
 
     var body: some View {
         VStack(spacing: 20) {
@@ -51,6 +52,8 @@ struct DemoProfileEditorView: View {
                 
                 Divider()
                 Toggle("Custom image cropper", isOn: $enableCustomImageCropper)
+                Divider()
+                Toggle("Prefers ephemeral browser session", isOn: $prefersEphemeralWebBrowserSession)
             }
             .padding(.horizontal)
                 Button("Open Profile Editor with OAuth flow") {
@@ -110,7 +113,11 @@ struct DemoProfileEditorView: View {
             updateHasSession(with: newValue)
             requestProfile()
         }
-        
+        .onChange(of: prefersEphemeralWebBrowserSession) { newValue in
+            Task {
+                await oauthSession.setPrefersEphemeralWebBrowserSession(prefersEphemeralWebBrowserSession)
+            }
+        }
     }
 
     func requestProfile() {

--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
@@ -2,7 +2,7 @@ import AuthenticationServices
 
 public struct OAuthSession: Sendable {
     static let shared = OAuthSession()
-    private var emailStorage = SessionEmailStorage()
+    private var sessionData = SessionData()
 
     private let storage: SecureStorage
     private let authenticationSession: AuthenticationSession
@@ -15,6 +15,24 @@ public struct OAuthSession: Sendable {
     init(authenticationSession: AuthenticationSession = OldAuthenticationSession(), storage: SecureStorage = Keychain()) {
         self.authenticationSession = authenticationSession
         self.storage = storage
+    }
+
+    /// Returns whether the user session remains active in the browser.
+    public static func getPrefersEphemeralWebBrowserSession() async -> Bool {
+        await shared.sessionData.getPrefersEphemeralWebBrowserSession()
+    }
+
+    /// Determines whether the user session remains active in the browser.
+    ///
+    /// When set to `true`, the user is required to enter their credentials from scratch during every OAuth flow.
+    /// Given that Gravatar access tokens expire after 2 weeks, this effectively means logging in every 2 weeks.
+    ///
+    /// When set to `false`, the user is still redirected through the OAuth flow every 2 weeks, but their session remains
+    /// active in the browser. As a result, they only need to authorize the app by tapping “Approve” without re-entering credentials.
+    ///
+    /// See also:  https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/prefersephemeralwebbrowsersession
+    public static func setPrefersEphemeralWebBrowserSession(_ value: Bool) async {
+        await shared.sessionData.setPrefersEphemeralWebBrowserSession(value)
     }
 
     public func hasSession(with email: Email) -> Bool {
@@ -61,10 +79,14 @@ public struct OAuthSession: Sendable {
             throw OAuthError.notConfigured
         }
 
-        await emailStorage.save(email)
+        await sessionData.save(email)
         do {
             let url = try oauthURL(with: email, secrets: secrets)
-            let callbackURL = try await authenticationSession.authenticate(using: url, callbackURLComponents: components)
+            let callbackURL = try await authenticationSession.authenticate(
+                using: url,
+                prefersEphemeralWebBrowserSession: sessionData.getPrefersEphemeralWebBrowserSession(),
+                callbackURLComponents: components
+            )
             _ = await Self.handleCallback(callbackURL)
         } catch {
             throw OAuthError.from(error: error)
@@ -74,7 +96,7 @@ public struct OAuthSession: Sendable {
     // Internal for tests purposes. This allows to inject a custom `shared` instance and a service double.
     // The public version will call this function directly.
     static func handleCallback(_ callbackURL: URL, shared: OAuthSession, checkTokenAuthorizationService: CheckTokenAuthorizationService) async -> Bool {
-        guard let email = await shared.emailStorage.restore() else { return false }
+        guard let email = await shared.sessionData.restore() else { return false }
 
         do {
             let tokenText = try shared.tokenResponse(from: callbackURL).token
@@ -247,15 +269,24 @@ extension [URLQueryItem] {
 }
 
 protocol AuthenticationSession: Sendable {
-    func authenticate(using url: URL, callbackURLComponents: URLComponents) async throws -> URL
+    func authenticate(using url: URL, prefersEphemeralWebBrowserSession: Bool, callbackURLComponents: URLComponents) async throws -> URL
     func cancel() async
 }
 
 extension OldAuthenticationSession: AuthenticationSession {}
 
 // Stores the email used for the current OAuth flow
-private actor SessionEmailStorage {
-    var current: Email?
+private actor SessionData {
+    private var current: Email?
+    private var prefersEphemeralWebBrowserSessionStorage: Bool = false
+
+    func getPrefersEphemeralWebBrowserSession() -> Bool {
+        prefersEphemeralWebBrowserSessionStorage
+    }
+
+    func setPrefersEphemeralWebBrowserSession(_ value: Bool) {
+        prefersEphemeralWebBrowserSessionStorage = value
+    }
 
     func save(_ email: Email) {
         current = email

--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OAuthSession.swift
@@ -18,8 +18,26 @@ public struct OAuthSession: Sendable {
     }
 
     /// Returns whether the user session remains active in the browser.
+    public func getPrefersEphemeralWebBrowserSession() async -> Bool {
+        await Self.shared.sessionData.getPrefersEphemeralWebBrowserSession()
+    }
+
+    /// Returns whether the user session remains active in the browser.
     public static func getPrefersEphemeralWebBrowserSession() async -> Bool {
-        await shared.sessionData.getPrefersEphemeralWebBrowserSession()
+        await shared.getPrefersEphemeralWebBrowserSession()
+    }
+
+    /// Determines whether the user session remains active in the browser.
+    ///
+    /// When set to `true`, the user is required to enter their credentials from scratch during every OAuth flow.
+    /// Given that Gravatar access tokens expire after 2 weeks, this effectively means logging in every 2 weeks.
+    ///
+    /// When set to `false`, the user is still redirected through the OAuth flow every 2 weeks, but their session remains
+    /// active in the browser. As a result, they only need to authorize the app by tapping “Approve” without re-entering credentials.
+    ///
+    /// See also:  https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/prefersephemeralwebbrowsersession
+    public func setPrefersEphemeralWebBrowserSession(_ value: Bool) async {
+        await Self.shared.sessionData.setPrefersEphemeralWebBrowserSession(value)
     }
 
     /// Determines whether the user session remains active in the browser.
@@ -32,7 +50,7 @@ public struct OAuthSession: Sendable {
     ///
     /// See also:  https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/prefersephemeralwebbrowsersession
     public static func setPrefersEphemeralWebBrowserSession(_ value: Bool) async {
-        await shared.sessionData.setPrefersEphemeralWebBrowserSession(value)
+        await shared.setPrefersEphemeralWebBrowserSession(value)
     }
 
     public func hasSession(with email: Email) -> Bool {

--- a/Sources/GravatarUI/SwiftUI/OAuthSession/OldAuthenticationSession.swift
+++ b/Sources/GravatarUI/SwiftUI/OAuthSession/OldAuthenticationSession.swift
@@ -9,7 +9,7 @@ extension OldAuthenticationSession: ASWebAuthenticationPresentationContextProvid
 final class OldAuthenticationSession: NSObject, Sendable {
     private let sessionStorage = SessionStorage()
 
-    func authenticate(using url: URL, callbackURLComponents: URLComponents) async throws -> URL {
+    func authenticate(using url: URL, prefersEphemeralWebBrowserSession: Bool, callbackURLComponents: URLComponents) async throws -> URL {
         try await withCheckedThrowingContinuation { continuation in
             let session: ASWebAuthenticationSession
             let completionHandler = authSessionCompletionHandler(with: continuation)
@@ -32,6 +32,7 @@ final class OldAuthenticationSession: NSObject, Sendable {
             Task { @MainActor in
                 await sessionStorage.save(session)
                 session.presentationContextProvider = self
+                session.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
                 session.start()
             }
         }

--- a/Tests/GravatarUITests/OAuthSessionTests.swift
+++ b/Tests/GravatarUITests/OAuthSessionTests.swift
@@ -132,7 +132,7 @@ private class AuthenticationSessionMock: AuthenticationSession, @unchecked Senda
         self.authenticateCalledExpectation = authenticateCalledExpectation
     }
 
-    func authenticate(using url: URL, callbackURLComponents: URLComponents) async throws -> URL {
+    func authenticate(using url: URL, prefersEphemeralWebBrowserSession: Bool, callbackURLComponents: URLComponents) async throws -> URL {
         authenticateCalledExpectation.fulfill()
         guard let _ = try await task?.value else {
             fatalError()


### PR DESCRIPTION
Closes #682

### Description

Allows enabling ephemeral web browser session for QE OAuth flow. 

### Testing Steps

Test both SwiftUI and UIKit demo screens for QuickEditor
Use the new toggle to enable/disable ephemeral web browser session
Go through OAuth flow
When enabled, your session is not kept so you need to go through login from scratch
When disabled, you just need to go through the authorization step and click "Approve"
