### PR TITLE
Centralize detent calculation in `QEDetents.detent(...)` again

### DIFF
--- a/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
@@ -7,7 +7,7 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
     private typealias CustomImageEditorProvider = ImageEditorBlock<CustomImageEditorControllerRepresentable>?
 
     let email: Email
-    let scope: QuickEditorScopeOption
+    let scopeOption: QuickEditorScopeOption
     let token: String?
     let configuration: QuickEditorConfiguration
     let updateHandler: ((QuickEditorUpdateType) -> Void)?
@@ -25,14 +25,6 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
 
     var verticalSizeClass: UserInterfaceSizeClass?
     var sheetHeight: CGFloat = QEModalPresentationConstants.bottomSheetEstimatedHeight
-    var contentLayoutWithPresentation: AvatarPickerContentLayout {
-        switch scope.scope {
-        case .avatarPicker:
-            scope.avatarPickerConfig.contentLayout
-        case .aboutInfoEditor:
-            .vertical(presentationStyle: scope.aboutEditorConfig.presentationStyle)
-        }
-    }
 
     private lazy var rootView: QuickEditor = {
         let provider: CustomImageEditorProvider = if let customProvider = configuration.customImageEditorProvider {
@@ -49,7 +41,7 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
 
         return QuickEditor(
             email: email,
-            scope: scope,
+            scopeOption: scopeOption,
             token: token,
             isPresented: isPresented,
             customImageEditor: provider,
@@ -75,14 +67,14 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
 
     init(
         email: Email,
-        scope: QuickEditorScopeOption,
+        scopeOption: QuickEditorScopeOption,
         configuration: QuickEditorConfiguration? = nil,
         token: String? = nil,
         onUpdate: ((QuickEditorUpdateType) -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) {
         self.email = email
-        self.scope = scope
+        self.scopeOption = scopeOption
         self.configuration = configuration ?? .default
         self.token = token
         self.onDismiss = onDismiss
@@ -123,12 +115,12 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
         if let sheet = sheetPresentationController {
             sheet.animateChanges {
                 sheet.detents = QEDetent.detents(
-                    for: contentLayoutWithPresentation,
+                    for: scopeOption,
                     intrinsicHeight: sheetHeight,
                     verticalSizeClass: verticalSizeClass
                 ).map()
             }
-            sheet.prefersScrollingExpandsWhenScrolledToEdge = !contentLayoutWithPresentation.prioritizeScrollOverResize
+            sheet.prefersScrollingExpandsWhenScrolledToEdge = !shouldPrioritizeScrollOverResize
         }
     }
 }
@@ -176,7 +168,7 @@ private class InnerHeightUIHostingController: UIHostingController<AnyView> {
 /// A struct responsible for presenting the Quick Editor from a UIKit context.
 public struct QuickEditorPresenter {
     let email: Email
-    let scope: QuickEditorScopeOption
+    let scopeOption: QuickEditorScopeOption
     let configuration: QuickEditorConfiguration
     let token: String?
 
@@ -196,9 +188,9 @@ public struct QuickEditorPresenter {
     ) {
         self.email = email
         if case .avatarPicker(let config) = scope {
-            self.scope = .avatarPicker(.init(contentLayout: config.contentLayout))
+            self.scopeOption = .avatarPicker(.init(contentLayout: config.contentLayout))
         } else {
-            self.scope = .avatarPicker(.horizontalInstrinsicHeight)
+            self.scopeOption = .avatarPicker(.horizontalInstrinsicHeight)
         }
         self.configuration = configuration ?? .default
         self.token = token
@@ -213,12 +205,12 @@ public struct QuickEditorPresenter {
     /// <doc:GravatarOAuth> for more info.
     public init(
         email: Email,
-        scopeOption scope: QuickEditorScopeOption,
+        scopeOption: QuickEditorScopeOption,
         configuration: QuickEditorConfiguration? = nil,
         token: String? = nil
     ) {
         self.email = email
-        self.scope = scope
+        self.scopeOption = scopeOption
         self.configuration = configuration ?? .default
         self.token = token
     }
@@ -241,7 +233,7 @@ public struct QuickEditorPresenter {
     ) {
         let quickEditor = QuickEditorViewController(
             email: email,
-            scope: scope,
+            scopeOption: scopeOption,
             configuration: configuration,
             token: token,
             onUpdate: { _ in
@@ -271,7 +263,7 @@ public struct QuickEditorPresenter {
     ) {
         let quickEditor = QuickEditorViewController(
             email: email,
-            scope: scope,
+            scopeOption: scopeOption,
             configuration: configuration,
             token: token,
             onUpdate: onUpdate,

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerContentLayout.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerContentLayout.swift
@@ -16,6 +16,15 @@ public enum VerticalContentPresentationStyle: Sendable, Equatable {
         initialFraction: CGFloat = VerticalContentPresentationStyle.expandableMediumInitialFraction,
         prioritizeScrollOverResize: Bool = false
     )
+
+    var prioritizeScrollOverResize: Bool {
+        switch self {
+        case .expandableMedium(_, let prioritizeScrollOverResize):
+            prioritizeScrollOverResize
+        default:
+            false
+        }
+    }
 }
 
 /// Presentation styles supported for the horizontially scrolling content.
@@ -51,8 +60,8 @@ public enum AvatarPickerContentLayout: AvatarPickerContentLayoutProviding, Equat
 
     var prioritizeScrollOverResize: Bool {
         switch self {
-        case .vertical(.expandableMedium(_, let prioritizeScrollOverResize)):
-            prioritizeScrollOverResize
+        case .vertical(let presentationStyle):
+            presentationStyle.prioritizeScrollOverResize
         default:
             false
         }

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerContentLayout.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerContentLayout.swift
@@ -73,21 +73,6 @@ public enum AvatarPickerContentLayout: AvatarPickerContentLayoutProviding, Equat
     }
 }
 
-extension VerticalContentPresentationStyle {
-    @available(iOS 16.0, *)
-    var detents: [QEDetent] {
-        switch self {
-        case .large:
-            [.large]
-        case .expandableMedium(initialFraction: let initialFraction, prioritizeScrollOverResize: _):
-            [
-                .fraction(initialFraction),
-                .large,
-            ]
-        }
-    }
-}
-
 /// Content layout to use pre iOS 16.0 where the system don't offer different presentation styles for SwiftUI.
 /// Use ``AvatarPickerContentLayout`` for iOS 16.0 +.
 enum AvatarPickerContentLayoutType: String, CaseIterable, Identifiable, AvatarPickerContentLayoutProviding {

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -52,21 +52,21 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
 
     private let externalToken: String?
     private var token: String? { externalToken ?? fetchedToken }
-    private let scope: QuickEditorScopeOption
+    private let scopeOption: QuickEditorScopeOption
     private let email: Email
     private let customImageEditor: ImageEditorBlock<ImageEditor>?
     private let updateHandler: ((QuickEditorUpdateType) -> Void)?
 
     init(
         email: Email,
-        scope: QuickEditorScopeOption,
+        scopeOption: QuickEditorScopeOption,
         token: String? = nil,
         isPresented: Binding<Bool>,
         customImageEditor: ImageEditorBlock<ImageEditor>? = nil,
         updateHandler: ((QuickEditorUpdateType) -> Void)? = nil
     ) {
         self.email = email
-        self.scope = scope
+        self.scopeOption = scopeOption
         self._isPresented = isPresented
         self.customImageEditor = customImageEditor
         self.externalToken = token
@@ -105,12 +105,12 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
     @MainActor
     @ViewBuilder
     func editorView(with token: String) -> some View {
-        switch scope.scope {
+        switch scopeOption.scope {
         case .avatarPicker:
             AvatarPickerView(
                 model: model,
                 isPresented: $isPresented,
-                contentLayoutProvider: scope.avatarPickerConfig.contentLayout,
+                contentLayoutProvider: scopeOption.avatarPickerConfig.contentLayout,
                 customImageEditor: customImageEditor,
                 tokenErrorHandler: externalToken != nil ? nil : {
                     oauthSession.markSessionAsExpired(with: email)
@@ -272,7 +272,7 @@ enum QuickEditorConstants {
 #Preview {
     QuickEditor<NoCustomEditor>(
         email: .init(""),
-        scope: .aboutEditor(.init()),
+        scopeOption: .aboutEditor(.init()),
         isPresented: .constant(true)
     )
 }

--- a/Sources/GravatarUI/SwiftUI/QEDetent.swift
+++ b/Sources/GravatarUI/SwiftUI/QEDetent.swift
@@ -9,6 +9,27 @@ enum QEDetent {
     case height(CGFloat)
 
     static func detents(
+        for scopeOption: QuickEditorScopeOption,
+        intrinsicHeight: CGFloat,
+        verticalSizeClass: UserInterfaceSizeClass?
+    ) -> [QEDetent] {
+        switch scopeOption.scope {
+        case .avatarPicker:
+            avatarPickerDetents(
+                for: scopeOption.avatarPickerConfig.contentLayout,
+                intrinsicHeight: intrinsicHeight,
+                verticalSizeClass: verticalSizeClass
+            )
+        case .aboutInfoEditor:
+            aboutEditorDetents(
+                for: scopeOption.aboutEditorConfig.presentationStyle,
+                intrinsicHeight: intrinsicHeight,
+                verticalSizeClass: verticalSizeClass
+            )
+        }
+    }
+
+    private static func avatarPickerDetents(
         for presentation: AvatarPickerContentLayout,
         intrinsicHeight: CGFloat,
         verticalSizeClass: UserInterfaceSizeClass?
@@ -29,6 +50,21 @@ enum QEDetent {
             case .expandableMedium(let initialFraction, _):
                 .init([.fraction(initialFraction), .large])
             }
+        }
+    }
+
+    private static func aboutEditorDetents(
+        for presentationStyle: VerticalContentPresentationStyle,
+        intrinsicHeight: CGFloat,
+        verticalSizeClass: UserInterfaceSizeClass?
+    )
+        -> [QEDetent]
+    {
+        switch presentationStyle {
+        case .large:
+            [.large]
+        case .expandableMedium(initialFraction: let initialFraction, _):
+            .init([.fraction(initialFraction), .large])
         }
     }
 

--- a/Sources/GravatarUI/SwiftUI/QuickEditorModalPresentationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/QuickEditorModalPresentationModifier.swift
@@ -27,16 +27,16 @@ struct QuickEditorModalPresentationModifier<ModalView: View>: ViewModifier, Moda
 
     let onDismiss: (() -> Void)?
     let modalView: ModalView
-    var contentLayoutWithPresentation: AvatarPickerContentLayout
+    var scopeOption: QuickEditorScopeOption
 
-    init(isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, modalView: ModalView, contentLayout: AvatarPickerContentLayout) {
+    init(isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, modalView: ModalView, scopeOption: QuickEditorScopeOption) {
         self._isPresented = isPresented
         self.isPresentedInner = isPresented.wrappedValue
         self.onDismiss = onDismiss
         self.modalView = modalView
-        self.contentLayoutWithPresentation = contentLayout
+        self.scopeOption = scopeOption
         self.presentationDetents = QEDetent.detents(
-            for: contentLayout,
+            for: scopeOption,
             intrinsicHeight: Constants.bottomSheetEstimatedHeight,
             verticalSizeClass: nil
         ).map()
@@ -51,7 +51,7 @@ struct QuickEditorModalPresentationModifier<ModalView: View>: ViewModifier, Moda
                     // when switching between different presentation styles (especially between horizontal and vertical_large).
                     // Doing the same thing in .onAppear of the "modalView" doesn't give as nice results as this one don't know why.
                     self.presentationDetents = QEDetent.detents(
-                        for: contentLayoutWithPresentation,
+                        for: scopeOption,
                         intrinsicHeight: max(sheetHeight, Constants.bottomSheetEstimatedHeight),
                         verticalSizeClass: verticalSizeClass
                     ).map()
@@ -87,18 +87,19 @@ struct QuickEditorModalPresentationModifier<ModalView: View>: ViewModifier, Moda
 
     private func updateDetents() {
         self.presentationDetents = QEDetent.detents(
-            for: contentLayoutWithPresentation,
+            for: scopeOption,
             intrinsicHeight: sheetHeight,
             verticalSizeClass: verticalSizeClass
         ).map()
-        self.prioritizeScrollOverResize = contentLayoutWithPresentation.prioritizeScrollOverResize
+        self.prioritizeScrollOverResize = shouldPrioritizeScrollOverResize
     }
 }
 
 @MainActor
 protocol ModalPresentationWithIntrinsicSize {
-    var contentLayoutWithPresentation: AvatarPickerContentLayout { get }
+    var scopeOption: QuickEditorScopeOption { get }
     var verticalSizeClass: UserInterfaceSizeClass? { get }
+    var shouldPrioritizeScrollOverResize: Bool { get }
 }
 
 extension ModalPresentationWithIntrinsicSize {
@@ -107,16 +108,30 @@ extension ModalPresentationWithIntrinsicSize {
     }
 
     var shouldUseIntrinsicSize: Bool {
-        switch contentLayoutWithPresentation {
-        case .horizontal:
-            switch verticalSizeClass {
-            case .compact:
+        switch scopeOption.scope {
+        case .avatarPicker:
+            switch scopeOption.avatarPickerConfig.contentLayout {
+            case .horizontal:
+                switch verticalSizeClass {
+                case .compact:
+                    false
+                default:
+                    true
+                }
+            case .vertical:
                 false
-            default:
-                true
             }
-        case .vertical:
+        case .aboutInfoEditor:
             false
+        }
+    }
+
+    var shouldPrioritizeScrollOverResize: Bool {
+        switch scopeOption.scope {
+        case .avatarPicker:
+            scopeOption.avatarPickerConfig.contentLayout.prioritizeScrollOverResize
+        case .aboutInfoEditor:
+            scopeOption.aboutEditorConfig.presentationStyle.prioritizeScrollOverResize
         }
     }
 }

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -46,7 +46,7 @@ extension View {
     ) -> some View {
         let editor = QuickEditor(
             email: .init(email),
-            scope: QuickEditorScopeOption.avatarPicker(),
+            scopeOption: QuickEditorScopeOption.avatarPicker(),
             token: authToken,
             isPresented: isPresented,
             customImageEditor: customImageEditor,
@@ -82,9 +82,10 @@ extension View {
     ) -> some View {
         switch scope {
         case .avatarPicker(let config):
+            let scopeOption = QuickEditorScopeOption.avatarPicker(.init(contentLayout: config.contentLayout))
             let editor = QuickEditor(
                 email: .init(email),
-                scope: QuickEditorScopeOption.avatarPicker(.init(contentLayout: config.contentLayout)),
+                scopeOption: scopeOption,
                 token: authToken,
                 isPresented: isPresented,
                 customImageEditor: customImageEditor,
@@ -96,7 +97,7 @@ extension View {
                 isPresented: isPresented,
                 onDismiss: onDismiss,
                 modalView: editor,
-                contentLayout: config.contentLayout
+                scopeOption: scopeOption
             ))
         }
     }
@@ -118,30 +119,24 @@ extension View {
         isPresented: Binding<Bool>,
         email: String,
         authToken: String? = nil,
-        scopeOption scope: QuickEditorScopeOption,
+        scopeOption: QuickEditorScopeOption,
         customImageEditor: ImageEditorBlock<some ImageEditorView>? = nil as NoCustomEditorBlock?,
         updateHandler: ((QuickEditorUpdateType) -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
         let editor = QuickEditor(
             email: .init(email),
-            scope: scope,
+            scopeOption: scopeOption,
             token: authToken,
             isPresented: isPresented,
             customImageEditor: customImageEditor,
             updateHandler: updateHandler
         )
-        let contentLayout = switch scope.scope {
-        case .avatarPicker: scope.avatarPickerConfig.contentLayout
-        case .aboutInfoEditor: AvatarPickerContentLayout.vertical(
-                presentationStyle: scope.aboutEditorConfig.presentationStyle
-            )
-        }
         modifier(QuickEditorModalPresentationModifier(
             isPresented: isPresented,
             onDismiss: onDismiss,
             modalView: editor,
-            contentLayout: contentLayout
+            scopeOption: scopeOption
         ))
     }
 
@@ -169,7 +164,7 @@ extension View {
     ) -> some View {
         let editor = QuickEditor(
             email: .init(email),
-            scope: scope.map(),
+            scopeOption: scope.map(),
             token: authToken,
             isPresented: isPresented,
             customImageEditor: customImageEditor,


### PR DESCRIPTION
Closes #706

### Description

Continuation of https://github.com/Automattic/Gravatar-SDK-iOS/pull/718#pullrequestreview-2806862156

I wanted to update `QEDetents.detent(...)` to accept `QuickEditorScopeOption` so we can keep the detent calculation centralized. This makes it easier to maintain, especially when ensuring consistency between UIKit and SwiftUI.

While on it, I also renamed some `scope` parameters/vars as `scopeOption`.

### Testing Steps

Same with [#706](https://github.com/Automattic/Gravatar-SDK-iOS/pull/718)
