### PR TITLE
About editor base networking

### DIFF
--- a/Sources/Gravatar/Network/Services/ProfileService.swift
+++ b/Sources/Gravatar/Network/Services/ProfileService.swift
@@ -80,6 +80,23 @@ public struct ProfileService: ProfileFetching, Sendable {
             throw error.apiError()
         }
     }
+
+    /// Update profile information for the authenticated user
+    ///
+    /// Updates the profile information for the authenticated user. Only a subset of `Profile` fields are available for supported, so only the provided fields
+    /// will be updated. To unset a field, set it explicitly to an empty string.
+    ///
+    /// - Parameters:
+    ///   - props: The subset of data available for update. Only the provided fields will be updated.
+    ///   - token: Gravatar OAuth2 token.
+    /// - Returns: An asynchronously-delivered user profile with the fields updated.
+    public func updateProfile(with props: UpdateProfileRequest, token: String) async throws -> Profile {
+        var request = URLRequest(url: meProfileURL).settingAuthorizationHeaderField(with: token)
+        request.httpMethod = "PATCH"
+        request.httpBody = try? JSONEncoder().encode(props)
+        let response = try await fetch(with: request)
+        return response
+    }
 }
 
 extension ProfileService {

--- a/Sources/Gravatar/OpenApi/Generated/Interest.swift
+++ b/Sources/Gravatar/OpenApi/Generated/Interest.swift
@@ -5,7 +5,7 @@ import Foundation
 public struct Interest: Codable, Hashable, Sendable {
     /// The unique identifier for the interest.
     public private(set) var id: Int
-    /// The name of the interest.
+    /// The name of the interest as originally defined (most often in English).
     public private(set) var name: String
 
     init(id: Int, name: String) {

--- a/Sources/Gravatar/OpenApi/Generated/UpdateProfileRequest.swift
+++ b/Sources/Gravatar/OpenApi/Generated/UpdateProfileRequest.swift
@@ -2,23 +2,23 @@ import Foundation
 
 /// The subset of data available for update. Field names match the ones in `Profile`. Only the provided fields will be updated.
 ///
-package struct UpdateProfileRequest: Codable, Hashable, Sendable {
+public struct UpdateProfileRequest: Codable, Hashable, Sendable {
     /// The user's display name. This is the name that is displayed on their profile.
-    package private(set) var displayName: String?
+    public private(set) var displayName: String?
     /// The about section on a user's profile.
-    package private(set) var description: String?
+    public private(set) var description: String?
     /// The phonetic pronunciation of the user's name.
-    package private(set) var pronunciation: String?
+    public private(set) var pronunciation: String?
     /// The pronouns the user uses.
-    package private(set) var pronouns: String?
+    public private(set) var pronouns: String?
     /// The user's location.
-    package private(set) var location: String?
+    public private(set) var location: String?
     /// The user's job title.
-    package private(set) var jobTitle: String?
+    public private(set) var jobTitle: String?
     /// The user's current company's name.
-    package private(set) var company: String?
+    public private(set) var company: String?
 
-    package init(
+    public init(
         displayName: String? = nil,
         description: String? = nil,
         pronunciation: String? = nil,
@@ -48,7 +48,7 @@ package struct UpdateProfileRequest: Codable, Hashable, Sendable {
 
     // Encodable protocol methods
 
-    package func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(displayName, forKey: .displayName)
         try container.encodeIfPresent(description, forKey: .description)

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -133,6 +133,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
             )
         case .aboutInfoEditor:
             Text("About info view")
+            UpdateProfileTestView(token: token)
             Spacer()
         }
     }
@@ -299,4 +300,54 @@ enum QuickEditorConstants {
         scopeOption: .aboutEditor(.init()),
         isPresented: .constant(true)
     )
+}
+
+struct UpdateProfileTestView: View {
+    let token: String
+
+    @State private var userName: String = ""
+    @State private var responseUserName: String = ""
+    @State private var error: Error?
+
+    var body: some View {
+        TextField("User name", text: $userName)
+        Button(action: {
+            Task {
+                await updateUserName()
+            }
+        }, label: {
+            Text("Update user name")
+        })
+        Text("Response user name: \(responseUserName)")
+        if let error = error as? APIError {
+            ScrollView {
+                switch error {
+                case .responseError(let reason):
+                    switch reason {
+                    case .URLSessionError(let error):
+                        Text(error.localizedDescription)
+                    case .invalidHTTPStatusCode(let response, let errorPayload):
+                        Text("\(response.statusCode) " + (errorPayload?.message ?? ""))
+                    case .invalidURLResponse(let response):
+                        Text(String(describing: response))
+                    case .unexpected(let error):
+                        Text(String(describing: error))
+                    }
+                case .decodingError(let decodingError):
+                    Text(String(describing: decodingError.localizedDescription))
+                default: Text("Unknown error")
+                }
+            }
+        }
+    }
+
+    func updateUserName() async {
+        let service = ProfileService()
+        do {
+            let profile = try await service.updateProfile(with: .init(displayName: userName), token: token)
+            responseUserName = profile.displayName
+        } catch {
+            self.error = error
+        }
+    }
 }

--- a/Tests/GravatarTests/ProfileServiceTests.swift
+++ b/Tests/GravatarTests/ProfileServiceTests.swift
@@ -70,4 +70,17 @@ final class ProfileServiceTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
+
+    func testProfileUpdateRequest() async {
+        let data = Bundle.fullProfileJsonData
+
+        let session = URLSessionMock(returnData: data, response: .successResponse())
+        let service = ProfileService(urlSession: session)
+
+        do {
+            _ = try await service.updateProfile(with: .init(displayName: "new name"), token: "some token")
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
 }

--- a/access-control-modifier.swift
+++ b/access-control-modifier.swift
@@ -12,6 +12,12 @@ let internalTypes: [String] = [
 ]
 
 let packageTypes: [String] = [
+]
+
+// By default, we want public types to have internal inits.
+// In some case we want the init to be public also.
+// Add those types here.
+let publicInitTypes: [String] = [
     "UpdateProfileRequest"
 ]
 
@@ -46,6 +52,11 @@ for case let fileURL as URL in filesEnumerator {
             .replacingOccurrences(of: "public enum", with: "package enum")
             .replacingOccurrences(of: "public init", with: "package init")
             .replacingOccurrences(of: "init", with: "package init")
+        try modified.write(to: fileURL, atomically: true, encoding: .utf8)
+    }
+    else if publicInitTypes.map({ $0 + ".swift" }).contains(fileURL.lastPathComponent) {
+        let modified = content
+            .replacingOccurrences(of: "init", with: "public init")
         try modified.write(to: fileURL, atomically: true, encoding: .utf8)
     }
 }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -5,9 +5,9 @@ info:
   description: Gravatar's public API endpoints
   contact:
     name: Gravatar
-    url: https://gravatar.com
+    url: 'https://gravatar.com'
 servers:
-  - url: https://api.gravatar.com/v3
+  - url: 'https://api.gravatar.com/v3'
     description: Production server
 tags:
   - name: profiles
@@ -16,6 +16,8 @@ tags:
     description: Operations about user avatars
   - name: qr-code
     description: Operations about QR codes
+  - name: experimental
+    description: Experimental operations that might be subject to change. Use with caution.
 components:
   headers:
     X-RateLimit-Limit:
@@ -81,7 +83,7 @@ components:
           type: string
           format: date-time
           description: Date and time when the image was last updated.
-          pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
+          pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
           examples:
             - '2021-10-01T12:00:00Z'
     AvatarRating:
@@ -109,7 +111,7 @@ components:
           format: uri
           description: The URL to the link.
           examples:
-            - https://example.com
+            - 'https://example.com'
     Interest:
       type: object
       description: An interest the user has added to their profile.
@@ -124,9 +126,11 @@ components:
             - 1
         name:
           type: string
-          description: The name of the interest.
+          description: >-
+            The name of the interest as originally defined (most often in
+            English).
           examples:
-            - Photography
+            - photography
     CryptoWalletAddress:
       type: object
       description: A crypto currency wallet address the user accepts.
@@ -169,13 +173,13 @@ components:
           description: The URL to the service's icon.
           format: uri
           examples:
-            - https://gravatar.com/icons/tumblr-alt.svg
+            - 'https://gravatar.com/icons/tumblr-alt.svg'
         url:
           type: string
           description: The URL to the user's profile on the service.
           format: uri
           examples:
-            - https://example.tumblr.com/
+            - 'https://example.tumblr.com/'
         is_hidden:
           type: boolean
           description: Whether the verified account is hidden from the user's profile.
@@ -264,7 +268,7 @@ components:
           description: The full URL for the user's profile.
           format: uri
           examples:
-            - https://gravatar.com/example
+            - 'https://gravatar.com/example'
         avatar_url:
           type: string
           format: uri
@@ -283,7 +287,7 @@ components:
           type: string
           description: The user's location.
           examples:
-            - New York, USA
+            - 'New York, USA'
         description:
           type: string
           description: The about section on a user's profile.
@@ -362,8 +366,8 @@ components:
           type: string
           description: The profile background color.
           examples:
-            - rgb(33, 0, 166)
-            - linear-gradient(135deg, rgb(2, 3, 129) 0%, rgb(40, 116, 252) 100%)
+            - 'rgb(33, 0, 166)'
+            - 'linear-gradient(135deg, rgb(2, 3, 129) 0%, rgb(40, 116, 252) 100%)'
         links:
           type: array
           description: >-
@@ -432,13 +436,13 @@ components:
               description: The URL to the user's contact form.
               format: uri
               examples:
-                - https://example.com/contact-me
+                - 'https://example.com/contact-me'
             calendar:
               type: string
               description: The URL to the user's calendar.
               format: uri
               examples:
-                - https://example.com/calendar
+                - 'https://example.com/calendar'
         gallery:
           type: array
           description: >-
@@ -463,7 +467,7 @@ components:
             The date and time (UTC) the user last edited their profile. This is
             only provided in authenticated API requests.
           format: date-time
-          pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
+          pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
           examples:
             - '2021-10-01T12:00:00Z'
         registration_date:
@@ -475,7 +479,7 @@ components:
             The date the user registered their account. This is only provided in
             authenticated API requests.
           format: date-time
-          pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
+          pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
           examples:
             - '2021-10-01T12:00:00Z'
     AssociatedResponse:
@@ -511,7 +515,7 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: https://public-api.wordpress.com/oauth2/authorize
+          authorizationUrl: 'https://public-api.wordpress.com/oauth2/authorize'
           scopes: {}
       description: WordPress OAuth token to authenticate the request.
   responses:
@@ -557,7 +561,7 @@ components:
                 error: Rate limit exceeded
                 code: rate_limit_exceeded
 paths:
-  /profiles/{profileIdentifier}:
+  '/profiles/{profileIdentifier}':
     get:
       summary: Get profile by identifier
       description: Returns a profile by the given identifier.
@@ -603,7 +607,58 @@ paths:
           $ref: '#/components/responses/rate_limit_exceeded'
         '500':
           description: Internal server error
-  /qr-code/{sha256_hash}:
+  '/profiles/{profileIdentifier}/inferred-interests':
+    get:
+      summary: Get inferred interests for a profile given their identifier
+      description: >-
+        Returns a list of inferred interests based on known and public
+        information about the profile.
+      tags:
+        - experimental
+      operationId: getProfileInferredInterestsById
+      parameters:
+        - name: profileIdentifier
+          in: path
+          required: true
+          description: >-
+            This can either be an SHA256 hash of an email address or profile URL
+            slug.
+          schema:
+            type: string
+      security:
+        - apiKey: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                description: A list of interests the user might (or might not) like.
+                items:
+                  $ref: '#/components/schemas/Interest'
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/X-RateLimit-Limit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/X-RateLimit-Remaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/X-RateLimit-Reset'
+        '404':
+          description: Profile not found
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/X-RateLimit-Limit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/X-RateLimit-Remaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/X-RateLimit-Reset'
+        '429':
+          description: Rate limit exceeded
+          $ref: '#/components/responses/rate_limit_exceeded'
+        '500':
+          description: Internal server error
+  '/qr-code/{sha256_hash}':
     get:
       summary: Get QR code for an email address' profile
       description: Returns a QR code for an email address by the given SHA256 hash.
@@ -763,7 +818,7 @@ paths:
                   type: string
                   description: The user's location.
                   examples:
-                    - New York, USA
+                    - 'New York, USA'
                 job_title:
                   type: string
                   description: The user's job title.
@@ -907,12 +962,12 @@ paths:
             schema:
               type: object
               properties:
-                data:
+                image:
                   type: string
                   format: binary
                   description: The avatar image file
               required:
-                - data
+                - image
       responses:
         '200':
           description: Avatar uploaded successfully
@@ -941,7 +996,7 @@ paths:
         '403':
           description: Insufficient Scope
           $ref: '#/components/responses/insufficient_scope'
-  /me/avatars/{imageHash}:
+  '/me/avatars/{imageHash}':
     delete:
       summary: Delete avatar
       description: Deletes a specific avatar for the authenticated user.
@@ -1019,7 +1074,7 @@ paths:
           $ref: '#/components/responses/insufficient_scope'
         '404':
           description: Avatar not found
-  /me/avatars/{imageId}/email:
+  '/me/avatars/{imageId}/email':
     post:
       summary: Set avatar for the hashed email
       description: Sets the avatar for the provided email hash.


### PR DESCRIPTION
Closes #708 

### Description

This PR adds the `updateProfile` method to the `ProfileService`, to be able to perform patch operations on the profile.

So far, I've decided to make `UpdateProfileRequest` public to avoid internal duplications. But we can change that before merging if we decide.

I have also added a very simple UI for testing the request, it will show the response Profile's display name, or any error.

![CleanShot 2025-05-01 at 13 59 39](https://github.com/user-attachments/assets/1c2fdcfa-4006-4b33-a31e-15ff5d45cb52)



### Testing Steps

- Use the provided test UI to try an update of the user's display name.
  - You can also close the QE and re-open to see the new name in the Profile card.
- Try an error like `Unauthorized` (modifying the given token)  to see the catch error.
