### PR TITLE
Use associated values for scopes

### DIFF
--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -81,7 +81,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
         self.externalToken = token
         self.updateHandler = updateHandler
         self._model = StateObject(wrappedValue: AvatarPickerViewModel(email: email, authToken: token))
-        if scopeOption.scope == .avatarPickerAndAboutInfoEditor {
+        if scopeOption.isAvatarPickerAndAboutInfoEditor {
             _multipleEditorMode = State(initialValue: .avatarPicker)
         }
     }
@@ -124,11 +124,11 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
         }
     }
 
-    var avatarPickerView: some View {
+    func avatarPickerView(config: AvatarPickerConfiguration) -> some View {
         AvatarPickerView(
             model: model,
             isPresented: $isPresented,
-            contentLayoutProvider: scopeOption.avatarPickerConfig.contentLayout,
+            contentLayoutProvider: config.contentLayout,
             customImageEditor: customImageEditor,
             tokenErrorHandler: externalToken != nil ? nil : {
                 oauthSession.markSessionAsExpired(with: email)
@@ -141,10 +141,10 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
     }
 
     @ViewBuilder
-    var aboutEditorView: some View {
+    func aboutEditorView(fields: AboutInfoField) -> some View {
         AboutEditorView(
             model: model,
-            fields: scopeOption.aboutEditorConfig.fields,
+            fields: fields,
             aboutUpdateHandler: {
                 updateHandler?(.aboutInfoUpdate)
             }
@@ -156,16 +156,16 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
     func editorView() -> some View {
         profileCardHeaderView()
         switch scopeOption.scope {
-        case .avatarPicker:
-            avatarPickerView
-        case .aboutInfoEditor:
-            aboutEditorView
-        case .avatarPickerAndAboutInfoEditor:
+        case .avatarPicker(let config):
+            avatarPickerView(config: config)
+        case .aboutInfoEditor(let config):
+            aboutEditorView(fields: config.fields)
+        case .avatarPickerAndAboutInfoEditor(let config):
             switch multipleEditorMode {
             case .avatarPicker:
-                avatarPickerView
+                avatarPickerView(config: .init(contentLayout: config.contentLayout))
             case .aboutEditor:
-                aboutEditorView
+                aboutEditorView(fields: config.fields)
             case nil:
                 EmptyView()
             }

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditorScopeOption.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditorScopeOption.swift
@@ -1,23 +1,14 @@
 /// Represents a profile editing scope with configuration options for each scope.
 public struct QuickEditorScopeOption {
     enum Scope {
-        case avatarPicker
-        case aboutInfoEditor
-        case avatarPickerAndAboutInfoEditor
+        case avatarPicker(AvatarPickerConfiguration)
+        case aboutInfoEditor(AboutEditorConfiguration)
+        case avatarPickerAndAboutInfoEditor(AvatarPickerAndAboutEditorConfiguration)
     }
-
-    let avatarPickerConfig: AvatarPickerConfiguration
-    let aboutEditorConfig: AboutEditorConfiguration
 
     let scope: Scope
 
-    init(
-        scope: Scope,
-        avatarPickerConfig: AvatarPickerConfiguration = .horizontalInstrinsicHeight,
-        aboutEditorConfig: AboutEditorConfiguration = .init(presentationStyle: .expandableMedium())
-    ) {
-        self.avatarPickerConfig = avatarPickerConfig
-        self.aboutEditorConfig = aboutEditorConfig
+    init(scope: Scope) {
         self.scope = scope
     }
 
@@ -28,8 +19,7 @@ public struct QuickEditorScopeOption {
         _ config: AvatarPickerConfiguration = .horizontalInstrinsicHeight
     ) -> Self {
         .init(
-            scope: .avatarPicker,
-            avatarPickerConfig: config
+            scope: .avatarPicker(config)
         )
     }
 
@@ -40,8 +30,7 @@ public struct QuickEditorScopeOption {
         _ config: AboutEditorConfiguration = .init()
     ) -> Self {
         .init(
-            scope: .aboutInfoEditor,
-            aboutEditorConfig: config
+            scope: .aboutInfoEditor(config)
         )
     }
 
@@ -49,36 +38,48 @@ public struct QuickEditorScopeOption {
         _ avatarPickerAndAboutEditorConfig: AvatarPickerAndAboutEditorConfiguration = .init()
     ) -> Self {
         .init(
-            scope: .avatarPickerAndAboutInfoEditor,
-            avatarPickerConfig: .init(contentLayout: avatarPickerAndAboutEditorConfig.contentLayout),
-            aboutEditorConfig: .init(fields: avatarPickerAndAboutEditorConfig.fields)
+            scope: .avatarPickerAndAboutInfoEditor(avatarPickerAndAboutEditorConfig)
         )
+    }
+
+    var isAvatarPickerAndAboutInfoEditor: Bool {
+        switch scope {
+        case .avatarPickerAndAboutInfoEditor:
+            true
+        default:
+            false
+        }
     }
 }
 
 /// Represents a profile editing scope with configuration options for each scope.
 @available(iOS, deprecated: 16.0, renamed: "QuickEditorScopeOption")
 public struct QuickEditorScopeOptionOld {
+    enum ScopeOld {
+        case avatarPicker
+        case aboutInfoEditor
+        case avatarPickerAndAboutInfoEditor
+    }
+
     typealias Scope = QuickEditorScopeOption.Scope
 
-    let avatarPickerConfig: AvatarPickerConfiguration
-    let aboutEditorConfig: AboutEditorConfiguration
     let scope: Scope
 
-    init(
-        scope: Scope
-    ) {
-        self.avatarPickerConfig = .verticalLarge
-        self.aboutEditorConfig = .init(presentationStyle: .large)
-        self.scope = scope
+    init(scope: ScopeOld) {
+        self.scope = switch scope {
+        case .avatarPicker:
+            .avatarPicker(.verticalLarge)
+        case .aboutInfoEditor:
+            .aboutInfoEditor(.init(presentationStyle: .large))
+        case .avatarPickerAndAboutInfoEditor:
+            .avatarPickerAndAboutInfoEditor(.init(contentLayout: .vertical(presentationStyle: .large)))
+        }
     }
 
     /// Creates a `QuickEditorScopeOption` configured for the avatar picker scope.
     /// - Returns: An instance of `QuickEditorScopeOption` for the avatar picker scope.
     public static func avatarPicker() -> Self {
-        .init(
-            scope: .avatarPicker
-        )
+        .init(scope: .avatarPicker)
     }
 
     /// Creates a `QuickEditorScopeOption` configured for the about info editor scope.
@@ -94,6 +95,6 @@ public struct QuickEditorScopeOptionOld {
     }
 
     func map() -> QuickEditorScopeOption {
-        .init(scope: scope, avatarPickerConfig: avatarPickerConfig, aboutEditorConfig: aboutEditorConfig)
+        .init(scope: scope)
     }
 }

--- a/Sources/GravatarUI/SwiftUI/QEDetent.swift
+++ b/Sources/GravatarUI/SwiftUI/QEDetent.swift
@@ -14,21 +14,21 @@ enum QEDetent {
         verticalSizeClass: UserInterfaceSizeClass?
     ) -> [QEDetent] {
         switch scopeOption.scope {
-        case .avatarPicker:
+        case .avatarPicker(let config):
             avatarPickerDetents(
-                for: scopeOption.avatarPickerConfig.contentLayout,
+                for: config.contentLayout,
                 intrinsicHeight: intrinsicHeight,
                 verticalSizeClass: verticalSizeClass
             )
-        case .aboutInfoEditor:
+        case .aboutInfoEditor(let config):
             aboutEditorDetents(
-                for: scopeOption.aboutEditorConfig.presentationStyle,
+                for: config.presentationStyle,
                 intrinsicHeight: intrinsicHeight,
                 verticalSizeClass: verticalSizeClass
             )
-        case .avatarPickerAndAboutInfoEditor:
+        case .avatarPickerAndAboutInfoEditor(let config):
             avatarPickerDetents(
-                for: scopeOption.avatarPickerConfig.contentLayout,
+                for: config.contentLayout,
                 intrinsicHeight: intrinsicHeight,
                 verticalSizeClass: verticalSizeClass
             )

--- a/Sources/GravatarUI/SwiftUI/QuickEditorModalPresentationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/QuickEditorModalPresentationModifier.swift
@@ -109,17 +109,17 @@ extension ModalPresentationWithIntrinsicSize {
 
     var shouldUseIntrinsicSize: Bool {
         switch scopeOption.scope {
-        case .avatarPicker:
-            shouldAvatarPickerUseIntrinsicSize
+        case .avatarPicker(let config):
+            shouldUseIntrinsicSize(for: config.contentLayout)
         case .aboutInfoEditor:
             false
-        case .avatarPickerAndAboutInfoEditor:
-            shouldAvatarPickerUseIntrinsicSize
+        case .avatarPickerAndAboutInfoEditor(let config):
+            shouldUseIntrinsicSize(for: config.contentLayout)
         }
     }
 
-    var shouldAvatarPickerUseIntrinsicSize: Bool {
-        switch scopeOption.avatarPickerConfig.contentLayout {
+    func shouldUseIntrinsicSize(for contentLayout: AvatarPickerContentLayout) -> Bool {
+        switch contentLayout {
         case .horizontal:
             switch verticalSizeClass {
             case .compact:
@@ -132,15 +132,14 @@ extension ModalPresentationWithIntrinsicSize {
         }
     }
 
-
     var shouldPrioritizeScrollOverResize: Bool {
         switch scopeOption.scope {
-        case .avatarPicker:
-            scopeOption.avatarPickerConfig.contentLayout.prioritizeScrollOverResize
-        case .aboutInfoEditor:
-            scopeOption.aboutEditorConfig.presentationStyle.prioritizeScrollOverResize
-        case .avatarPickerAndAboutInfoEditor:
-            scopeOption.avatarPickerConfig.contentLayout.prioritizeScrollOverResize
+        case .avatarPicker(let config):
+            config.contentLayout.prioritizeScrollOverResize
+        case .aboutInfoEditor(let config):
+            config.presentationStyle.prioritizeScrollOverResize
+        case .avatarPickerAndAboutInfoEditor(let config):
+            config.contentLayout.prioritizeScrollOverResize
         }
     }
 }


### PR DESCRIPTION
Closes #

### Description

Proposal on: https://github.com/Automattic/Gravatar-SDK-iOS/pull/733

Updating the `QuickEditorScopeOption.Scope` to use associated values for configurations.

Also, we actually don't have to make config types public (like `AboutEditorConfiguration`, `AvatarPickerAndAboutEditorConfiguration` etc.). But I didn't want to touch that in this PR as I wasn't so sure.

### Testing Steps

Same with https://github.com/Automattic/Gravatar-SDK-iOS/pull/733