### PR TITLE
Add accessibility label to avatar & Generate strings

### DIFF
--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -10,6 +10,15 @@
 /* The title of Alt Text editor screen. */
 "AltText.Editor.title" = "Alt Text";
 
+/* Hint spoken outloud by VoiceOver when an avatar is selected */
+"Avatar.Accessibility.AvatarButton.Hint" = "Select this avatar";
+
+/* Accessibility label spoken outloud by VoiceOver when an avatar is selected. The '%@' is the Alt text of the avatar image. */
+"Avatar.Accessibility.AvatarButton.Label" = "Avatar Image. %@";
+
+/* Accessibility label spoken outloud by VoiceOver when the avatar options button is selected */
+"Avatar.Accessibility.AvatarButton.OptionsLabel" = "Avatar options";
+
 /* Rating that indicates that the avatar is suitable for everyone */
 "Avatar.Rating.G.subtitle" = "General";
 
@@ -117,6 +126,9 @@
 
 /* Placeholder text for the name field */
 "AvatarPickerProfile.Name.placeholder" = "Your Name";
+
+/* VoiceOver readout for the avatar image in the profile card. */
+"AvatarPickerProfile.ProfileFields.avatarAccessibilityLabel" = "Your avatar";
 
 /* Placeholder text for the profile card. Will show as subtitle bellow the name placeholder. */
 "AvatarPickerProfile.ProfileFields.placeholder" = "Location";

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
@@ -113,6 +113,7 @@ struct AvatarPickerProfileView: View {
         .background(placeholderColorManager.placeholderColor)
         .aspectRatio(1, contentMode: .fill)
         .shape(Circle())
+        .accessibilityLabel(Localized.avatarAccessibilityLabel)
     }
 
     private var paletteType: PaletteType? {
@@ -145,6 +146,11 @@ extension AvatarPickerProfileView {
             "AvatarPickerProfile.ProfileFields.placeholder",
             value: "Location",
             comment: "Placeholder text for the profile card. Will show as subtitle bellow the name placeholder."
+        )
+        static let avatarAccessibilityLabel = SDKLocalizedString(
+            "AvatarPickerProfile.ProfileFields.avatarAccessibilityLabel",
+            value: "Your avatar",
+            comment: "VoiceOver readout for the avatar image in the profile card."
         )
     }
 }


### PR DESCRIPTION
Closes #

### Description

Add accessibility label to avatar and generate strings.

### Testing Steps

VoiceOver on
Open QE 
Tap on the avatar in the profile card
It should readout "Your avatar"