### PR TITLE
Implement about detents

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
@@ -146,6 +146,10 @@ final class DemoQuickEditorViewController: UIViewController {
             .intrinsicHeight()
         case .automatic:
             .automatic()
+        case .automaticPrioritizeScrolling:
+            .automatic(prioritizeScrollOverResize: true)
+        case .intrinsicHeightPrioritizeScrolling:
+            .intrinsicHeight(prioritizeScrollOverResize: true)
         }
     }
 
@@ -577,7 +581,9 @@ enum SheetPresentationStyleRepresentation: String, CaseIterable, Hashable {
     case expandableMedium = "Expandable Medium"
     case expandableMediumPrioritizeScrolling = "Expandable Medium - Prioritize scrolling"
     case intrinsicHeight = "Intrinsic Height"
+    case intrinsicHeightPrioritizeScrolling = "Intrinsic Height - Prioritize scrolling"
     case automatic = "Automatic"
+    case automaticPrioritizeScrolling = "Automatic - Prioritize scrolling"
 }
 
 private extension UIView {

--- a/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
@@ -96,7 +96,7 @@ final class DemoQuickEditorViewController: UIViewController {
             .avatarPicker(.init(contentLayout: selectedLayout.contentLayout))
         case .aboutEditor:
             .aboutEditor(.init(
-                presentationStyle: selectedVerticalContentPresentationStyle,
+                presentationStyle: selectedSheetPresentationStyle,
                 fields: selectedAboutInfoFields
             ))
         case .avatarAndAboutEditor:
@@ -134,19 +134,25 @@ final class DemoQuickEditorViewController: UIViewController {
         }
     }
 
-    private var selectedVerticalContentPresentationStyle: VerticalContentPresentationStyle {
-        switch selectedVerticalContentPresentationStyleRepresentation {
+    private var selectedSheetPresentationStyle: SheetPresentationStyle {
+        switch selectedSheetPresentationStyleRepresentation {
         case .expandableMedium:
             .expandableMedium()
+        case .expandableMediumPrioritizeScrolling:
+            .expandableMedium(prioritizeScrollOverResize: true)
         case .large:
-            .large
+            .large()
+        case .intrinsicHeight:
+            .intrinsicHeight()
+        case .automatic:
+            .automatic()
         }
     }
 
-    private var selectedVerticalContentPresentationStyleRepresentation: VerticalContentPresentationStyleRepresentation = .expandableMedium {
+    private var selectedSheetPresentationStyleRepresentation: SheetPresentationStyleRepresentation = .expandableMedium {
         didSet {
             aboutPresentationStyleButton.setTitle(
-                "Vertical Presentation Style: \(selectedVerticalContentPresentationStyleRepresentation.rawValue)",
+                "Sheet Presentation Style: \(selectedSheetPresentationStyleRepresentation.rawValue)",
                 for: .normal
             )
         }
@@ -193,7 +199,7 @@ final class DemoQuickEditorViewController: UIViewController {
     lazy var aboutPresentationStyleButton: UIButton = {
         let button = UIButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle("Vertical Presentation Style: \(selectedVerticalContentPresentationStyleRepresentation.rawValue)", for: .normal)
+        button.setTitle("Sheet Presentation Style: \(selectedSheetPresentationStyleRepresentation.rawValue)", for: .normal)
         button.addTarget(self, action: #selector(presentVerticalPresentationStyleOptions), for: .touchUpInside)
         return button
     }()
@@ -241,9 +247,9 @@ final class DemoQuickEditorViewController: UIViewController {
 
     @objc func presentVerticalPresentationStyleOptions(from button: UIButton) {
         let sheet = UIAlertController(title: "Vertical Presentation Styles", message: nil, preferredStyle: .actionSheet)
-        VerticalContentPresentationStyleRepresentation.allCases.forEach { style in
+        SheetPresentationStyleRepresentation.allCases.forEach { style in
             sheet.addAction(.init(title: style.rawValue, style: .default) { _ in
-                self.selectedVerticalContentPresentationStyleRepresentation = style
+                self.selectedSheetPresentationStyleRepresentation = style
             })
         }
         sheet.popoverPresentationController?.sourceView = button
@@ -566,9 +572,12 @@ enum QEScope: String, CaseIterable, Hashable {
     case avatarAndAboutEditor = "Avatar & About Editor"
 }
 
-private enum VerticalContentPresentationStyleRepresentation: String, CaseIterable, Hashable {
+enum SheetPresentationStyleRepresentation: String, CaseIterable, Hashable {
     case large = "Large"
     case expandableMedium = "Expandable Medium"
+    case expandableMediumPrioritizeScrolling = "Expandable Medium - Prioritize scrolling"
+    case intrinsicHeight = "Intrinsic Height"
+    case automatic = "Automatic"
 }
 
 private extension UIView {

--- a/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
@@ -148,8 +148,6 @@ final class DemoQuickEditorViewController: UIViewController {
             .automatic()
         case .automaticPrioritizeScrolling:
             .automatic(prioritizeScrollOverResize: true)
-        case .intrinsicHeightPrioritizeScrolling:
-            .intrinsicHeight(prioritizeScrollOverResize: true)
         }
     }
 
@@ -581,7 +579,6 @@ enum SheetPresentationStyleRepresentation: String, CaseIterable, Hashable {
     case expandableMedium = "Expandable Medium"
     case expandableMediumPrioritizeScrolling = "Expandable Medium - Prioritize scrolling"
     case intrinsicHeight = "Intrinsic Height"
-    case intrinsicHeightPrioritizeScrolling = "Intrinsic Height - Prioritize scrolling"
     case automatic = "Automatic"
     case automaticPrioritizeScrolling = "Automatic - Prioritize scrolling"
 }

--- a/Demo/Demo/Gravatar-Demo/SwiftUI/Controls/QEVerticalStylePickerRow.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/Controls/QEVerticalStylePickerRow.swift
@@ -1,20 +1,16 @@
 import SwiftUI
 import GravatarUI
 
-struct QEVerticalStylePickerRow: View {
-    enum VerticalContentPresentationStyleRepresentation: String, CaseIterable, Hashable {
-        case large = "Large"
-        case expandableMedium = "Expandable Medium"
-    }
-    @Binding var verticalStyle: VerticalContentPresentationStyle
-    @State var verticalStyleRep: VerticalContentPresentationStyleRepresentation = .expandableMedium
+struct SheetStylePickerRow: View {
+    @Binding var sheetStyle: SheetPresentationStyle
+    @State var verticalStyleRep: SheetPresentationStyleRepresentation = .expandableMedium
 
     var body: some View {
         HStack {
-            Text("Vertical Style")
+            Text("Sheet Style")
             Spacer()
             Picker("Vertical Style", selection: $verticalStyleRep) {
-                ForEach(VerticalContentPresentationStyleRepresentation.allCases, id: \.self) { option in
+                ForEach(SheetPresentationStyleRepresentation.allCases, id: \.self) { option in
                     Text(option.rawValue).tag(option)
                 }
             }
@@ -22,10 +18,15 @@ struct QEVerticalStylePickerRow: View {
             .onChange(of: verticalStyleRep) { newValue in
                 switch newValue {
                 case .large:
-                    verticalStyle = .large
+                    sheetStyle = .large()
                 case .expandableMedium:
-                    verticalStyle = .expandableMedium()
-
+                    sheetStyle = .expandableMedium()
+                case .expandableMediumPrioritizeScrolling:
+                    sheetStyle = .expandableMedium(prioritizeScrollOverResize: true)
+                case .intrinsicHeight:
+                    sheetStyle = .intrinsicHeight()
+                case .automatic:
+                    sheetStyle = .automatic()
                 }
             }
         }

--- a/Demo/Demo/Gravatar-Demo/SwiftUI/Controls/QEVerticalStylePickerRow.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/Controls/QEVerticalStylePickerRow.swift
@@ -27,6 +27,8 @@ struct SheetStylePickerRow: View {
                     sheetStyle = .intrinsicHeight()
                 case .automatic:
                     sheetStyle = .automatic()
+                case .automaticPrioritizeScrolling:
+                    sheetStyle = .automatic(prioritizeScrollOverResize: true)
                 }
             }
         }

--- a/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
@@ -18,7 +18,7 @@ struct DemoProfileEditorView: View {
     @State var enableCustomImageCropper: Bool = false
     @State var prefersEphemeralWebBrowserSession: Bool = false
     @AppStorage("demoSelectedScope") private var scope: QEScope = .avatarPicker
-    @State private var verticalPresentationStyle: VerticalContentPresentationStyle = .expandableMedium()
+    @State private var sheetPresentationStyle: SheetPresentationStyle = .expandableMedium()
     @State private var isPresentingAboutFieldsSheet: Bool = false
     @AppStorage("demoSelectedAboutInfoFields") var selectedAboutInfoFields: AboutInfoField = .all
     @AppStorage("demoSelectedAvatar&AboutInitialPage") var initialPage: InitialPage = .avatarPicker
@@ -148,7 +148,7 @@ struct DemoProfileEditorView: View {
             .avatarPicker(.init(contentLayout: contentLayoutOptions.contentLayout))
         case .aboutEditor:
             .aboutEditor(.init(
-                presentationStyle: verticalPresentationStyle,
+                presentationStyle: sheetPresentationStyle,
                 fields: selectedAboutInfoFields)
             )
         case .avatarAndAboutEditor:
@@ -184,7 +184,7 @@ struct DemoProfileEditorView: View {
             Toggle("Custom image cropper", isOn: $enableCustomImageCropper)
         case .aboutEditor:
             if #available(iOS 16.0, *) {
-                QEVerticalStylePickerRow(verticalStyle: $verticalPresentationStyle)
+                SheetStylePickerRow(sheetStyle: $sheetPresentationStyle)
             }
             aboutFieldsButton()
         case .avatarAndAboutEditor:

--- a/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
@@ -32,7 +32,7 @@ public struct AboutEditorConfiguration: Sendable {
     let fields: AboutInfoField
 
     public init(
-        presentationStyle: SheetPresentationStyle = .expandableMedium(),
+        presentationStyle: SheetPresentationStyle = .automatic(),
         fields: AboutInfoField = AboutInfoField.all
     ) {
         self.presentationStyle = presentationStyle

--- a/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
@@ -28,11 +28,11 @@ public struct AvatarPickerConfiguration: Sendable {
 
 /// Configuration which will be applied to the About info editor.
 public struct AboutEditorConfiguration: Sendable {
-    let presentationStyle: VerticalContentPresentationStyle
+    let presentationStyle: SheetPresentationStyle
     let fields: AboutInfoField
 
     public init(
-        presentationStyle: VerticalContentPresentationStyle = .expandableMedium(),
+        presentationStyle: SheetPresentationStyle = .expandableMedium(),
         fields: AboutInfoField = AboutInfoField.all
     ) {
         self.presentationStyle = presentationStyle

--- a/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
+++ b/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
@@ -21,10 +21,14 @@ public struct SheetPresentationStyle: Sendable {
         .init(detentMode: .large)
     }
 
-    /// Medium height sheet that is expandable to full height. In compact height this is inactive and the sheet is displayed as full height.
-    /// - initialFraction: The fractional height of the sheet in its initial state.
-    /// - prioritizeScrollOverResize: A behavior that prioritizes scrolling the content of the sheet when
-    /// swiping, rather than resizing it. Note that this parameter is effective only for iOS 16.4 +.
+    /// A medium-height sheet presentation style that can expand to full height.
+    ///
+    /// In a compact height size class environment, the medium-height presentation is disabled and the sheet is presented at full height by default.
+    /// - Parameters:
+    ///   - initialFraction: The fractional height (relative to the full height) at which the sheet is initially presented.
+    ///   - prioritizeScrollOverResize: Determines whether scroll gestures within the sheet take precedence over resizing gestures. Available on iOS 16.4 and
+    /// later.
+    /// - Returns: A configured ``SheetPresentationStyle`` instance representing an expandable medium-height sheet.
     public static func expandableMedium(
         initialFraction: CGFloat = SheetPresentationStyle.expandableMediumInitialFraction,
         prioritizeScrollOverResize: Bool = false

--- a/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
+++ b/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
@@ -15,7 +15,8 @@ public struct SheetPresentationStyle: Sendable {
 
     let detentMode: DetentMode
 
-    /// Full height sheet.
+    /// A full-height sheet presentation style.
+    /// - Returns: A `SheetPresentationStyle` instance configured to present the sheet at full height.
     public static func large() -> SheetPresentationStyle {
         .init(detentMode: .large)
     }

--- a/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
+++ b/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
@@ -9,8 +9,8 @@ public struct SheetPresentationStyle: Sendable {
             initialFraction: CGFloat = SheetPresentationStyle.expandableMediumInitialFraction,
             prioritizeScrollOverResize: Bool = false
         )
-        case intrinsicHeight
-        case automatic
+        case intrinsicHeight(prioritizeScrollOverResize: Bool = false)
+        case automatic(prioritizeScrollOverResize: Bool = false)
     }
 
     let detentMode: DetentMode
@@ -41,21 +41,25 @@ public struct SheetPresentationStyle: Sendable {
     /// There are 2 size classes where this mode is inactive:
     ///  - Compact height: The sheet is displayed in full height.
     ///  - Regular width: The system ignores the intrinsic height and defaults to a full size sheet by the system.
-    public static func intrinsicHeight() -> SheetPresentationStyle {
-        .init(detentMode: .intrinsicHeight)
+    public static func intrinsicHeight(prioritizeScrollOverResize: Bool = false) -> SheetPresentationStyle {
+        .init(detentMode: .intrinsicHeight(prioritizeScrollOverResize: prioritizeScrollOverResize))
     }
 
     /// If the content height is below a certain threshold then `.intrinsicHeight` is applied.
     /// Otherwise `.expandableMedium()` is applied with the proper `initialFraction` and `prioritizeScrollOverResize` parameters depending on the content.
-    public static func automatic() -> SheetPresentationStyle {
-        .init(detentMode: .automatic)
+    public static func automatic(prioritizeScrollOverResize: Bool = false) -> SheetPresentationStyle {
+        .init(detentMode: .automatic(prioritizeScrollOverResize: prioritizeScrollOverResize))
     }
 
     var prioritizeScrollOverResize: Bool {
         switch detentMode {
         case .expandableMedium(_, let prioritizeScrollOverResize):
             prioritizeScrollOverResize
-        default:
+        case .automatic(let prioritizeScrollOverResize):
+            prioritizeScrollOverResize
+        case .intrinsicHeight(let prioritizeScrollOverResize):
+            prioritizeScrollOverResize
+        case .large:
             false
         }
     }

--- a/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
+++ b/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
@@ -1,5 +1,5 @@
 import Foundation
-
+/// A value that describes how the Quick Editor sheet should be presented,
 public struct SheetPresentationStyle: Sendable {
     public static let expandableMediumInitialFraction: CGFloat = 0.7
 

--- a/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
+++ b/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
@@ -50,7 +50,16 @@ public struct SheetPresentationStyle: Sendable {
         .init(detentMode: .intrinsicHeight)
     }
 
-    /// Applies `.intrinsicHeight` when the content height is below a defined threshold. Otherwise, applies `.expandableMedium()`.
+    /// Returns a sheet presentation style that automatically chooses between `.intrinsicHeight` and `.expandableMedium()`,
+    /// depending on the content height.
+    ///
+    /// If the content height is below a predefined threshold, `.intrinsicHeight` is used;
+    /// otherwise, `.expandableMedium()` is applied.
+    ///
+    /// - Parameter prioritizeScrollOverResize: Determines whether scroll gestures within the sheet take precedence over resizing gestures.
+    ///   This parameter is effective only on iOS 16.4 and later.
+    ///
+    /// - Returns: A `SheetPresentationStyle` instance that adapts the sheet height based on content size.
     public static func automatic(prioritizeScrollOverResize: Bool = false) -> SheetPresentationStyle {
         .init(detentMode: .automatic(prioritizeScrollOverResize: prioritizeScrollOverResize))
     }

--- a/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
+++ b/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
@@ -45,8 +45,7 @@ public struct SheetPresentationStyle: Sendable {
         .init(detentMode: .intrinsicHeight)
     }
 
-    /// If the content height is below a certain threshold then `.intrinsicHeight` is applied.
-    /// Otherwise `.expandableMedium()` is applied with the proper `initialFraction` and `prioritizeScrollOverResize` parameters depending on the content.
+    /// Applies `.intrinsicHeight` when the content height is below a defined threshold. Otherwise, applies `.expandableMedium()`.
     public static func automatic(prioritizeScrollOverResize: Bool = false) -> SheetPresentationStyle {
         .init(detentMode: .automatic(prioritizeScrollOverResize: prioritizeScrollOverResize))
     }

--- a/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
+++ b/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-public struct SheetPresentationStyle {
+public struct SheetPresentationStyle: Sendable {
     public static let expandableMediumInitialFraction: CGFloat = 0.7
 
-    enum DetentMode {
+    enum DetentMode: Sendable {
         case large
         case expandableMedium(
             initialFraction: CGFloat = SheetPresentationStyle.expandableMediumInitialFraction,

--- a/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
+++ b/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 /// A value that describes how the Quick Editor sheet should be presented,
 public struct SheetPresentationStyle: Sendable {
     public static let expandableMediumInitialFraction: CGFloat = 0.7

--- a/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
+++ b/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
@@ -9,7 +9,7 @@ public struct SheetPresentationStyle: Sendable {
             initialFraction: CGFloat = SheetPresentationStyle.expandableMediumInitialFraction,
             prioritizeScrollOverResize: Bool = false
         )
-        case intrinsicHeight(prioritizeScrollOverResize: Bool = false)
+        case intrinsicHeight
         case automatic(prioritizeScrollOverResize: Bool = false)
     }
 
@@ -41,8 +41,8 @@ public struct SheetPresentationStyle: Sendable {
     /// There are 2 size classes where this mode is inactive:
     ///  - Compact height: The sheet is displayed in full height.
     ///  - Regular width: The system ignores the intrinsic height and defaults to a full size sheet by the system.
-    public static func intrinsicHeight(prioritizeScrollOverResize: Bool = false) -> SheetPresentationStyle {
-        .init(detentMode: .intrinsicHeight(prioritizeScrollOverResize: prioritizeScrollOverResize))
+    public static func intrinsicHeight() -> SheetPresentationStyle {
+        .init(detentMode: .intrinsicHeight)
     }
 
     /// If the content height is below a certain threshold then `.intrinsicHeight` is applied.
@@ -57,8 +57,8 @@ public struct SheetPresentationStyle: Sendable {
             prioritizeScrollOverResize
         case .automatic(let prioritizeScrollOverResize):
             prioritizeScrollOverResize
-        case .intrinsicHeight(let prioritizeScrollOverResize):
-            prioritizeScrollOverResize
+        case .intrinsicHeight:
+            false
         case .large:
             false
         }

--- a/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
+++ b/Sources/GravatarUI/QuickEditor/SheetPresentationStyle.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public struct SheetPresentationStyle {
+    public static let expandableMediumInitialFraction: CGFloat = 0.7
+
+    enum DetentMode {
+        case large
+        case expandableMedium(
+            initialFraction: CGFloat = SheetPresentationStyle.expandableMediumInitialFraction,
+            prioritizeScrollOverResize: Bool = false
+        )
+        case intrinsicHeight
+        case automatic
+    }
+
+    let detentMode: DetentMode
+
+    /// Full height sheet.
+    public static func large() -> SheetPresentationStyle {
+        .init(detentMode: .large)
+    }
+
+    /// Medium height sheet that is expandable to full height. In compact height this is inactive and the sheet is displayed as full height.
+    /// - initialFraction: The fractional height of the sheet in its initial state.
+    /// - prioritizeScrollOverResize: A behavior that prioritizes scrolling the content of the sheet when
+    /// swiping, rather than resizing it. Note that this parameter is effective only for iOS 16.4 +.
+    public static func expandableMedium(
+        initialFraction: CGFloat = SheetPresentationStyle.expandableMediumInitialFraction,
+        prioritizeScrollOverResize: Bool = false
+    ) -> SheetPresentationStyle {
+        .init(
+            detentMode: .expandableMedium(
+                initialFraction: initialFraction,
+                prioritizeScrollOverResize: prioritizeScrollOverResize
+            )
+        )
+    }
+
+    /// Represents a bottom sheet with intrinsic height.
+    ///
+    /// There are 2 size classes where this mode is inactive:
+    ///  - Compact height: The sheet is displayed in full height.
+    ///  - Regular width: The system ignores the intrinsic height and defaults to a full size sheet by the system.
+    public static func intrinsicHeight() -> SheetPresentationStyle {
+        .init(detentMode: .intrinsicHeight)
+    }
+
+    /// If the content height is below a certain threshold then `.intrinsicHeight` is applied.
+    /// Otherwise `.expandableMedium()` is applied with the proper `initialFraction` and `prioritizeScrollOverResize` parameters depending on the content.
+    public static func automatic() -> SheetPresentationStyle {
+        .init(detentMode: .automatic)
+    }
+
+    var prioritizeScrollOverResize: Bool {
+        switch detentMode {
+        case .expandableMedium(_, let prioritizeScrollOverResize):
+            prioritizeScrollOverResize
+        default:
+            false
+        }
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditorScopeOption.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditorScopeOption.swift
@@ -81,7 +81,7 @@ public struct QuickEditorScopeOptionOld {
         case .avatarPicker:
             .avatarPicker(.verticalLarge)
         case .aboutInfoEditor:
-            .aboutInfoEditor(.init(presentationStyle: .large))
+            .aboutInfoEditor(.init(presentationStyle: .large()))
         case .avatarPickerAndAboutInfoEditor:
             .avatarPickerAndAboutInfoEditor(.init(contentLayout: .vertical(presentationStyle: .large)))
         }

--- a/Sources/GravatarUI/SwiftUI/QEDetent.swift
+++ b/Sources/GravatarUI/SwiftUI/QEDetent.swift
@@ -96,17 +96,25 @@ enum QEDetent {
     }
 
     private static func aboutEditorDetents(
-        for presentationStyle: VerticalContentPresentationStyle,
+        for presentationStyle: SheetPresentationStyle,
         intrinsicHeight: CGFloat,
         verticalSizeClass: UserInterfaceSizeClass?
     )
         -> [QEDetent]
     {
-        switch presentationStyle {
+        switch presentationStyle.detentMode {
         case .large:
             [.large]
         case .expandableMedium(initialFraction: let initialFraction, _):
             .init([.fraction(initialFraction), .large])
+        case .intrinsicHeight:
+            .init([.height(intrinsicHeight)])
+        case .automatic:
+            if intrinsicHeight >= QEModalPresentationConstants.bottomSheetEstimatedHeight {
+                .init([.height(QEModalPresentationConstants.bottomSheetEstimatedHeight), .large])
+            } else {
+                .init([.height(intrinsicHeight)])
+            }
         }
     }
 

--- a/Sources/GravatarUI/SwiftUI/QuickEditorModalPresentationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/QuickEditorModalPresentationModifier.swift
@@ -133,8 +133,13 @@ extension ModalPresentationWithIntrinsicSize {
         switch scopeOption.scope {
         case .avatarPicker(let config):
             shouldUseIntrinsicSize(for: config.contentLayout)
-        case .aboutInfoEditor:
-            false
+        case .aboutInfoEditor(let config):
+            switch config.presentationStyle.detentMode {
+            case .intrinsicHeight, .automatic:
+                true
+            case .expandableMedium(_, _), .large:
+                false
+            }
         case .avatarPickerAndAboutInfoEditor(let config):
             shouldUseIntrinsicSize(for: config.contentLayout)
         }


### PR DESCRIPTION
Closes BETS-47

### Description

Defines a generic `SheetPresentationStyle` and uses it to define "About" scope detents.

**intrinsicHeight**: Displays sheet based on the content height.
**automatic**: If the content height is smaller than the default sheet height then it applies intrinsicHeight, otherwise it applies 2 detents: default sheet height + large.
The rest is as usual.

### Testing Steps

Test with both UIKit and SwiftUI demo apps.
Select "About" scope
Pick different number of fields.
Pick different presentation styles.
Display the QE and check if anything looks odd.
