### PR TITLE
Add about info UI

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
@@ -375,7 +375,7 @@ final class DemoQuickEditorViewController: UIViewController {
                     case .avatarUpdate:
                         self?.profileSummaryView.loadAvatar(with: .email(email), rating: .x, options: [.forceRefresh])
                     case .aboutInfoUpdate:
-                        break
+                        self?.fetchProfile(with: email)
                     default:
                         break
                 }

--- a/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
@@ -77,7 +77,7 @@ struct DemoProfileEditorView: View {
                                     case .avatarUpdate:
                                         self.oneTimeAvatarForceRefresh = true
                                     case .aboutInfoUpdate:
-                                        break
+                                        self.requestProfile()
                                     default: break
                                     }
                                 },

--- a/Sources/GravatarUI/Base/Array+Additions.swift
+++ b/Sources/GravatarUI/Base/Array+Additions.swift
@@ -6,3 +6,9 @@ extension Array {
         return self[index]
     }
 }
+
+extension [Bool] {
+    var hasMoreThanOneTrue: Bool {
+        count { $0 } > 1
+    }
+}

--- a/Sources/GravatarUI/QuickEditor/AboutInfoField.swift
+++ b/Sources/GravatarUI/QuickEditor/AboutInfoField.swift
@@ -49,6 +49,13 @@ public struct AboutInfoField: OptionSet, Sendable {
         .company,
     ]
 
+    var hasMultipleCategories: Bool {
+        (
+            (self.intersection(.personalFields).rawValue > 0 ? 1 : 0) +
+            (self.intersection(.professionalFields).rawValue > 0 ? 1 : 0)
+        ) > 1
+    }
+
     func localizedName() -> String {
         switch self {
         case .displayName:

--- a/Sources/GravatarUI/QuickEditor/AboutInfoField.swift
+++ b/Sources/GravatarUI/QuickEditor/AboutInfoField.swift
@@ -51,8 +51,8 @@ public struct AboutInfoField: OptionSet, Sendable {
 
     var hasMultipleCategories: Bool {
         (
-            (self.intersection(.personalFields).rawValue > 0 ? 1 : 0) +
-            (self.intersection(.professionalFields).rawValue > 0 ? 1 : 0)
+            (self.intersection(.personalFields).isEmpty ? 0 : 1) +
+                (self.intersection(.professionalFields).isEmpty ? 0 : 1)
         ) > 1
     }
 

--- a/Sources/GravatarUI/QuickEditor/AboutInfoField.swift
+++ b/Sources/GravatarUI/QuickEditor/AboutInfoField.swift
@@ -50,10 +50,10 @@ public struct AboutInfoField: OptionSet, Sendable {
     ]
 
     var hasMultipleCategories: Bool {
-        (
-            (self.intersection(.personalFields).isEmpty ? 0 : 1) +
-                (self.intersection(.professionalFields).isEmpty ? 0 : 1)
-        ) > 1
+        [
+            !self.intersection(.personalFields).isEmpty,
+            !self.intersection(.professionalFields).isEmpty,
+        ].hasMoreThanOneTrue
     }
 
     func localizedName() -> String {

--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -178,13 +178,16 @@
 /* Label of a field that contains a short biography or description about the user. */
 "Profile.AboutInfoField.aboutMe" = "About Me";
 
-/* Label of a field that contains the user's company or organization the user is affiliated with. */
+/* Description for the 'About me' field in the profile editing screen. */
+"Profile.AboutInfoField.aboutMe.footer" = "Brief description for your profile.";
+
+/* Label of a field that contains the company or organization the user is affiliated with. */
 "Profile.AboutInfoField.company" = "Company";
 
 /* Label of a field that contains a user’s display name. */
 "Profile.AboutInfoField.displayName" = "Display Name";
 
-/* Label of a field that contains the The user's current job title or role. */
+/* Label of a field that contains the user's current job title or role. */
 "Profile.AboutInfoField.jobTitle" = "Job Title";
 
 /* Label of a field that contains the user's geographic location. */
@@ -195,6 +198,18 @@
 
 /* Label of a field that contains a phonetic pronunciation of the user’s name. */
 "Profile.AboutInfoField.pronunciation" = "Pronunciation";
+
+/* Description for the 'Pronunciation' field in the profile editing screen. */
+"Profile.AboutInfoField.pronunciation.footer" = "Let them know how your name sounds like.";
+
+/* Title of the button to save changes in the profile editing screen. */
+"Profile.Save.title" = "Save";
+
+/* Title of the personal info section in the profile editing screen. */
+"Profile.Section.Personal.header" = "Personal";
+
+/* Title of the professional/work info section in the profile editing screen. */
+"Profile.Section.Professional.header" = "Professional";
 
 /* Title for a button that allows you to claim a new Gravatar profile */
 "ProfileButton.title.create" = "Claim profile";

--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
@@ -16,7 +16,9 @@ struct AboutEditorView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 personalInfoContent()
-                Spacer().frame(height: .DS.Padding.double)
+                if fields.hasMultipleCategories {
+                    Spacer().frame(height: .DS.Padding.double)
+                }
                 professionalInfoContent()
             }
             .padding(.DS.Padding.double)
@@ -41,7 +43,7 @@ struct AboutEditorView: View {
 
     @ViewBuilder
     private func personalInfoContent() -> some View {
-        if hasMultipleSections {
+        if fields.hasMultipleCategories {
             sectionHeader(title: Localized.personalSectionHeaderText)
         }
         if fields.contains(.displayName) {
@@ -81,7 +83,7 @@ struct AboutEditorView: View {
 
     @ViewBuilder
     private func professionalInfoContent() -> some View {
-        if hasMultipleSections {
+        if fields.hasMultipleCategories {
             sectionHeader(title: Localized.professionalSectionHeaderText)
         }
         if fields.contains(.jobTitle) {
@@ -141,11 +143,6 @@ struct AboutEditorView: View {
         }
         .padding(.vertical, .DS.Padding.single)
         .frame(maxWidth: .infinity)
-    }
-
-    private var hasMultipleSections: Bool {
-        (fields.contains(.personalFields) ? 1 : 0) +
-            (fields.contains(.professionalFields) ? 1 : 0) > 1
     }
 
     private enum Localized {

--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
@@ -9,7 +9,6 @@ struct AboutEditorView: View {
 
     @ObservedObject var model: AvatarPickerViewModel
     let fields: AboutInfoField
-    @StateObject private var inputFields: AboutInputFields = .init()
     @Environment(\.colorScheme) var colorScheme: ColorScheme
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
 
@@ -32,7 +31,9 @@ struct AboutEditorView: View {
 
     private func saveButton() -> some View {
         Button {
-            print("")
+            Task {
+                await self.model.saveAboutInfo(for: fields)
+            }
         } label: {
             CTAButtonView(Localized.saveButtonTitle)
         }
@@ -46,14 +47,14 @@ struct AboutEditorView: View {
         if fields.contains(.displayName) {
             inputField(
                 for: AboutInfoField.displayName.localizedName(),
-                value: $inputFields.displayName
+                value: $model.aboutInfoModel.displayName
             )
         }
         if fields.contains(.aboutMe) {
             inputField(
                 for: AboutInfoField.aboutMe.localizedName(),
                 footerText: Localized.aboutMeFooterText,
-                value: $inputFields.aboutMe,
+                value: $model.aboutInfoModel.aboutMe,
                 isLarge: true
             )
         }
@@ -61,19 +62,19 @@ struct AboutEditorView: View {
             inputField(
                 for: AboutInfoField.pronunciation.localizedName(),
                 footerText: Localized.pronunciationFooterText,
-                value: $inputFields.pronunciation
+                value: $model.aboutInfoModel.pronunciation
             )
         }
         if fields.contains(.pronouns) {
             inputField(
                 for: AboutInfoField.pronouns.localizedName(),
-                value: $inputFields.pronouns
+                value: $model.aboutInfoModel.pronouns
             )
         }
         if fields.contains(.location) {
             inputField(
                 for: AboutInfoField.location.localizedName(),
-                value: $inputFields.location
+                value: $model.aboutInfoModel.location
             )
         }
     }
@@ -86,13 +87,13 @@ struct AboutEditorView: View {
         if fields.contains(.jobTitle) {
             inputField(
                 for: AboutInfoField.jobTitle.localizedName(),
-                value: $inputFields.jobTitle
+                value: $model.aboutInfoModel.jobTitle
             )
         }
         if fields.contains(.company) {
             inputField(
                 for: AboutInfoField.company.localizedName(),
-                value: $inputFields.company
+                value: $model.aboutInfoModel.company
             )
         }
     }
@@ -174,38 +175,6 @@ struct AboutEditorView: View {
             comment: "Title of the button to save changes in the profile editing screen."
         )
     }
-}
-
-private class AboutInputFields: ObservableObject {
-    @Published var displayName: String = ""
-    @Published var aboutMe: String = ""
-    @Published var pronunciation: String = ""
-    @Published var pronouns: String = ""
-    @Published var location: String = ""
-    @Published var jobTitle: String = ""
-    @Published var company: String = ""
-
-    func fieldsToUpdate(from fields: AboutInfoField) -> FieldsToUpdate {
-        FieldsToUpdate(
-            displayName: fields.contains(.aboutMe) ? aboutMe : nil,
-            aboutMe: fields.contains(.aboutMe) ? aboutMe : nil,
-            pronunciation: fields.contains(.pronunciation) ? pronunciation : nil,
-            pronouns: fields.contains(.pronouns) ? pronouns : nil,
-            location: fields.contains(.location) ? location : nil,
-            jobTitle: fields.contains(.jobTitle) ? jobTitle : nil,
-            company: fields.contains(.company) ? company : nil
-        )
-    }
-}
-
-struct FieldsToUpdate {
-    var displayName: String? = nil
-    var aboutMe: String? = nil
-    var pronunciation: String? = nil
-    var pronouns: String? = nil
-    var location: String? = nil
-    var jobTitle: String? = nil
-    var company: String? = nil
 }
 
 extension View {

--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct AboutEditorView: View {
     private enum Constants {
         static let primaryFont: Font = .subheadline
-        static let sectionHeaderFont: Font = .subheadline.weight(.bold)
+        static let sectionHeaderFont: Font = .subheadline.weight(.semibold)
         static let footerFont: Font = .footnote
     }
 

--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+struct AboutEditorView: View {
+    @ObservedObject var model: AvatarPickerViewModel
+    let fields: AboutInfoField
+    @StateObject private var inputFields: AboutInputFields = .init()
+    @Environment(\.colorScheme) var colorScheme: ColorScheme
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: .DS.Padding.double) {
+                personalInfoContent()
+            }
+            .padding(.DS.Padding.double)
+            .avatarPickerBorder(colorScheme: colorScheme, borderWidth: 1)
+            .padding(.horizontal, .DS.Padding.double)
+        }
+    }
+
+    @ViewBuilder
+    func personalInfoContent() -> some View {
+        if fields.contains(.displayName) {
+            inputField(
+                for: AboutInfoField.displayName.localizedName(),
+                value: $inputFields.displayName
+            )
+        }
+        if fields.contains(.aboutMe) {
+            inputField(
+                for: AboutInfoField.aboutMe.localizedName(),
+                value: $inputFields.aboutMe,
+                isLarge: true
+            )
+        }
+        if fields.contains(.pronunciation) {
+            inputField(
+                for: AboutInfoField.pronunciation.localizedName(),
+                value: $inputFields.pronunciation
+            )
+        }
+        if fields.contains(.pronouns) {
+            inputField(
+                for: AboutInfoField.pronouns.localizedName(),
+                value: $inputFields.pronouns
+            )
+        }
+        if fields.contains(.location) {
+            inputField(
+                for: AboutInfoField.location.localizedName(),
+                value: $inputFields.location
+            )
+        }
+    }
+
+    private func inputField(
+        for title: String,
+        footerText: String? = nil,
+        value: Binding<String>,
+        isLarge: Bool = false
+    ) -> some View {
+        VStack(alignment: .leading, spacing: .DS.Padding.single) {
+            Text(title)
+                .font(.subheadline)
+                .multilineTextAlignment(.leading)
+            if isLarge {
+                TextEditor(text: value)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity)
+                    .padding(.DS.Padding.split)
+                    .shape(
+                        RoundedRectangle(cornerRadius: 2),
+                        borderColor: Color(uiColor: .label.withAlphaComponent(0.15)),
+                        borderWidth: 1
+                    )
+                    .frame(height: dynamicTypeSize >= .accessibility1 ? 150 : 120)
+            } else {
+                TextField(
+                    "",
+                    text: value
+                )
+                .lineLimit(isLarge ? 4 : 1)
+                .frame(maxWidth: .infinity)
+                .padding(.DS.Padding.split)
+                .shape(
+                    RoundedRectangle(cornerRadius: 2),
+                    borderColor: Color(uiColor: .label.withAlphaComponent(0.15)),
+                    borderWidth: 1
+                )
+            }
+
+            if let footerText {
+                Text(footerText)
+                    .font(.subheadline)
+                    .multilineTextAlignment(.leading)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+fileprivate class AboutInputFields: ObservableObject {
+    @Published var displayName: String = ""
+    @Published var aboutMe: String = ""
+    @Published var pronunciation: String = ""
+    @Published var pronouns: String = ""
+    @Published var location: String = ""
+
+    func convertToUpdatedFields(for fields: AboutInfoField) -> UpdatedFields {
+        UpdatedFields(
+            displayName: fields.contains(.aboutMe) ? aboutMe : nil,
+            aboutMe: fields.contains(.aboutMe) ? aboutMe : nil,
+            pronunciation: fields.contains(.pronunciation) ? pronunciation : nil,
+            pronouns: fields.contains(.pronouns) ? pronouns : nil,
+            location: fields.contains(.location) ? location : nil
+        )
+    }
+}
+
+struct UpdatedFields {
+    var displayName: String? = nil
+    var aboutMe: String? = nil
+    var pronunciation: String? = nil
+    var pronouns: String? = nil
+    var location: String? = nil
+}
+
+#Preview {
+    AboutEditorView(model: .init(avatarImageModels: []), fields: .all)
+}

--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
@@ -1,6 +1,12 @@
 import SwiftUI
 
 struct AboutEditorView: View {
+    private enum Constants {
+        static let primaryFont: Font = .subheadline
+        static let sectionHeaderFont: Font = .subheadline.weight(.bold)
+        static let footerFont: Font = .footnote
+    }
+
     @ObservedObject var model: AvatarPickerViewModel
     let fields: AboutInfoField
     @StateObject private var inputFields: AboutInputFields = .init()
@@ -9,17 +15,34 @@ struct AboutEditorView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: .DS.Padding.double) {
+            VStack(alignment: .leading, spacing: 0) {
                 personalInfoContent()
+                Spacer().frame(height: .DS.Padding.double)
+                professionalInfoContent()
             }
             .padding(.DS.Padding.double)
             .avatarPickerBorder(colorScheme: colorScheme, borderWidth: 1)
             .padding(.horizontal, .DS.Padding.double)
+            Spacer().frame(height: .DS.Padding.double)
+        }
+        saveButton()
+            .padding(.horizontal, .DS.Padding.large)
+            .padding(.bottom, .DS.Padding.double)
+    }
+
+    private func saveButton() -> some View {
+        Button {
+            print("")
+        } label: {
+            CTAButtonView(Localized.saveButtonTitle)
         }
     }
 
     @ViewBuilder
     private func personalInfoContent() -> some View {
+        if hasMultipleSections {
+            sectionHeader(title: Localized.personalSectionHeaderText)
+        }
         if fields.contains(.displayName) {
             inputField(
                 for: AboutInfoField.displayName.localizedName(),
@@ -55,6 +78,32 @@ struct AboutEditorView: View {
         }
     }
 
+    @ViewBuilder
+    private func professionalInfoContent() -> some View {
+        if hasMultipleSections {
+            sectionHeader(title: Localized.professionalSectionHeaderText)
+        }
+        if fields.contains(.jobTitle) {
+            inputField(
+                for: AboutInfoField.jobTitle.localizedName(),
+                value: $inputFields.jobTitle
+            )
+        }
+        if fields.contains(.company) {
+            inputField(
+                for: AboutInfoField.company.localizedName(),
+                value: $inputFields.company
+            )
+        }
+    }
+
+    private func sectionHeader(title: String) -> some View {
+        Text(title)
+            .font(Constants.sectionHeaderFont)
+            .multilineTextAlignment(.leading)
+            .padding(.bottom, .DS.Padding.single)
+    }
+
     private func inputField(
         for title: String,
         footerText: String? = nil,
@@ -63,11 +112,11 @@ struct AboutEditorView: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: .DS.Padding.single) {
             Text(title)
-                .font(.subheadline)
+                .font(Constants.primaryFont)
                 .multilineTextAlignment(.leading)
             if isLarge {
                 TextEditor(text: value)
-                    .font(.subheadline)
+                    .font(Constants.primaryFont)
                     .multilineTextAlignment(.leading)
                     .padding(.DS.Padding.split)
                     .inputBorders(colorScheme: colorScheme)
@@ -77,19 +126,25 @@ struct AboutEditorView: View {
                     "",
                     text: value
                 )
-                .font(.subheadline)
+                .font(Constants.primaryFont)
                 .padding(.DS.Padding.split)
                 .inputBorders(colorScheme: colorScheme)
             }
 
             if let footerText {
                 Text(footerText)
-                    .font(.footnote)
+                    .font(Constants.footerFont)
                     .multilineTextAlignment(.leading)
                     .foregroundColor(Color(uiColor: UIColor.secondaryLabel))
             }
         }
+        .padding(.vertical, .DS.Padding.single)
         .frame(maxWidth: .infinity)
+    }
+
+    private var hasMultipleSections: Bool {
+        (fields.contains(.personalFields) ? 1 : 0) +
+            (fields.contains(.professionalFields) ? 1 : 0) > 1
     }
 
     private enum Localized {
@@ -103,6 +158,21 @@ struct AboutEditorView: View {
             value: "Let them know how your name sounds like.",
             comment: "Description for the 'Pronunciation' field in the profile editing screen."
         )
+        static let personalSectionHeaderText = SDKLocalizedString(
+            "Profile.Section.Personal.header",
+            value: "Personal",
+            comment: "Title of the personal info section in the profile editing screen."
+        )
+        static let professionalSectionHeaderText = SDKLocalizedString(
+            "Profile.Section.Professional.header",
+            value: "Professional",
+            comment: "Title of the professional/work info section in the profile editing screen."
+        )
+        static let saveButtonTitle = SDKLocalizedString(
+            "Profile.Save.title",
+            value: "Save",
+            comment: "Title of the button to save changes in the profile editing screen."
+        )
     }
 }
 
@@ -112,24 +182,30 @@ private class AboutInputFields: ObservableObject {
     @Published var pronunciation: String = ""
     @Published var pronouns: String = ""
     @Published var location: String = ""
+    @Published var jobTitle: String = ""
+    @Published var company: String = ""
 
-    func convertToUpdatedFields(for fields: AboutInfoField) -> UpdatedFields {
-        UpdatedFields(
+    func fieldsToUpdate(from fields: AboutInfoField) -> FieldsToUpdate {
+        FieldsToUpdate(
             displayName: fields.contains(.aboutMe) ? aboutMe : nil,
             aboutMe: fields.contains(.aboutMe) ? aboutMe : nil,
             pronunciation: fields.contains(.pronunciation) ? pronunciation : nil,
             pronouns: fields.contains(.pronouns) ? pronouns : nil,
-            location: fields.contains(.location) ? location : nil
+            location: fields.contains(.location) ? location : nil,
+            jobTitle: fields.contains(.jobTitle) ? jobTitle : nil,
+            company: fields.contains(.company) ? company : nil
         )
     }
 }
 
-struct UpdatedFields {
+struct FieldsToUpdate {
     var displayName: String? = nil
     var aboutMe: String? = nil
     var pronunciation: String? = nil
     var pronouns: String? = nil
     var location: String? = nil
+    var jobTitle: String? = nil
+    var company: String? = nil
 }
 
 extension View {
@@ -144,4 +220,12 @@ extension View {
 
 #Preview {
     AboutEditorView(model: .init(avatarImageModels: []), fields: .all)
+}
+
+#Preview("professional") {
+    AboutEditorView(model: .init(avatarImageModels: []), fields: .professionalFields)
+}
+
+#Preview("personal") {
+    AboutEditorView(model: .init(avatarImageModels: []), fields: .personalFields)
 }

--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
@@ -67,6 +67,7 @@ struct AboutEditorView: View {
                 .multilineTextAlignment(.leading)
             if isLarge {
                 TextEditor(text: value)
+                    .font(.subheadline)
                     .multilineTextAlignment(.leading)
                     .padding(.DS.Padding.split)
                     .inputBorders(colorScheme: colorScheme)
@@ -76,13 +77,14 @@ struct AboutEditorView: View {
                     "",
                     text: value
                 )
+                .font(.subheadline)
                 .padding(.DS.Padding.split)
                 .inputBorders(colorScheme: colorScheme)
             }
 
             if let footerText {
                 Text(footerText)
-                    .font(.subheadline)
+                    .font(.footnote)
                     .multilineTextAlignment(.leading)
                     .foregroundColor(Color(uiColor: UIColor.secondaryLabel))
             }

--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
@@ -11,6 +11,7 @@ struct AboutEditorView: View {
     let fields: AboutInfoField
     @Environment(\.colorScheme) var colorScheme: ColorScheme
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    var aboutUpdateHandler: (() -> Void)?
 
     var body: some View {
         VStack {
@@ -38,7 +39,9 @@ struct AboutEditorView: View {
     private func saveButton() -> some View {
         Button {
             Task {
-                await self.model.saveAboutInfo(for: fields)
+                if await self.model.saveAboutInfo(for: fields) {
+                    aboutUpdateHandler?()
+                }
             }
         } label: {
             CTAButtonView(Localized.saveButtonTitle)

--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
@@ -121,7 +121,8 @@ struct AboutEditorView: View {
                 TextEditor(text: value)
                     .font(Constants.primaryFont)
                     .multilineTextAlignment(.leading)
-                    .padding(.DS.Padding.split)
+                    .padding(.horizontal, .DS.Padding.single)
+                    .padding(.vertical, 0)
                     .inputBorders(colorScheme: colorScheme)
                     .frame(height: dynamicTypeSize >= .accessibility1 ? 150 : 120)
             } else {

--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
@@ -19,7 +19,7 @@ struct AboutEditorView: View {
     }
 
     @ViewBuilder
-    func personalInfoContent() -> some View {
+    private func personalInfoContent() -> some View {
         if fields.contains(.displayName) {
             inputField(
                 for: AboutInfoField.displayName.localizedName(),
@@ -29,6 +29,7 @@ struct AboutEditorView: View {
         if fields.contains(.aboutMe) {
             inputField(
                 for: AboutInfoField.aboutMe.localizedName(),
+                footerText: Localized.aboutMeFooterText,
                 value: $inputFields.aboutMe,
                 isLarge: true
             )
@@ -36,6 +37,7 @@ struct AboutEditorView: View {
         if fields.contains(.pronunciation) {
             inputField(
                 for: AboutInfoField.pronunciation.localizedName(),
+                footerText: Localized.pronunciationFooterText,
                 value: $inputFields.pronunciation
             )
         }
@@ -66,7 +68,6 @@ struct AboutEditorView: View {
             if isLarge {
                 TextEditor(text: value)
                     .multilineTextAlignment(.leading)
-                    .frame(maxWidth: .infinity)
                     .padding(.DS.Padding.split)
                     .shape(
                         RoundedRectangle(cornerRadius: 2),
@@ -79,8 +80,6 @@ struct AboutEditorView: View {
                     "",
                     text: value
                 )
-                .lineLimit(isLarge ? 4 : 1)
-                .frame(maxWidth: .infinity)
                 .padding(.DS.Padding.split)
                 .shape(
                     RoundedRectangle(cornerRadius: 2),
@@ -93,9 +92,23 @@ struct AboutEditorView: View {
                 Text(footerText)
                     .font(.subheadline)
                     .multilineTextAlignment(.leading)
+                    .foregroundColor(Color(uiColor: UIColor.secondaryLabel))
             }
         }
         .frame(maxWidth: .infinity)
+    }
+    
+    private enum Localized {
+        static let aboutMeFooterText = SDKLocalizedString(
+            "Profile.AboutInfoField.aboutMe.footer",
+            value: "Brief description for your profile.",
+            comment: "Description for the 'About me' field in the profile editing screen."
+        )
+        static let pronunciationFooterText = SDKLocalizedString(
+            "Profile.AboutInfoField.pronunciation.footer",
+            value: "Let them know how your name sounds like.",
+            comment: "Description for the 'Pronunciation' field in the profile editing screen."
+        )
     }
 }
 

--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
@@ -69,11 +69,7 @@ struct AboutEditorView: View {
                 TextEditor(text: value)
                     .multilineTextAlignment(.leading)
                     .padding(.DS.Padding.split)
-                    .shape(
-                        RoundedRectangle(cornerRadius: 2),
-                        borderColor: Color(uiColor: .label.withAlphaComponent(0.15)),
-                        borderWidth: 1
-                    )
+                    .inputBorders(colorScheme: colorScheme)
                     .frame(height: dynamicTypeSize >= .accessibility1 ? 150 : 120)
             } else {
                 TextField(
@@ -81,11 +77,7 @@ struct AboutEditorView: View {
                     text: value
                 )
                 .padding(.DS.Padding.split)
-                .shape(
-                    RoundedRectangle(cornerRadius: 2),
-                    borderColor: Color(uiColor: .label.withAlphaComponent(0.15)),
-                    borderWidth: 1
-                )
+                .inputBorders(colorScheme: colorScheme)
             }
 
             if let footerText {
@@ -97,7 +89,7 @@ struct AboutEditorView: View {
         }
         .frame(maxWidth: .infinity)
     }
-    
+
     private enum Localized {
         static let aboutMeFooterText = SDKLocalizedString(
             "Profile.AboutInfoField.aboutMe.footer",
@@ -112,7 +104,7 @@ struct AboutEditorView: View {
     }
 }
 
-fileprivate class AboutInputFields: ObservableObject {
+private class AboutInputFields: ObservableObject {
     @Published var displayName: String = ""
     @Published var aboutMe: String = ""
     @Published var pronunciation: String = ""
@@ -136,6 +128,16 @@ struct UpdatedFields {
     var pronunciation: String? = nil
     var pronouns: String? = nil
     var location: String? = nil
+}
+
+extension View {
+    fileprivate func inputBorders(colorScheme: ColorScheme) -> some View {
+        self.shape(
+            RoundedRectangle(cornerRadius: 2),
+            borderColor: Color(uiColor: .label).opacity(colorScheme == .dark ? 0.30 : 0.15),
+            borderWidth: 1
+        )
+    }
 }
 
 #Preview {

--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
@@ -13,19 +13,23 @@ struct AboutEditorView: View {
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                personalInfoContent()
-                if fields.hasMultipleCategories {
-                    Spacer().frame(height: .DS.Padding.double)
+        VStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    personalInfoContent()
+                    if fields.hasMultipleCategories {
+                        Spacer().frame(height: .DS.Padding.double)
+                    }
+                    professionalInfoContent()
                 }
-                professionalInfoContent()
+                .padding(.horizontal, .DS.Padding.double)
+                .padding(.vertical, .DS.Padding.double)
             }
-            .padding(.DS.Padding.double)
-            .avatarPickerBorder(colorScheme: colorScheme, borderWidth: 1)
-            .padding(.horizontal, .DS.Padding.double)
-            Spacer().frame(height: .DS.Padding.double)
         }
+        .avatarPickerBorder(colorScheme: colorScheme, borderWidth: 1)
+        .padding(.horizontal, .DS.Padding.double)
+        Spacer().frame(height: .DS.Padding.double)
+
         saveButton()
             .padding(.horizontal, .DS.Padding.large)
             .padding(.bottom, .DS.Padding.double)

--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutInfoModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutInfoModel.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+class AboutInfoModel: ObservableObject {
+    @Published var displayName: String = ""
+    @Published var aboutMe: String = ""
+    @Published var pronunciation: String = ""
+    @Published var pronouns: String = ""
+    @Published var location: String = ""
+    @Published var jobTitle: String = ""
+    @Published var company: String = ""
+
+    init() {}
+
+    init(displayName: String, aboutMe: String, pronunciation: String, pronouns: String, location: String, jobTitle: String, company: String) {
+        self.displayName = displayName
+        self.aboutMe = aboutMe
+        self.pronunciation = pronunciation
+        self.pronouns = pronouns
+        self.location = location
+        self.jobTitle = jobTitle
+        self.company = company
+    }
+
+    func updateProfileRequest(for fields: AboutInfoField) -> UpdateProfileRequest {
+        UpdateProfileRequest(
+            displayName: fields.contains(.displayName) ? displayName : nil,
+            description: fields.contains(.aboutMe) ? aboutMe : nil,
+            pronunciation: fields.contains(.pronunciation) ? pronunciation : nil,
+            pronouns: fields.contains(.pronouns) ? pronouns : nil,
+            location: fields.contains(.location) ? location : nil,
+            jobTitle: fields.contains(.jobTitle) ? jobTitle : nil,
+            company: fields.contains(.company) ? company : nil
+        )
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -45,7 +45,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
     fileprivate init(
         avatarImageModels: [AvatarImageModel],
         selectedImageID: String? = nil,
-        profileModel: ProfileSummaryModel? = nil,
+        profileModel: Profile? = nil,
         isPresented: Binding<Bool>,
         contentLayoutProvider: AvatarPickerContentLayoutProviding = AvatarPickerContentLayoutType.vertical,
         customImageEditor: ImageEditorBlock<ImageEditor>? = nil as NoCustomEditorBlock?,
@@ -580,40 +580,6 @@ enum AvatarPicker {
 // MARK: - Previews
 
 #Preview("Existing elements") {
-    struct PreviewModel: ProfileSummaryModel {
-        var avatarIdentifier: Gravatar.AvatarIdentifier? {
-            .email("some@email.com")
-        }
-
-        var displayName: String {
-            "Shelly Kimbrough"
-        }
-
-        var jobTitle: String {
-            "Payroll clerk"
-        }
-
-        var pronunciation: String {
-            "shell-ee"
-        }
-
-        var pronouns: String {
-            "she/her"
-        }
-
-        var location: String {
-            "San Antonio, TX"
-        }
-
-        var profileURL: URL? {
-            URL(string: "https://gravatar.com")
-        }
-
-        var profileEditURL: URL? {
-            URL(string: "https://gravatar.com")
-        }
-    }
-
     let avatarImageModels: [AvatarImageModel] = [
         .preview_init(id: "0", source: .local(image: UIImage()), state: .loading),
         .preview_init(id: "1", source: .remote(url: "https://gravatar.com/userimage/110207384/aa5f129a2ec75162cee9a1f0c472356a.jpeg?size=256")),
@@ -626,12 +592,11 @@ enum AvatarPicker {
         .preview_init(id: "8", source: .local(image: UIImage()), state: .error(supportsRetry: false, errorMessage: "Something went wrong.")),
     ]
     let selectedImageID = "5"
-    let profileModel = PreviewModel()
 
-    return AvatarPickerView<NoCustomEditor>(
+    AvatarPickerView<NoCustomEditor>(
         avatarImageModels: avatarImageModels,
         selectedImageID: selectedImageID,
-        profileModel: profileModel,
+        profileModel: nil,
         isPresented: .constant(true),
         contentLayoutProvider: AvatarPickerContentLayoutType.horizontal
     )

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -245,15 +245,17 @@ class AvatarPickerViewModel: ObservableObject {
         }
     }
 
-    func saveAboutInfo(for fields: AboutInfoField) async {
-        guard let authToken else { return }
+    func saveAboutInfo(for fields: AboutInfoField) async -> Bool {
+        guard let authToken else { return false }
         do {
             let request = aboutInfoModel.updateProfileRequest(for: fields)
             let updatedProfile = try await profileService.updateProfile(with: request, token: authToken)
             self.profileResult = .success(updatedProfile)
+            return true
         } catch {
             // TODO: Handle errors properly.
             toastManager.showToast(error.localizedDescription, type: .error)
+            return false
         }
     }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -29,13 +29,14 @@ class AvatarPickerViewModel: ObservableObject {
     @Published private(set) var backendSelectedAvatarURL: URL?
     @Published private(set) var gridResponseStatus: Result<Void, Error>?
     @Published private(set) var grid: AvatarGridModel = .init(avatars: [])
-    @Published private(set) var profileResult: Result<ProfileSummaryModel, Error>?
+    @Published private(set) var profileResult: Result<Profile, Error>?
 
     @Published var isProfileLoading: Bool = false
     @Published private(set) var isAvatarsLoading: Bool = false
     @Published var avatarIdentifier: AvatarIdentifier?
     @Published var forceRefreshAvatar: Bool = false
     @Published var profileModel: AvatarPickerProfileView.Model?
+    @Published var aboutInfoModel: AboutInfoModel = .init()
     @Published var shouldDisplayNoSelectedAvatarWarning: Bool = false
     @ObservedObject var toastManager: ToastManager = .init()
     private var cancellables = Set<AnyCancellable>()
@@ -60,7 +61,7 @@ class AvatarPickerViewModel: ObservableObject {
     init(
         avatarImageModels: [AvatarImageModel],
         selectedImageID: String? = nil,
-        profileModel: ProfileSummaryModel? = nil,
+        profileModel: Profile? = nil,
         profileService: ProfileService? = nil,
         avatarService: AvatarService? = nil,
         imageDownloader: ImageDownloader? = nil
@@ -118,6 +119,15 @@ class AvatarPickerViewModel: ObservableObject {
                     displayName: value.displayName,
                     location: value.location,
                     profileURL: value.profileURL
+                )
+                self?.aboutInfoModel = AboutInfoModel(
+                    displayName: value.displayName,
+                    aboutMe: value.description,
+                    pronunciation: value.pronunciation,
+                    pronouns: value.pronouns,
+                    location: value.location,
+                    jobTitle: value.jobTitle,
+                    company: value.company
                 )
             default:
                 self?.profileModel = nil
@@ -232,6 +242,18 @@ class AvatarPickerViewModel: ObservableObject {
         } catch {
             profileResult = .failure(error)
             isProfileLoading = false
+        }
+    }
+
+    func saveAboutInfo(for fields: AboutInfoField) async {
+        guard let authToken else { return }
+        do {
+            let request = aboutInfoModel.updateProfileRequest(for: fields)
+            let updatedProfile = try await profileService.updateProfile(with: request, token: authToken)
+            self.profileResult = .success(updatedProfile)
+        } catch {
+            // TODO: Handle errors properly.
+            toastManager.showToast(error.localizedDescription, type: .error)
         }
     }
 

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -134,7 +134,10 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
         case .aboutInfoEditor:
             AboutEditorView(
                 model: model,
-                fields: scopeOption.aboutEditorConfig.fields
+                fields: scopeOption.aboutEditorConfig.fields,
+                aboutUpdateHandler: {
+                    updateHandler?(.aboutInfoUpdate)
+                }
             )
         }
     }

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -132,9 +132,10 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
                 }
             )
         case .aboutInfoEditor:
-            Text("About info view")
-            UpdateProfileTestView(token: token)
-            Spacer()
+            AboutEditorView(
+                model: model,
+                fields: scopeOption.aboutEditorConfig.fields
+            )
         }
     }
 
@@ -300,54 +301,4 @@ enum QuickEditorConstants {
         scopeOption: .aboutEditor(.init()),
         isPresented: .constant(true)
     )
-}
-
-struct UpdateProfileTestView: View {
-    let token: String
-
-    @State private var userName: String = ""
-    @State private var responseUserName: String = ""
-    @State private var error: Error?
-
-    var body: some View {
-        TextField("User name", text: $userName)
-        Button(action: {
-            Task {
-                await updateUserName()
-            }
-        }, label: {
-            Text("Update user name")
-        })
-        Text("Response user name: \(responseUserName)")
-        if let error = error as? APIError {
-            ScrollView {
-                switch error {
-                case .responseError(let reason):
-                    switch reason {
-                    case .URLSessionError(let error):
-                        Text(error.localizedDescription)
-                    case .invalidHTTPStatusCode(let response, let errorPayload):
-                        Text("\(response.statusCode) " + (errorPayload?.message ?? ""))
-                    case .invalidURLResponse(let response):
-                        Text(String(describing: response))
-                    case .unexpected(let error):
-                        Text(String(describing: error))
-                    }
-                case .decodingError(let decodingError):
-                    Text(String(describing: decodingError.localizedDescription))
-                default: Text("Unknown error")
-                }
-            }
-        }
-    }
-
-    func updateUserName() async {
-        let service = ProfileService()
-        do {
-            let profile = try await service.updateProfile(with: .init(displayName: userName), token: token)
-            responseUserName = profile.displayName
-        } catch {
-            self.error = error
-        }
-    }
 }

--- a/Tests/GravatarUITests/AboutInfoFieldTests.swift
+++ b/Tests/GravatarUITests/AboutInfoFieldTests.swift
@@ -1,7 +1,7 @@
 @testable import GravatarUI
 import Testing
 
-@Suite("AboutInfoFieldTests")
+@Suite
 struct AboutInfoFieldTests {
     
     @Test

--- a/Tests/GravatarUITests/AboutInfoFieldTests.swift
+++ b/Tests/GravatarUITests/AboutInfoFieldTests.swift
@@ -13,8 +13,8 @@ struct AboutInfoFieldTests {
             .pronouns,
             .location,
         ]
-        #expect(AboutInfoField.personalFields.contains(fields), "`AboutInfoField.personalFields` convenience property does not include necessary fields")
-        #expect(AboutInfoField.personalFields.symmetricDifference(fields).isEmpty, "`AboutInfoField.personalFields` convenience property has unwanted fields")
+        #expect(AboutInfoField.personalFields.contains(fields), "`AboutInfoField.personalFields` convenience property must contain the necessary fields")
+        #expect(AboutInfoField.personalFields.symmetricDifference(fields).isEmpty, "`AboutInfoField.personalFields` convenience must not have unwanted fields")
     }
     
     @Test
@@ -23,8 +23,8 @@ struct AboutInfoFieldTests {
             .jobTitle,
             .company,
         ]
-        #expect(AboutInfoField.professionalFields.contains(fields), "`AboutInfoField.professionalFields` convenience property does not include necessary fields")
-        #expect(AboutInfoField.professionalFields.symmetricDifference(fields).isEmpty, "`AboutInfoField.professionalFields` convenience property has unwanted fields")
+        #expect(AboutInfoField.professionalFields.contains(fields), "`AboutInfoField.professionalFields` convenience property must contain the necessary fields")
+        #expect(AboutInfoField.professionalFields.symmetricDifference(fields).isEmpty, "`AboutInfoField.professionalFields` convenience must not have unwanted fields")
     }
     
     @Test
@@ -39,8 +39,8 @@ struct AboutInfoFieldTests {
             .company,
         ]
 
-        #expect(AboutInfoField.all.contains(fields), "`AboutInfoField.all` convenience property does not include necessary fields")
-        #expect(AboutInfoField.all.symmetricDifference(fields).isEmpty, "`AboutInfoField.all` convenience property has unwanted fields")
+        #expect(AboutInfoField.all.contains(fields), "`AboutInfoField.all` convenience property must contain the necessary fields")
+        #expect(AboutInfoField.all.symmetricDifference(fields).isEmpty, "`AboutInfoField.all` convenience must not have unwanted fields")
     }
 
     @Test
@@ -61,7 +61,7 @@ struct AboutInfoFieldTests {
                 let mergedFields = personalField.union(professionalField)
                 #expect(
                     mergedFields.hasMultipleCategories == true,
-                    "Different combinations of `personal` and `professional` fields mean that there are multiple categories in this set. So we should expect `hasMultipleCategories` to be true."
+                    "Different combinations of `personal` and `professional` fields mean that there are multiple categories in this set. So we expect `hasMultipleCategories` to be true."
                 )
             }
         }
@@ -71,11 +71,11 @@ struct AboutInfoFieldTests {
     func testMultipleSectionsDontExist() async throws {
         #expect(
             AboutInfoField.personalFields.hasMultipleCategories == false,
-            "`personalFields` convenience property corresponds to a single category. So we should expect `hasMultipleCategories` to be false"
+            "`personalFields` convenience property corresponds to a single category. So we expect `hasMultipleCategories` to be false"
         )
         #expect(
             AboutInfoField.professionalFields.hasMultipleCategories == false,
-            "`professionalFields` convenience property corresponds to a single category. So we should expect `hasMultipleCategories` to be false"
+            "`professionalFields` convenience property corresponds to a single category. So we expect `hasMultipleCategories` to be false"
         )
     }
 }

--- a/Tests/GravatarUITests/AboutInfoFieldTests.swift
+++ b/Tests/GravatarUITests/AboutInfoFieldTests.swift
@@ -1,0 +1,81 @@
+@testable import GravatarUI
+import Testing
+
+@Suite("AboutInfoFieldTests")
+struct AboutInfoFieldTests {
+    
+    @Test
+    func testPersonalFields() async throws {
+        let fields: AboutInfoField = [
+            .displayName,
+            .aboutMe,
+            .pronunciation,
+            .pronouns,
+            .location,
+        ]
+        #expect(AboutInfoField.personalFields.contains(fields), "`AboutInfoField.personalFields` convenience property does not include necessary fields")
+        #expect(AboutInfoField.personalFields.symmetricDifference(fields).isEmpty, "`AboutInfoField.personalFields` convenience property has unwanted fields")
+    }
+    
+    @Test
+    func testProfessionalFields() async throws {
+        let fields: AboutInfoField = [
+            .jobTitle,
+            .company,
+        ]
+        #expect(AboutInfoField.professionalFields.contains(fields), "`AboutInfoField.professionalFields` convenience property does not include necessary fields")
+        #expect(AboutInfoField.professionalFields.symmetricDifference(fields).isEmpty, "`AboutInfoField.professionalFields` convenience property has unwanted fields")
+    }
+    
+    @Test
+    func testAllFields() async throws {
+        let fields: AboutInfoField = [
+            .displayName,
+            .aboutMe,
+            .pronunciation,
+            .pronouns,
+            .location,
+            .jobTitle,
+            .company,
+        ]
+
+        #expect(AboutInfoField.all.contains(fields), "`AboutInfoField.all` convenience property does not include necessary fields")
+        #expect(AboutInfoField.all.symmetricDifference(fields).isEmpty, "`AboutInfoField.all` convenience property has unwanted fields")
+    }
+
+    @Test
+    func testMultipleSectionsExist() async throws {
+        let personalFields: [AboutInfoField] = [
+            .displayName,
+            .aboutMe,
+            .pronunciation,
+            .pronouns,
+            .location,
+        ]
+        let professionalFields: [AboutInfoField] = [
+            .jobTitle,
+            .company,
+        ]
+        for personalField in personalFields {
+            for professionalField in professionalFields {
+                let mergedFields = personalField.union(professionalField)
+                #expect(
+                    mergedFields.hasMultipleCategories == true,
+                    "Different combinations of `personal` and `professional` fields mean that there are multiple categories in this set. So we should expect `hasMultipleCategories` to be true."
+                )
+            }
+        }
+    }
+
+    @Test
+    func testMultipleSectionsDontExist() async throws {
+        #expect(
+            AboutInfoField.personalFields.hasMultipleCategories == false,
+            "`personalFields` convenience property corresponds to a single category. So we should expect `hasMultipleCategories` to be false"
+        )
+        #expect(
+            AboutInfoField.professionalFields.hasMultipleCategories == false,
+            "`professionalFields` convenience property corresponds to a single category. So we should expect `hasMultipleCategories` to be false"
+        )
+    }
+}

--- a/Tests/GravatarUITests/AboutInfoFieldTests.swift
+++ b/Tests/GravatarUITests/AboutInfoFieldTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite
 struct AboutInfoFieldTests {
-    
     @Test
     func testPersonalFields() async throws {
         let fields: AboutInfoField = [
@@ -16,17 +15,23 @@ struct AboutInfoFieldTests {
         #expect(AboutInfoField.personalFields.contains(fields), "`AboutInfoField.personalFields` convenience property must contain the necessary fields")
         #expect(AboutInfoField.personalFields.symmetricDifference(fields).isEmpty, "`AboutInfoField.personalFields` convenience must not have unwanted fields")
     }
-    
+
     @Test
     func testProfessionalFields() async throws {
         let fields: AboutInfoField = [
             .jobTitle,
             .company,
         ]
-        #expect(AboutInfoField.professionalFields.contains(fields), "`AboutInfoField.professionalFields` convenience property must contain the necessary fields")
-        #expect(AboutInfoField.professionalFields.symmetricDifference(fields).isEmpty, "`AboutInfoField.professionalFields` convenience must not have unwanted fields")
+        #expect(
+            AboutInfoField.professionalFields.contains(fields),
+            "`AboutInfoField.professionalFields` convenience property must contain the necessary fields"
+        )
+        #expect(
+            AboutInfoField.professionalFields.symmetricDifference(fields).isEmpty,
+            "`AboutInfoField.professionalFields` convenience must not have unwanted fields"
+        )
     }
-    
+
     @Test
     func testAllFields() async throws {
         let fields: AboutInfoField = [

--- a/Tests/GravatarUITests/AboutInfoModelTests.swift
+++ b/Tests/GravatarUITests/AboutInfoModelTests.swift
@@ -1,0 +1,41 @@
+import Testing
+@testable import GravatarUI
+
+@Suite
+struct AboutInfoModelTests {
+
+    @Test func testCreateUpdateProfileRequestForAllFields() async throws {
+        let model = aboutInfoModel()
+        let request = model.updateProfileRequest(for: AboutInfoField.all)
+        #expect(request.displayName == model.displayName)
+        #expect(request.description == model.aboutMe)
+        #expect(request.pronunciation == model.pronunciation)
+        #expect(request.pronouns == model.pronouns)
+        #expect(request.location == model.location)
+        #expect(request.jobTitle == model.jobTitle)
+        #expect(request.company == model.company)
+    }
+
+    @Test("If the passed `AboutInfoField` set is empty, the request should be empty")
+    func testCreateUpdateProfileRequestForEmptySet() async throws {
+        let model = aboutInfoModel()
+        let request = model.updateProfileRequest(for: [])
+        #expect(request.displayName == nil)
+        #expect(request.description == nil)
+        #expect(request.pronunciation == nil)
+        #expect(request.pronouns == nil)
+        #expect(request.location == nil)
+        #expect(request.jobTitle == nil)
+        #expect(request.company == nil)
+    }
+
+    private func aboutInfoModel() -> AboutInfoModel {
+        return AboutInfoModel(displayName: "displayName",
+                              aboutMe: "aboutMe",
+                              pronunciation: "pronunciation",
+                              pronouns: "pronouns",
+                              location: "location",
+                              jobTitle: "jobTitle",
+                              company: "company")
+    }
+}

--- a/Tests/GravatarUITests/AboutInfoModelTests.swift
+++ b/Tests/GravatarUITests/AboutInfoModelTests.swift
@@ -1,10 +1,10 @@
-import Testing
 @testable import GravatarUI
+import Testing
 
 @Suite
 struct AboutInfoModelTests {
-
-    @Test func testCreateUpdateProfileRequestForAllFields() async throws {
+    @Test
+    func testCreateUpdateProfileRequestForAllFields() async throws {
         let model = aboutInfoModel()
         let request = model.updateProfileRequest(for: AboutInfoField.all)
         #expect(request.displayName == model.displayName)
@@ -30,12 +30,14 @@ struct AboutInfoModelTests {
     }
 
     private func aboutInfoModel() -> AboutInfoModel {
-        return AboutInfoModel(displayName: "displayName",
-                              aboutMe: "aboutMe",
-                              pronunciation: "pronunciation",
-                              pronouns: "pronouns",
-                              location: "location",
-                              jobTitle: "jobTitle",
-                              company: "company")
+        AboutInfoModel(
+            displayName: "displayName",
+            aboutMe: "aboutMe",
+            pronunciation: "pronunciation",
+            pronouns: "pronouns",
+            location: "location",
+            jobTitle: "jobTitle",
+            company: "company"
+        )
     }
 }


### PR DESCRIPTION
Closes #709 #711 #712

### Description

Adds the input fields and the ability to save changes.

<img src="https://github.com/user-attachments/assets/7597c0f2-2ade-45e8-b3a0-df0f86ae650c" width=300 />


### Testing Steps

Go to QuickEditor demo screens for both SwiftUI and UIKit
Select the "about" scope
Use the "Select input fields" button to select the fields you want to test
Open the QE 
Observe that the input fields are filled from the network
Change some fields and tap Save
Observe that the changes are reflected in the profile card (or check them via "View profile" button)
