### PR TITLE
Fix truncated text content in the QuickEditor

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/ContentLoadingErrorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/ContentLoadingErrorView.swift
@@ -40,6 +40,7 @@ struct ContentLoadingErrorView<ActionButton: View>: View {
             .padding(innerPadding)
             .avatarPickerBorder(colorScheme: colorScheme)
         }
+        .fixedSize(horizontal: false, vertical: true)
     }
 }
 

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditorNoticeView.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditorNoticeView.swift
@@ -59,6 +59,7 @@ struct QuickEditorNoticeView: View {
             )
             .padding(.bottom, .DS.Padding.double)
         }
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     var shouldShowIntro: Bool {


### PR DESCRIPTION
Closes #726

### Description

The problem is that for some reason the text is shrunk vertically. So I am making use of [fixedSize(horizontal:vertical:)](https://developer.apple.com/documentation/swiftui/view/fixedsize(horizontal:vertical:)) to vertically fix the content this way it won't shrink.

### Testing Steps

Go to QuickEditor
Login with email A
Use the logout button in the demo app
Change the email in the demo app
Start QuickEditor but use email A for the OAuth flow
This will generate the wrong email error
Observe that the error text is not truncated

Additonal:

Test the intro state
Test in landscape orientation