### PR TITLE
Adding bottom padding to error view on About editor

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
@@ -6,6 +6,7 @@ struct AboutEditorView: View {
         static let sectionHeaderFont: Font = .subheadline.weight(.semibold)
         static let footerFont: Font = .footnote
         static let horizontalPadding: CGFloat = .DS.Padding.double
+        static let vStackVerticalSpacing: CGFloat = .DS.Padding.medium
     }
 
     @State private var isSaving: Bool = false
@@ -222,6 +223,9 @@ struct AboutEditorView: View {
             isPresented: $isPresented,
             model: model, tokenErrorHandler: tokenErrorHandler
         )
+
+        Spacer()
+            .frame(height: Constants.vStackVerticalSpacing)
     }
 
     private enum Localized {


### PR DESCRIPTION
Closes BETS-48 

### Description

Adding padding under error view on the about editor.

Now both avatar and about error views have the same space at the bottom

<img src="https://github.com/user-attachments/assets/bbe45646-00b0-4559-a285-40e554373169" width="40%">

I've chosen to add it only under the error view, as the content already looks well laid out

<img src="https://github.com/user-attachments/assets/acd334ba-4fd2-42a6-b65a-442ae40a0ce9" width="40%">


### Testing Steps

- Run the demo app on an old iPhone without notch (iPhone SE)
- Go to the Quick Editor demo screen
- Insert an invalid auth token (to force auth error)
- Open the Quick Editor with About Editor scope
  - Check that there's a space between the lower frame of the error and the screen. 