### PR TITLE
Avoid split navigation on regular horizontal size class

### DIFF
--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -100,7 +100,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
                 preferenceKey: InnerHeightPreferenceKey.self
             )
         }
-        .navigationViewStyle(StackNavigationViewStyle())
+        .navigationViewStyle(.stack)
         .presentSafariView(identifiableURL: $safariURL, colorScheme: colorScheme)
         .onAppear {
             fetchedToken = oauthSession.sessionToken(with: email)?.token

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -100,6 +100,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
                 preferenceKey: InnerHeightPreferenceKey.self
             )
         }
+        .navigationViewStyle(StackNavigationViewStyle())
         .presentSafariView(identifiableURL: $safariURL, colorScheme: colorScheme)
         .onAppear {
             fetchedToken = oauthSession.sessionToken(with: email)?.token


### PR DESCRIPTION
Closes #758 

### Description

Fixes the issue described in #758 

### Testing Steps

- Run the demo app in a big size iPhone (Pro Max or Plus)
- Open the Quick Editor
- Rotate the device to landscape
  - Check that the content is still all visible. 
