### PR TITLE
Fallback to the public profile endpoint if there's no token

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -219,10 +219,16 @@ class AvatarPickerViewModel: ObservableObject {
     }
 
     func fetchProfile() async {
-        guard let authToken else { return }
         do {
             isProfileLoading = true
-            let profile = try await profileService.fetchOwnProfile(token: authToken)
+            let profile: Profile
+            if let authToken {
+                profile = try await profileService.fetchOwnProfile(token: authToken)
+            }
+            else {
+                // Fallback to the public profile endpoint if there's no token.
+                profile = try await profileService.fetch(with: .email(email))
+            }
             profileResult = .success(profile)
             isProfileLoading = false
         } catch {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -221,13 +221,11 @@ class AvatarPickerViewModel: ObservableObject {
     func fetchProfile() async {
         do {
             isProfileLoading = true
-            let profile: Profile
-            if let authToken {
-                profile = try await profileService.fetchOwnProfile(token: authToken)
-            }
-            else {
+            let profile: Profile = if let authToken {
+                try await profileService.fetchOwnProfile(token: authToken)
+            } else {
                 // Fallback to the public profile endpoint if there's no token.
-                profile = try await profileService.fetch(with: .email(email))
+                try await profileService.fetch(with: .email(email))
             }
             profileResult = .success(profile)
             isProfileLoading = false


### PR DESCRIPTION
Closes #725

### Description

Recently we introduced the authenticated profile fetching endpoint but it only works when there's an auth token. We should fallback to the old endpoint when there isn't.

### Testing Steps

Go to QuickEditor
Login with email A
Use the logout button in the demo app
Change the email in the demo app
Start QuickEditor but use email A for the OAuth flow
This will generate the wrong email error
Observe that the profile card is filled with data