### PR TITLE
Add about fields definitions and enhance demo app to select them

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import SwiftUI
 import GravatarUI
 
 final class DemoQuickEditorViewController: UIViewController {
@@ -17,6 +18,19 @@ final class DemoQuickEditorViewController: UIViewController {
         }
         set {
             UserDefaults.standard.setValue(newValue, forKey: "QETokenKey")
+        }
+    }
+
+    private var selectedAboutInfoFields: AboutInfoField  {
+        get {
+            if let rawValue = UserDefaults.standard.object(forKey: "demoSelectedAboutInfoFields") as? AboutInfoField.RawValue {
+                return AboutInfoField(rawValue: rawValue)
+            } else {
+                return AboutInfoField.all
+            }
+        }
+        set {
+            UserDefaults.standard.setValue(newValue.rawValue, forKey: "demoSelectedAboutInfoFields")
         }
     }
 
@@ -75,7 +89,12 @@ final class DemoQuickEditorViewController: UIViewController {
         case .avatarPicker:
             .avatarPicker(.init(contentLayout: selectedLayout.contentLayout))
         case .aboutEditor:
-            .aboutEditor(.init(presentationStyle: selectedVerticalContentPresentationStyle))
+            .aboutEditor(
+                .init(
+                    presentationStyle: selectedVerticalContentPresentationStyle,
+                    fields: selectedAboutInfoFields
+                )
+            )
         }
     }
 
@@ -146,6 +165,14 @@ final class DemoQuickEditorViewController: UIViewController {
         return button
     }()
 
+    lazy var aboutFieldsButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("Select input fields", for: .normal)
+        button.addTarget(self, action: #selector(aboutFieldsButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
     @objc func presentLayoutOptions() {
         let sheet = UIAlertController(title: "Layout Options", message: nil, preferredStyle: .actionSheet)
         AvatarPickerLayoutOptions.allCases.forEach { layout in
@@ -174,6 +201,23 @@ final class DemoQuickEditorViewController: UIViewController {
             })
         }
         present(sheet, animated: true)
+    }
+
+    @objc func aboutFieldsButtonTapped() {
+        let aboutChecklistHostingController = UIHostingController(
+            rootView: AboutInfoChecklistView(
+                selectedFields: Binding(
+                    get: {
+                        self.selectedAboutInfoFields
+                    },
+                    set: { fields in
+                        self.selectedAboutInfoFields = fields
+                    }
+                )
+            )
+        )
+        aboutChecklistHostingController.sheetPresentationController?.detents = [.medium(), .large()]
+        present(aboutChecklistHostingController, animated: true)
     }
 
     lazy var colorSchemeLabel: UILabel = {
@@ -257,6 +301,7 @@ final class DemoQuickEditorViewController: UIViewController {
     lazy var aboutEditorOptionsStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
             aboutPresentationStyleButton,
+            aboutFieldsButton
         ])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical

--- a/Demo/Demo/Gravatar-Demo/SwiftUI/Controls/AboutInfoChecklistView.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/Controls/AboutInfoChecklistView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import GravatarUI
+
+struct AboutInfoChecklistView: View {
+    @Binding var selectedFields: AboutInfoField
+
+    private let allOptions: [(AboutInfoField, String)] = [
+        (.displayName, "Display Name"),
+        (.aboutMe, "About Me"),
+        (.pronunciation, "Pronunciation"),
+        (.pronouns, "Pronouns"),
+        (.location, "Location"),
+        (.jobTitle, "Job Title"),
+        (.company, "Company / Organization")
+    ]
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Select Fields")
+                .font(.headline)
+                .padding(.bottom, 16)
+            
+            ForEach(allOptions, id: \.0.rawValue) { (field, label) in
+                Toggle(isOn: Binding(
+                    get: { selectedFields.contains(field) },
+                    set: { isOn in
+                        if isOn {
+                            selectedFields.insert(field)
+                        } else {
+                            selectedFields.remove(field)
+                        }
+                    }
+                )) {
+                    Text(label)
+                }
+            }
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    @Previewable @State var selectedFields: AboutInfoField = []
+    AboutInfoChecklistView(selectedFields: $selectedFields)
+}

--- a/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
@@ -17,8 +17,10 @@ struct DemoProfileEditorView: View {
     @State private var isSecure: Bool = true
     @State var enableCustomImageCropper: Bool = false
     @State var prefersEphemeralWebBrowserSession: Bool = false
-    @State private var scope: QEScope = .avatarPicker
+    @AppStorage("demoSelectedScope") private var scope: QEScope = .avatarPicker
     @State private var verticalPresentationStyle: VerticalContentPresentationStyle = .expandableMedium()
+    @State private var isPresentingAboutFieldsSheet: Bool = false
+    @AppStorage("demoSelectedAboutInfoFields") var selectedAboutInfoFields: AboutInfoField = .all
 
     var body: some View {
         VStack(spacing: 20) {
@@ -129,6 +131,14 @@ struct DemoProfileEditorView: View {
                 await oauthSession.setPrefersEphemeralWebBrowserSession(prefersEphemeralWebBrowserSession)
             }
         }
+        .sheet(isPresented: $isPresentingAboutFieldsSheet) {
+            if #available(iOS 16.0, *) {
+                AboutInfoChecklistView(selectedFields: $selectedAboutInfoFields)
+                    .presentationDetents([.medium, .large])
+            } else {
+                AboutInfoChecklistView(selectedFields: $selectedAboutInfoFields)
+            }
+        }
     }
 
     var finalScope: QuickEditorScopeOption {
@@ -136,7 +146,8 @@ struct DemoProfileEditorView: View {
         case .avatarPicker:
             .avatarPicker(.init(contentLayout: contentLayoutOptions.contentLayout))
         case .aboutEditor:
-            .aboutEditor(.init(presentationStyle: verticalPresentationStyle))
+                .aboutEditor(.init(presentationStyle: verticalPresentationStyle,
+                                   fields: selectedAboutInfoFields))
         }
     }
 
@@ -162,7 +173,19 @@ struct DemoProfileEditorView: View {
             if #available(iOS 16.0, *) {
                 QEVerticalStylePickerRow(verticalStyle: $verticalPresentationStyle)
             }
+            aboutFieldsButton()
         }
+    }
+
+    func aboutFieldsButton() -> some View {
+        HStack(alignment: .center) {
+            Spacer()
+            Button("Select input fields") {
+                isPresentingAboutFieldsSheet = true
+            }
+            .buttonStyle(.bordered)
+        }
+        .frame(maxWidth: .infinity)
     }
 
     func requestProfile() {

--- a/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Gravatar-Demo.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		91C76B432D970F5600F248B9 /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C76B422D970F5600F248B9 /* SafariView.swift */; };
 		91CB2CD42D2EB2E100569581 /* View+Demo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91CB2CD32D2EB2E100569581 /* View+Demo.swift */; };
 		91E2FB042BC0276E00265E8E /* DemoProfileViewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E2FB032BC0276E00265E8E /* DemoProfileViewsViewController.swift */; };
+		91E993622DC38EB800C0BE7F /* AboutInfoChecklistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E993612DC38EB800C0BE7F /* AboutInfoChecklistView.swift */; };
 		91F0B3DD2B62815F0025C4F8 /* MainTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F0B3DB2B62815F0025C4F8 /* MainTableViewController.swift */; };
 		91F0B3DE2B62815F0025C4F8 /* DemoAvatarDownloadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F0B3DC2B62815F0025C4F8 /* DemoAvatarDownloadViewController.swift */; };
 		91F0B3E32B6281A60025C4F8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 91F0B3E12B6281A60025C4F8 /* Main.storyboard */; };
@@ -148,6 +149,7 @@
 		91C76B422D970F5600F248B9 /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		91CB2CD32D2EB2E100569581 /* View+Demo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Demo.swift"; sourceTree = "<group>"; };
 		91E2FB032BC0276E00265E8E /* DemoProfileViewsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoProfileViewsViewController.swift; sourceTree = "<group>"; };
+		91E993612DC38EB800C0BE7F /* AboutInfoChecklistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutInfoChecklistView.swift; sourceTree = "<group>"; };
 		91F0B3DB2B62815F0025C4F8 /* MainTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainTableViewController.swift; sourceTree = "<group>"; };
 		91F0B3DC2B62815F0025C4F8 /* DemoAvatarDownloadViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoAvatarDownloadViewController.swift; sourceTree = "<group>"; };
 		91F0B3E22B6281A60025C4F8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -204,6 +206,7 @@
 				1E741C452DBB9BF800216752 /* QEVerticalStylePickerRow.swift */,
 				1E741C432DBB9BDC00216752 /* QEScopesPickerRow.swift */,
 				919C70562CAAF28E0036B03C /* QEColorSchemePickerRow.swift */,
+				91E993612DC38EB800C0BE7F /* AboutInfoChecklistView.swift */,
 			);
 			path = Controls;
 			sourceTree = "<group>";
@@ -448,6 +451,7 @@
 				1E15CA722D3FB48900B5FCB4 /* SwitchField.swift in Sources */,
 				1E15CA782D3FB84700B5FCB4 /* TextFormField.swift in Sources */,
 				91CB2CD42D2EB2E100569581 /* View+Demo.swift in Sources */,
+				91E993622DC38EB800C0BE7F /* AboutInfoChecklistView.swift in Sources */,
 				9133058E2C91F8D1009F5C0B /* DemoImageCropperViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/GravatarUI/QuickEditor/AboutInfoField.swift
+++ b/Sources/GravatarUI/QuickEditor/AboutInfoField.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Represents a set of fields that can be shown in the "About" section of the QuickEditor.
+public struct AboutInfoField: OptionSet, Sendable {
+    public let rawValue: Int
+
+    public init(rawValue: Self.RawValue) {
+        self.rawValue = rawValue
+    }
+
+    /// The user’s display name.
+    public static let displayName = AboutInfoField(rawValue: 1 << 0)
+    /// A short biography or description about the user.
+    public static let aboutMe = AboutInfoField(rawValue: 1 << 1)
+    /// A phonetic pronunciation of the user’s name.
+    public static let pronunciation = AboutInfoField(rawValue: 1 << 2)
+    /// The pronouns the user identifies with (e.g., she/her, they/them).
+    public static let pronouns = AboutInfoField(rawValue: 1 << 3)
+    /// The user's geographic location.
+    public static let location = AboutInfoField(rawValue: 1 << 4)
+    /// The user's current job title or role.
+    public static let jobTitle = AboutInfoField(rawValue: 1 << 5)
+    /// The company or organization the user is affiliated with.
+    public static let company = AboutInfoField(rawValue: 1 << 6)
+
+    /// A convenience set representing all possible about info fields.
+    public static let all: AboutInfoField = [
+        .displayName,
+        .aboutMe,
+        .pronunciation,
+        .pronouns,
+        .location,
+        .jobTitle,
+        .company,
+    ]
+
+    /// A subset of fields that are personal.
+    public static let personalFields: AboutInfoField = [
+        .displayName,
+        .aboutMe,
+        .pronunciation,
+        .pronouns,
+        .location,
+    ]
+
+    /// A subset of fields that are professional or work-related.
+    public static let professionalFields: AboutInfoField = [
+        .jobTitle,
+        .company,
+    ]
+
+    func localizedName() -> String {
+        switch self {
+        case .displayName:
+            SDKLocalizedString(
+                "Profile.AboutInfoField.displayName",
+                value: "Display Name",
+                comment: "Label of a field that contains a user’s display name."
+            )
+        case .aboutMe:
+            SDKLocalizedString(
+                "Profile.AboutInfoField.aboutMe",
+                value: "About Me",
+                comment: "Label of a field that contains a short biography or description about the user."
+            )
+        case .pronunciation:
+            SDKLocalizedString(
+                "Profile.AboutInfoField.pronunciation",
+                value: "Pronunciation",
+                comment: "Label of a field that contains a phonetic pronunciation of the user’s name."
+            )
+        case .pronouns:
+            SDKLocalizedString(
+                "Profile.AboutInfoField.pronouns",
+                value: "Pronouns",
+                comment: "Label of a field that contains the pronouns the user identifies with (e.g., she/her, they/them)."
+            )
+        case .location:
+            SDKLocalizedString(
+                "Profile.AboutInfoField.location",
+                value: "Location",
+                comment: "Label of a field that contains the user's geographic location."
+            )
+        case .jobTitle:
+            SDKLocalizedString(
+                "Profile.AboutInfoField.jobTitle",
+                value: "Job Title",
+                comment: "Label of a field that contains the user's current job title or role."
+            )
+        case .company:
+            SDKLocalizedString(
+                "Profile.AboutInfoField.company",
+                value: "Company",
+                comment: "Label of a field that contains the company or organization the user is affiliated with."
+            )
+        default:
+            ""
+        }
+    }
+}

--- a/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
@@ -29,9 +29,14 @@ public struct AvatarPickerConfiguration: Sendable {
 /// Configuration which will be applied to the About info editor.
 public struct AboutEditorConfiguration: Sendable {
     let presentationStyle: VerticalContentPresentationStyle
+    let fields: AboutInfoField
 
-    public init(presentationStyle: VerticalContentPresentationStyle = .expandableMedium()) {
+    public init(
+        presentationStyle: VerticalContentPresentationStyle = .expandableMedium(),
+        fields: AboutInfoField = AboutInfoField.all
+    ) {
         self.presentationStyle = presentationStyle
+        self.fields = fields
     }
 }
 

--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -175,6 +175,27 @@
 /* Screen title. Resize and crop an image. */
 "ImageCropper.title" = "Resize & Crop";
 
+/* Label of a field that contains a short biography or description about the user. */
+"Profile.AboutInfoField.aboutMe" = "About Me";
+
+/* Label of a field that contains the user's company or organization the user is affiliated with. */
+"Profile.AboutInfoField.company" = "Company";
+
+/* Label of a field that contains a user’s display name. */
+"Profile.AboutInfoField.displayName" = "Display Name";
+
+/* Label of a field that contains the The user's current job title or role. */
+"Profile.AboutInfoField.jobTitle" = "Job Title";
+
+/* Label of a field that contains the user's geographic location. */
+"Profile.AboutInfoField.location" = "Location";
+
+/* Label of a field that contains the pronouns the user identifies with (e.g., she/her, they/them). */
+"Profile.AboutInfoField.pronouns" = "Pronouns";
+
+/* Label of a field that contains a phonetic pronunciation of the user’s name. */
+"Profile.AboutInfoField.pronunciation" = "Pronunciation";
+
 /* Title for a button that allows you to claim a new Gravatar profile */
 "ProfileButton.title.create" = "Claim profile";
 


### PR DESCRIPTION
Closes part of #709

I'll make another PR to actually use these fields in the QuickEditor.

### Description

A new `OptionSet` named `AboutInfoField` to represent about input fields.
Adds localized names for the fields
New UI to select fields from the UIKit & SwiftUI demo apps:

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/16497e89-c878-490f-8edd-2ee169d49534" width=300/></td>
    <td><img src="https://github.com/user-attachments/assets/731dd305-e9f8-4b71-b656-239ac2f7c3a4" width=300/></td>
  </tr>
</table>

### Testing Steps

Go to QuickEditor demo pages for both UIKit & SwiftUI
Switch to about editing scope
Observe the new "Select input fields" button and tap on it
Observe the new sheet to select the fields
Observe that changing the fields are persisted between each app session (Persisting makes it really easier to test so I went for it)