### PR TITLE
Improve Voice Over on the avatar image.

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/AvatarPickerAvatarView.swift
@@ -64,17 +64,20 @@ struct AvatarPickerAvatarView: View {
             .onTapGesture {
                 onAvatarTap(avatar)
             }
-            .accessibilityRepresentation {
-                Button("", action: { onAvatarTap(avatar) })
-                    .accessibilityLabel(Text(avatar.accessibilityLabel(altText: avatar.altText)))
-                    .accessibilityHint(shouldSelect() ? "" : .accessibilityAvatarHint)
-                    .accessibilityAddTraits(shouldSelect() ? .isSelected : [])
-            }
             switch avatar.state {
             case .loaded:
                 actionsMenu()
             default:
                 EmptyView()
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAddTraits(shouldSelect() ? .isSelected : [])
+        .accessibilityLabel(Text(avatar.accessibilityLabel(altText: avatar.altText)))
+        .accessibilityAction(named: shouldSelect() ? "" : .accessibilityAvatarHint) {
+            if !shouldSelect() {
+                onAvatarTap(avatar)
             }
         }
     }
@@ -187,7 +190,7 @@ extension AvatarRating {
 extension String {
     fileprivate static let accessibilityAvatarHint = SDKLocalizedString(
         "Avatar.Accessibility.AvatarButton.Hint",
-        value: "Double tap to select avatar",
+        value: "Select this avatar",
         comment: "Hint spoken outloud by VoiceOver when an avatar is selected"
     )
     fileprivate static let accessibilityAvatarOptionsLabel = SDKLocalizedString(


### PR DESCRIPTION
Closes #700

### Description

- Allow reading of image description.
- Include the avatar options menu in the accessibility avatar element.

By sweeping up and down, the user can choose the action to be executed by double tap to be either selecting the avatar, or opening the options menu.

The image description comes at the very end of Voice Over reading.

https://github.com/user-attachments/assets/518a9adb-a247-4c71-9d01-2421b904d82a


### Testing Steps

- Run the demo app
- Display the Quick Editor
- Enable Voice Over
- Navigate around the avatars grid.
- Check that:
  - Selecting an avatar with screen reader will read the alt text.
  - Voice Over will mention "Actions Available"
  - "Select this avatar" action will be read only on non-selected avatar (this text can probably be improved)
  - The last part of the Voice Over description of the element, will be a description of the image.
