### PR TITLE
UIKit sheet presentation from SwiftUI context

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
@@ -284,9 +284,9 @@ final class DemoQuickEditorViewController: UIViewController {
 
     lazy var schemeToggle: UISegmentedControl = {
         let control = UISegmentedControl(items: [
-            UIAction.init(title: "System") { _ in self.customColorScheme = .unspecified },
-            UIAction.init(title: "Light") { _ in self.customColorScheme = .light },
-            UIAction.init(title: "Dark") { _ in self.customColorScheme = .dark },
+            UIAction.init(title: "System") { [weak self] _ in self?.customColorScheme = .unspecified },
+            UIAction.init(title: "Light") { [weak self] _ in self?.customColorScheme = .light },
+            UIAction.init(title: "Dark") { [weak self] _ in self?.customColorScheme = .dark },
         ])
         control.selectedSegmentIndex = 0
         return control
@@ -294,8 +294,8 @@ final class DemoQuickEditorViewController: UIViewController {
 
     lazy var imageEditorToggle: UISegmentedControl = {
         let control = UISegmentedControl(items: [
-            UIAction.init(title: "Default Image Editor") { _ in self.useCustomImageEditor = false },
-            UIAction.init(title: "Custom Image Editor") { _ in self.useCustomImageEditor = true },
+            UIAction.init(title: "Default Image Editor") { [weak self] _ in self?.useCustomImageEditor = false },
+            UIAction.init(title: "Custom Image Editor") { [weak self] _ in self?.useCustomImageEditor = true },
         ])
         control.selectedSegmentIndex = 0
         return control

--- a/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/DemoProfileEditorView.swift
@@ -85,7 +85,10 @@ struct DemoProfileEditorView: View {
                                 onDismiss: {
                                     updateHasSession(with: email)
                                 }
-                            ).environment(\.colorScheme, ColorScheme(selectedScheme) ?? .light)
+                            )
+                            .if(selectedScheme != .unspecified, transform: { content in
+                                content.environment(\.colorScheme, ColorScheme(selectedScheme) ?? .light)
+                            })
                     } else {
                         view
                             .gravatarQuickEditorSheet(
@@ -106,7 +109,10 @@ struct DemoProfileEditorView: View {
                                 onDismiss: {
                                     updateHasSession(with: email)
                                 }
-                            ).environment(\.colorScheme, ColorScheme(selectedScheme) ?? .light)
+                            )
+                            .if(selectedScheme != .unspecified, transform: { content in
+                                content.environment(\.colorScheme, ColorScheme(selectedScheme) ?? .light)
+                            })
                     }
                 }
             if hasSession {
@@ -264,4 +270,19 @@ struct DemoProfileEditorView: View {
 
 #Preview {
     DemoProfileEditorView()
+}
+
+extension View {
+    /// Applies the given transform if the given condition evaluates to `true`.
+    /// - Parameters:
+    ///   - condition: The condition to evaluate.
+    ///   - transform: The transform to apply to the source `View`.
+    /// - Returns: Either the original `View` or the modified `View` if the condition is `true`.
+    @ViewBuilder func `if`<Content: View>(_ condition: @autoclosure () -> Bool, transform: (Self) -> Content) -> some View {
+        if condition() {
+            transform(self)
+        } else {
+            self
+        }
+    }
 }

--- a/Demo/Gravatar-Demo.xcodeproj/xcshareddata/xcschemes/Gravatar Demo.xcscheme
+++ b/Demo/Gravatar-Demo.xcodeproj/xcshareddata/xcschemes/Gravatar Demo.xcscheme
@@ -50,6 +50,13 @@
             ReferencedContainer = "container:Gravatar-Demo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
+++ b/Sources/Gravatar/Network/Services/URLSessionHTTPClient.swift
@@ -11,17 +11,11 @@ struct URLSessionHTTPClient: HTTPClient {
     private let urlSession: URLSessionProtocol
 
     init(urlSession: URLSessionProtocol? = nil) {
-        let configuration = URLSessionConfiguration.default
-        configuration.httpAdditionalHeaders = [
-            "Accept": "application/json",
-            "X-Platform": "ios",
-            "X-SDK-Version": BundleInfo.sdkVersion ?? "",
-            "X-Source": BundleInfo.appName ?? "",
-        ]
-        self.urlSession = urlSession ?? URLSession(configuration: configuration)
+        self.urlSession = urlSession ?? URLSession(configuration: URLSessionConfiguration.default)
     }
 
     func data(with request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let request = request.withHeaders()
         let result: (data: Data, response: URLResponse)
         do {
             result = try await urlSession.data(for: request)
@@ -33,6 +27,7 @@ struct URLSessionHTTPClient: HTTPClient {
     }
 
     func uploadData(with request: URLRequest, data: Data) async throws -> (Data, HTTPURLResponse) {
+        let request = request.withHeaders()
         let result: (data: Data, response: URLResponse)
         do {
             result = try await urlSession.upload(for: request, from: data)
@@ -48,6 +43,15 @@ extension URLRequest {
         var requestCopy = self
         requestCopy.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         return requestCopy
+    }
+
+    func withHeaders() -> URLRequest {
+        var request = self
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        request.addValue("ios", forHTTPHeaderField: "X-Platform")
+        request.addValue(BundleInfo.sdkVersion ?? "", forHTTPHeaderField: "X-SDK-Version")
+        request.addValue(BundleInfo.appName ?? "", forHTTPHeaderField: "X-Source")
+        return request
     }
 }
 

--- a/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public class QuickEditorConfiguration {
+public struct QuickEditorConfiguration {
     let interfaceStyle: UIUserInterfaceStyle
     let customImageEditorProvider: CustomImageEditorControllerProvider?
 

--- a/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
@@ -3,17 +3,19 @@ import UIKit
 
 public typealias CustomImageEditorControllerProvider = (UIImage, @escaping @Sendable (UIImage) -> Void) -> CustomImageEditorController
 
-final class QuickEditorViewController: UIViewController, ModalPresentationWithIntrinsicSize {
-    private typealias CustomImageEditorProvider = ImageEditorBlock<CustomImageEditorControllerRepresentable>?
-
-    let email: Email
-    let scopeOption: QuickEditorScopeOption
-    let token: String?
-    let configuration: QuickEditorConfiguration
-    let updateHandler: ((QuickEditorUpdateType) -> Void)?
-    let onDismiss: (() -> Void)?
+final class QuickEditorViewController<ImageEditor: ImageEditorView>: UIViewController,
+    ModalPresentationWithIntrinsicSize,
+    UISheetPresentationControllerDelegate
+{
+    private let email: Email
+    private let token: String?
+    private let customImageEditorProvider: ImageEditorBlock<ImageEditor>?
+    private let updateHandler: ((QuickEditorUpdateType) -> Void)?
+    private let onDismiss: (() -> Void)?
 
     private let unsavedChangesAlertPresentationModel = UnsavedChangesAlertPresentationModel()
+    private var sheetHeight: CGFloat = QEModalPresentationConstants.bottomSheetEstimatedHeight
+    private var currentPage: QuickEditorPage
 
     private lazy var isPresented: Binding<Bool> = Binding {
         true
@@ -26,32 +28,17 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
     }
 
     var verticalSizeClass: UserInterfaceSizeClass?
-    var sheetHeight: CGFloat = QEModalPresentationConstants.bottomSheetEstimatedHeight
-    var currentPage: QuickEditorPage
+    let scopeOption: QuickEditorScopeOption
 
-    private lazy var rootView: QuickEditor = {
-        let provider: CustomImageEditorProvider = if let customProvider = configuration.customImageEditorProvider {
-            { image, callback in
-                CustomImageEditorControllerRepresentable(
-                    controllerProvider: customProvider,
-                    inputImage: image,
-                    editingDidFinish: callback
-                )
-            }
-        } else {
-            nil as ImageEditorBlock<CustomImageEditorControllerRepresentable>?
-        }
-
-        return QuickEditor(
-            email: email,
-            scopeOption: scopeOption,
-            token: token,
-            isPresented: isPresented,
-            customImageEditor: provider,
-            updateHandler: updateHandler,
-            unsavedChangesAlertPresentationModel: unsavedChangesAlertPresentationModel
-        )
-    }()
+    private lazy var rootView = QuickEditor(
+        email: email,
+        scopeOption: scopeOption,
+        token: token,
+        isPresented: isPresented,
+        customImageEditor: customImageEditorProvider,
+        updateHandler: updateHandler,
+        unsavedChangesAlertPresentationModel: unsavedChangesAlertPresentationModel
+    )
 
     private lazy var quickEditor: InnerHeightUIHostingController = .init(
         rootView: rootView,
@@ -77,18 +64,19 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
     init(
         email: Email,
         scopeOption: QuickEditorScopeOption,
-        configuration: QuickEditorConfiguration? = nil,
+        customImageEditorProvider: ImageEditorBlock<ImageEditor>? = nil,
         token: String? = nil,
         onUpdate: ((QuickEditorUpdateType) -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) {
         self.email = email
         self.scopeOption = scopeOption
-        self.configuration = configuration ?? .default
+
         self.token = token
         self.onDismiss = onDismiss
         self.updateHandler = onUpdate
         self.currentPage = scopeOption.initialPage
+        self.customImageEditorProvider = customImageEditorProvider
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -135,9 +123,7 @@ final class QuickEditorViewController: UIViewController, ModalPresentationWithIn
             sheet.delegate = self
         }
     }
-}
 
-extension QuickEditorViewController: UISheetPresentationControllerDelegate {
     func presentationControllerShouldDismiss(_: UIPresentationController) -> Bool {
         if unsavedChangesAlertPresentationModel.hasUnsavedChanges {
             unsavedChangesAlertPresentationModel.presentAlert = true
@@ -207,7 +193,10 @@ private class InnerHeightUIHostingController: UIHostingController<AnyView> {
 }
 
 /// A struct responsible for presenting the Quick Editor from a UIKit context.
+@MainActor
 public struct QuickEditorPresenter {
+    private typealias CustomImageEditorProvider = ImageEditorBlock<CustomImageEditorControllerRepresentable>?
+
     let email: Email
     let scopeOption: QuickEditorScopeOption
     let configuration: QuickEditorConfiguration
@@ -272,11 +261,24 @@ public struct QuickEditorPresenter {
         onAvatarUpdated: (() -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) {
+        let customImageEditorProvider: CustomImageEditorProvider = if let customProvider = configuration.customImageEditorProvider {
+            { image, callback in
+                CustomImageEditorControllerRepresentable(
+                    controllerProvider: customProvider,
+                    inputImage: image,
+                    editingDidFinish: callback
+                )
+            }
+        } else {
+            nil as ImageEditorBlock<CustomImageEditorControllerRepresentable>?
+        }
+
         let quickEditor = QuickEditorViewController(
             email: email,
             scopeOption: scopeOption,
-            configuration: configuration,
+            customImageEditorProvider: customImageEditorProvider,
             token: token,
+
             onUpdate: { _ in
                 onAvatarUpdated?()
             },
@@ -302,10 +304,22 @@ public struct QuickEditorPresenter {
         onUpdate: ((QuickEditorUpdateType) -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) {
+        let customImageEditorProvider: CustomImageEditorProvider = if let customProvider = configuration.customImageEditorProvider {
+            { image, callback in
+                CustomImageEditorControllerRepresentable(
+                    controllerProvider: customProvider,
+                    inputImage: image,
+                    editingDidFinish: callback
+                )
+            }
+        } else {
+            nil as ImageEditorBlock<CustomImageEditorControllerRepresentable>?
+        }
+
         let quickEditor = QuickEditorViewController(
             email: email,
             scopeOption: scopeOption,
-            configuration: configuration,
+            customImageEditorProvider: customImageEditorProvider,
             token: token,
             onUpdate: onUpdate,
             onDismiss: onDismiss

--- a/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
@@ -19,11 +19,11 @@ final class QuickEditorViewController<ImageEditor: ImageEditorView>: UIViewContr
 
     private lazy var isPresented: Binding<Bool> = Binding {
         true
-    } set: { isPresented in
+    } set: { [weak self] isPresented in
         Task { @MainActor in
             guard !isPresented else { return }
-            self.dismiss(animated: true)
-            self.onDismiss?()
+            self?.dismiss(animated: true)
+            self?.onDismiss?()
         }
     }
 
@@ -87,7 +87,6 @@ final class QuickEditorViewController<ImageEditor: ImageEditorView>: UIViewContr
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         quickEditor.willMove(toParent: self)
         addChild(quickEditor)
         view.addSubview(quickEditor.view)
@@ -111,7 +110,8 @@ final class QuickEditorViewController<ImageEditor: ImageEditorView>: UIViewContr
 
     func updateDetents() {
         if let sheet = sheetPresentationController {
-            sheet.animateChanges {
+            sheet.animateChanges { [weak self] in
+                guard let self else { return }
                 sheet.detents = QEDetent.detents(
                     for: scopeOption,
                     intrinsicHeight: sheetHeight,

--- a/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
@@ -144,6 +144,10 @@ extension QuickEditorViewController: UISheetPresentationControllerDelegate {
         }
         return !unsavedChangesAlertPresentationModel.hasUnsavedChanges
     }
+
+    func presentationControllerDidDismiss(_: UIPresentationController) {
+        isPresented.wrappedValue = false
+    }
 }
 
 /// UIHostingController subclass which reads the InnerHeightPreferenceKey changes
@@ -314,8 +318,8 @@ public struct QuickEditorPresenter {
 
 /// A protocol defining a customizable image editor interface used in the Quick Editor flow.
 ///
-/// This `UIViewController` subclass is presented after the user selects an image from their photo library and before it is uploaded to Gravatar. It provides an
-/// opportunity to:
+/// This `UIViewController` subclass is presented modally after the user selects an image from their photo library and before it is uploaded to Gravatar.
+/// It provides an opportunity to:
 /// - Enforce a square aspect ratio.
 /// - Apply arbitrary, user-defined customizations to the image.
 ///

--- a/Sources/GravatarUI/QuickEditor/UIKitSheetPresentationOnSwiftUI.swift
+++ b/Sources/GravatarUI/QuickEditor/UIKitSheetPresentationOnSwiftUI.swift
@@ -3,29 +3,38 @@ import UIKit
 
 /// This is the view controller which will present the UIKit sheet from the SwiftUI context.
 ///
-class QuickEditorBottomSheetPresenterViewController: UIViewController {
-    let presenter: QuickEditorPresenter
+class QuickEditorBottomSheetPresenterViewController<ImageEditor: ImageEditorView>: UIViewController {
+    let email: Email
+    let scopeOption: QuickEditorScopeOption
+
+    let token: String?
+    let customImageEditor: ImageEditorBlock<ImageEditor>?
 
     let completion: (() -> Void)? = nil
     let onUpdate: ((QuickEditorUpdateType) -> Void)?
     let onDismiss: (() -> Void)?
 
+    override var overrideUserInterfaceStyle: UIUserInterfaceStyle {
+        didSet {
+            presentedViewController?.overrideUserInterfaceStyle = overrideUserInterfaceStyle
+        }
+    }
+
     init(
         email: Email,
         scopeOption: QuickEditorScopeOption,
-        configuration: QuickEditorConfiguration,
-        token: String?, completion: (() -> Void)? = nil,
+        token: String?,
+        customImageEditorProvider: ImageEditorBlock<ImageEditor>? = nil,
+        completion: (() -> Void)? = nil,
         onUpdate: ((QuickEditorUpdateType) -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) {
-        self.presenter = QuickEditorPresenter(
-            email: email,
-            scopeOption: scopeOption,
-            configuration: configuration,
-            token: token
-        )
+        self.email = email
+        self.scopeOption = scopeOption
+        self.token = token
         self.onUpdate = onUpdate
         self.onDismiss = onDismiss
+        self.customImageEditor = customImageEditorProvider
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -42,22 +51,27 @@ class QuickEditorBottomSheetPresenterViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        presenter.present(in: self, animated: true) {
-            self.completion?()
-        } onUpdate: { update in
-            self.onUpdate?(update)
-        } onDismiss: {
-            self.onDismiss?()
-        }
+        let quickEditor = QuickEditorViewController(
+            email: email,
+            scopeOption: scopeOption,
+            customImageEditorProvider: customImageEditor,
+            token: token,
+            onUpdate: onUpdate,
+            onDismiss: onDismiss
+        )
+
+        quickEditor.overrideUserInterfaceStyle = overrideUserInterfaceStyle
+
+        present(quickEditor, animated: true)
     }
 }
 
 /// SwiftUI representable version of `QuickEditorBottomSheetPresenterViewController`
-struct QuickEditorBottomSheetPresenterViewControllerRepresentable: UIViewControllerRepresentable {
+struct QuickEditorBottomSheetPresenterViewControllerRepresentable<ImageEditor: ImageEditorView>: UIViewControllerRepresentable {
     let email: Email
     let scopeOption: QuickEditorScopeOption
-    let configuration: QuickEditorConfiguration
-    let token: String?, completion: (() -> Void)?
+    let token: String?
+    let customImageEditor: ImageEditorBlock<ImageEditor>?
     let onUpdate: ((QuickEditorUpdateType) -> Void)?
     let onDismiss: (() -> Void)?
 
@@ -65,12 +79,14 @@ struct QuickEditorBottomSheetPresenterViewControllerRepresentable: UIViewControl
         QuickEditorBottomSheetPresenterViewController(
             email: email,
             scopeOption: scopeOption,
-            configuration: configuration,
             token: token,
+            customImageEditorProvider: customImageEditor,
             onUpdate: onUpdate,
             onDismiss: onDismiss
         )
     }
 
-    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
+        uiViewController.overrideUserInterfaceStyle = UIUserInterfaceStyle(context.environment.colorScheme)
+    }
 }

--- a/Sources/GravatarUI/QuickEditor/UIKitSheetPresentationOnSwiftUI.swift
+++ b/Sources/GravatarUI/QuickEditor/UIKitSheetPresentationOnSwiftUI.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+import UIKit
+
+/// This is the view controller which will present the UIKit sheet from the SwiftUI context.
+///
+class QuickEditorBottomSheetPresenterViewController: UIViewController {
+    let presenter: QuickEditorPresenter
+
+    let completion: (() -> Void)? = nil
+    let onUpdate: ((QuickEditorUpdateType) -> Void)?
+    let onDismiss: (() -> Void)?
+
+    init(
+        email: Email,
+        scopeOption: QuickEditorScopeOption,
+        configuration: QuickEditorConfiguration,
+        token: String?, completion: (() -> Void)? = nil,
+        onUpdate: ((QuickEditorUpdateType) -> Void)? = nil,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.presenter = QuickEditorPresenter(
+            email: email,
+            scopeOption: scopeOption,
+            configuration: configuration,
+            token: token
+        )
+        self.onUpdate = onUpdate
+        self.onDismiss = onDismiss
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        presenter.present(in: self, animated: true) {
+            self.completion?()
+        } onUpdate: { update in
+            self.onUpdate?(update)
+        } onDismiss: {
+            self.onDismiss?()
+        }
+    }
+}
+
+/// SwiftUI representable version of `QuickEditorBottomSheetPresenterViewController`
+struct QuickEditorBottomSheetPresenterViewControllerRepresentable: UIViewControllerRepresentable {
+    let email: Email
+    let scopeOption: QuickEditorScopeOption
+    let configuration: QuickEditorConfiguration
+    let token: String?, completion: (() -> Void)?
+    let onUpdate: ((QuickEditorUpdateType) -> Void)?
+    let onDismiss: (() -> Void)?
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        QuickEditorBottomSheetPresenterViewController(
+            email: email,
+            scopeOption: scopeOption,
+            configuration: configuration,
+            token: token,
+            onUpdate: onUpdate,
+            onDismiss: onDismiss
+        )
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
+}

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -125,7 +125,9 @@ class AvatarPickerViewModel: ObservableObject {
                 // Determine if the warning should be displayed
                 selectedAvatarURL == nil && loadedAvatarCount > 0
             }
-            .assign(to: \.shouldDisplayNoSelectedAvatarWarning, on: self)
+            .sink { [weak self] shouldShowWarning in
+                self?.shouldDisplayNoSelectedAvatarWarning = shouldShowWarning
+            }
             .store(in: &cancellables)
 
         $profileResult.sink { [weak self] profileResult in

--- a/Sources/GravatarUI/SwiftUI/ModalPresentationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/ModalPresentationModifier.swift
@@ -1,34 +1,5 @@
 import SwiftUI
 
-struct ModalPresentationModifier<ModalView: View>: ViewModifier {
-    @Binding var isPresented: Bool
-    @Environment(\.colorScheme) var colorScheme: ColorScheme
-    @State private var dismissAttempt = false
-
-    let onDismiss: (() -> Void)?
-    let modalView: ModalView
-
-    init(isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, modalView: ModalView) {
-        self._isPresented = isPresented
-        self.onDismiss = onDismiss
-        self.modalView = modalView
-    }
-
-    func body(content: Content) -> some View {
-        content
-            .sheet(isPresented: $isPresented, onDismiss: onDismiss) {
-                modalView
-                    .preferredColorScheme(colorScheme)
-                    .dismissAttemptDetecting(
-                        dismissAttempt: $dismissAttempt,
-                        isPresented: $isPresented,
-                        isLargeDetentOnly: true
-                    )
-                    .environment(\.dismissAttempt, dismissAttempt)
-            }
-    }
-}
-
 struct ModalItemPresentationModifier<ModalView: View, T>: ViewModifier where T: Identifiable {
     @Binding var item: T?
 

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -28,7 +28,6 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
 
     @Environment(\.oauthSession) private var oauthSession
     @Environment(\.colorScheme) var colorScheme: ColorScheme
-    @Environment(\.dismissAttempt) var dismissAttempt
     @Environment(\.verticalSizeClass) var vertcalSizeClass
 
     @AppStorage("QuickEditor.startOAuthOnAppear") private var startOAuthOnAppear: Bool = false
@@ -123,12 +122,6 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
         .interactiveDismissDisabled(model.hasUnsavedChanges)
         .onChange(of: model.hasUnsavedChanges) { _ in
             unsavedChangesAlertPresentationModel.hasUnsavedChanges = model.hasUnsavedChanges
-        }
-        .onChange(of: dismissAttempt) { newValue in
-            guard newValue else { return }
-            if unsavedChangesAlertPresentationModel.hasUnsavedChanges {
-                unsavedChangesAlertPresentationModel.presentAlert = true
-            }
         }
         .preference(key: QuikcEditorCurrentPagePreferenceKey.self, value: currentPage)
         .task {

--- a/Sources/GravatarUI/SwiftUI/QuickEditorModalPresentationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/QuickEditorModalPresentationModifier.swift
@@ -13,108 +13,19 @@ enum QEModalPresentationConstants {
     static let bottomSheetMinHeight: CGFloat = 350
 }
 
-@available(iOS 16.0, *)
-struct QuickEditorModalPresentationModifier<ModalView: View>: ViewModifier, ModalPresentationWithIntrinsicSize {
-    fileprivate typealias Constants = QEModalPresentationConstants
-
+struct QuickEditorBottomSheetViewControllerPresentationModifier: ViewModifier {
     @Binding var isPresented: Bool
-    @State private var isPresentedInner: Bool
-    @State private var sheetHeight: CGFloat = Constants.bottomSheetEstimatedHeight
-    @State private(set) var verticalSizeClass: UserInterfaceSizeClass?
-    @State private var presentationDetents: Set<PresentationDetent>
-    @State private var prioritizeScrollOverResize: Bool = false
-    @Environment(\.colorScheme) var colorScheme: ColorScheme
-    @State private var dismissAttempt: Bool = false
-    @State private var currentPage: QuickEditorPage
-
-    let onDismiss: (() -> Void)?
-    let modalView: ModalView
-    var scopeOption: QuickEditorScopeOption
-
-    init(isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, modalView: ModalView, scopeOption: QuickEditorScopeOption) {
-        self._isPresented = isPresented
-        self.isPresentedInner = isPresented.wrappedValue
-        self.onDismiss = onDismiss
-        self.modalView = modalView
-        self.scopeOption = scopeOption
-        self.currentPage = scopeOption.initialPage
-        self.presentationDetents = QEDetent.detents(
-            for: scopeOption,
-            intrinsicHeight: Constants.bottomSheetEstimatedHeight,
-            verticalSizeClass: nil,
-            currentPage: scopeOption.initialPage
-        ).map()
-    }
+    var quickEditorPresenter: QuickEditorBottomSheetPresenterViewControllerRepresentable
 
     func body(content: Content) -> some View {
-        content
-            .onChange(of: isPresented) { newValue in
-                if newValue {
-                    // First init the detents and then present. This helps with starting off with the correct state.
-                    // Otherwise the view remembers its previous height. And an animation glitch happens
-                    // when switching between different presentation styles (especially between horizontal and vertical_large).
-                    // Doing the same thing in .onAppear of the "modalView" doesn't give as nice results as this one don't know why.
-                    self.presentationDetents = QEDetent.detents(
-                        for: scopeOption,
-                        intrinsicHeight: max(sheetHeight, Constants.bottomSheetEstimatedHeight),
-                        verticalSizeClass: verticalSizeClass,
-                        currentPage: currentPage
-                    ).map()
-                }
-                isPresentedInner = newValue
+        content.if(isPresented) { content in
+            ZStack {
+                content
+                quickEditorPresenter
+                    .frame(width: 0, height: 0)
             }
-            .onChange(of: isPresentedInner) { newValue in
-                self.isPresented = newValue
-            }
-            .sheet(isPresented: $isPresentedInner, onDismiss: onDismiss) {
-                modalView
-                    .preferredColorScheme(colorScheme)
-                    .frame(minHeight: Constants.bottomSheetMinHeight)
-                    .onPreferenceChange(InnerHeightPreferenceKey.self) { newHeight in
-                        Task { @MainActor in
-                            if shouldAcceptHeight(newHeight) {
-                                sheetHeight = newHeight
-                            }
-                            updateDetents()
-                        }
-                    }
-                    .onPreferenceChange(VerticalSizeClassPreferenceKey.self) { newSizeClass in
-                        Task { @MainActor in
-                            guard newSizeClass != nil else { return }
-                            self.verticalSizeClass = newSizeClass
-                            updateDetents()
-                        }
-                    }
-                    .onPreferenceChange(QuikcEditorCurrentPagePreferenceKey.self) { newValue in
-                        Task { @MainActor in
-                            self.currentPage = newValue
-                            updateDetents()
-                        }
-                    }
-                    .presentationDetents(presentationDetents)
-                    .presentationContentInteraction(shouldPrioritizeScrolling: prioritizeScrollOverResize)
-                    .dismissAttemptDetecting(
-                        dismissAttempt: $dismissAttempt,
-                        isPresented: $isPresented,
-                        isLargeDetentOnly: presentationDetents == [.large]
-                    )
-                    .environment(\.dismissAttempt, dismissAttempt)
-            }
+        }
     }
-
-    private func updateDetents() {
-        self.presentationDetents = QEDetent.detents(
-            for: scopeOption,
-            intrinsicHeight: sheetHeight,
-            verticalSizeClass: verticalSizeClass,
-            currentPage: currentPage
-        ).map()
-        self.prioritizeScrollOverResize = shouldPrioritizeScrollOverResize
-    }
-}
-
-extension EnvironmentValues {
-    @Entry var dismissAttempt: Bool = false
 }
 
 @MainActor

--- a/Sources/GravatarUI/SwiftUI/QuickEditorModalPresentationModifier.swift
+++ b/Sources/GravatarUI/SwiftUI/QuickEditorModalPresentationModifier.swift
@@ -13,9 +13,10 @@ enum QEModalPresentationConstants {
     static let bottomSheetMinHeight: CGFloat = 350
 }
 
-struct QuickEditorBottomSheetViewControllerPresentationModifier: ViewModifier {
+struct QuickEditorBottomSheetViewControllerPresentationModifier<QuickEditorPresenter: View>: ViewModifier {
     @Binding var isPresented: Bool
-    var quickEditorPresenter: QuickEditorBottomSheetPresenterViewControllerRepresentable
+
+    var quickEditorPresenter: QuickEditorPresenter
 
     func body(content: Content) -> some View {
         content.if(isPresented) { content in

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -47,9 +47,8 @@ extension View {
         let editor = QuickEditorBottomSheetPresenterViewControllerRepresentable(
             email: .init(email),
             scopeOption: QuickEditorScopeOption.avatarPicker(),
-            configuration: QuickEditorConfiguration.default,
             token: authToken,
-            completion: nil,
+            customImageEditor: customImageEditor,
             onUpdate: { _ in
                 avatarUpdatedHandler?()
             },
@@ -93,9 +92,8 @@ extension View {
             let editor = QuickEditorBottomSheetPresenterViewControllerRepresentable(
                 email: .init(email),
                 scopeOption: scopeOption,
-                configuration: QuickEditorConfiguration.default,
                 token: authToken,
-                completion: nil,
+                customImageEditor: customImageEditor,
                 onUpdate: { _ in
                     avatarUpdatedHandler?()
                 },
@@ -135,9 +133,8 @@ extension View {
         let editor = QuickEditorBottomSheetPresenterViewControllerRepresentable(
             email: .init(email),
             scopeOption: scopeOption,
-            configuration: QuickEditorConfiguration.default,
             token: authToken,
-            completion: nil,
+            customImageEditor: customImageEditor,
             onUpdate: updateHandler,
             onDismiss: {
                 isPresented.wrappedValue = false
@@ -176,9 +173,8 @@ extension View {
         let editor = QuickEditorBottomSheetPresenterViewControllerRepresentable(
             email: .init(email),
             scopeOption: scope.map(),
-            configuration: QuickEditorConfiguration.default,
             token: authToken,
-            completion: nil,
+            customImageEditor: customImageEditor,
             onUpdate: updateHandler,
             onDismiss: {
                 isPresented.wrappedValue = false

--- a/Sources/GravatarUI/SwiftUI/View+Additions.swift
+++ b/Sources/GravatarUI/SwiftUI/View+Additions.swift
@@ -44,17 +44,24 @@ extension View {
         avatarUpdatedHandler: (() -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
-        let editor = QuickEditor(
+        let editor = QuickEditorBottomSheetPresenterViewControllerRepresentable(
             email: .init(email),
             scopeOption: QuickEditorScopeOption.avatarPicker(),
+            configuration: QuickEditorConfiguration.default,
             token: authToken,
-            isPresented: isPresented,
-            customImageEditor: customImageEditor,
-            updateHandler: { _ in
+            completion: nil,
+            onUpdate: { _ in
                 avatarUpdatedHandler?()
+            },
+            onDismiss: {
+                isPresented.wrappedValue = false
+                onDismiss?()
             }
         )
-        return modifier(ModalPresentationModifier(isPresented: isPresented, onDismiss: onDismiss, modalView: editor))
+        return modifier(QuickEditorBottomSheetViewControllerPresentationModifier(
+            isPresented: isPresented,
+            quickEditorPresenter: editor
+        ))
     }
 
     /// A modifier to display the QuickEditor sheet. The QuickEditor can be used to modify the information and avatar images of your Gravatar profile.
@@ -83,21 +90,23 @@ extension View {
         switch scope {
         case .avatarPicker(let config):
             let scopeOption = QuickEditorScopeOption.avatarPicker(.init(contentLayout: config.contentLayout))
-            let editor = QuickEditor(
+            let editor = QuickEditorBottomSheetPresenterViewControllerRepresentable(
                 email: .init(email),
                 scopeOption: scopeOption,
+                configuration: QuickEditorConfiguration.default,
                 token: authToken,
-                isPresented: isPresented,
-                customImageEditor: customImageEditor,
-                updateHandler: { _ in
+                completion: nil,
+                onUpdate: { _ in
                     avatarUpdatedHandler?()
+                },
+                onDismiss: {
+                    isPresented.wrappedValue = false
+                    onDismiss?()
                 }
             )
-            return modifier(QuickEditorModalPresentationModifier(
+            return modifier(QuickEditorBottomSheetViewControllerPresentationModifier(
                 isPresented: isPresented,
-                onDismiss: onDismiss,
-                modalView: editor,
-                scopeOption: scopeOption
+                quickEditorPresenter: editor
             ))
         }
     }
@@ -114,7 +123,6 @@ extension View {
     ///   - onDismiss: *(Optional)* A closure called when the sheet is dismissed.
     /// - Returns: A view modifier that presents the QuickEditor sheet.
     @ViewBuilder
-    @available(iOS 16, *)
     public func gravatarQuickEditorSheet(
         isPresented: Binding<Bool>,
         email: String,
@@ -124,19 +132,22 @@ extension View {
         updateHandler: ((QuickEditorUpdateType) -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
-        let editor = QuickEditor(
+        let editor = QuickEditorBottomSheetPresenterViewControllerRepresentable(
             email: .init(email),
             scopeOption: scopeOption,
+            configuration: QuickEditorConfiguration.default,
             token: authToken,
-            isPresented: isPresented,
-            customImageEditor: customImageEditor,
-            updateHandler: updateHandler
+            completion: nil,
+            onUpdate: updateHandler,
+            onDismiss: {
+                isPresented.wrappedValue = false
+                onDismiss?()
+            }
         )
-        modifier(QuickEditorModalPresentationModifier(
+
+        modifier(QuickEditorBottomSheetViewControllerPresentationModifier(
             isPresented: isPresented,
-            onDismiss: onDismiss,
-            modalView: editor,
-            scopeOption: scopeOption
+            quickEditorPresenter: editor
         ))
     }
 
@@ -162,22 +173,23 @@ extension View {
         updateHandler: ((QuickEditorUpdateType) -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
-        let editor = QuickEditor(
+        let editor = QuickEditorBottomSheetPresenterViewControllerRepresentable(
             email: .init(email),
             scopeOption: scope.map(),
+            configuration: QuickEditorConfiguration.default,
             token: authToken,
-            isPresented: isPresented,
-            customImageEditor: customImageEditor,
-            updateHandler: updateHandler
+            completion: nil,
+            onUpdate: updateHandler,
+            onDismiss: {
+                isPresented.wrappedValue = false
+                onDismiss?()
+            }
         )
 
-        modifier(
-            ModalPresentationModifier(
-                isPresented: isPresented,
-                onDismiss: onDismiss,
-                modalView: editor
-            )
-        )
+        modifier(QuickEditorBottomSheetViewControllerPresentationModifier(
+            isPresented: isPresented,
+            quickEditorPresenter: editor
+        ))
     }
 
     func altTextSheet(


### PR DESCRIPTION
Closes BETS-50

### Description

This PR is aimed to replace the native SwiftUI sheet presentation with the UIKit sheet presentation.

Wins from this changes are:

- Native transition animation on SwiftUI context when the sheet height changes.
- Native detection of dismissal attempt by the user.
- Half and full detents support for pre-iOS16 

### To Achieve this the follow changes were made:

`QuickEditorViewController` is now used by both UIKit and SwiftUI contexts. It wraps `QuickEditor` view in a `UIHostingController` to be presented by UIKit framework.

#### From UIKit context:
Not many changes. It uses the public `QuickEditorPresenter` to present `QuickEditorViewController` in a bottom sheet.

A change was made where the `CustomImageEditorControllerRepresentable` conversion is handled by `QuickEditorPresenter` directly, in order to remove UIKit dependencies from the `QuickEditorViewController` init parameters.

#### From SwiftUI context:

There's a new `QuickEditorBottomSheetPresenterViewController` which will present modally (on a sheet) the`QuickEditorViewController`. This part is the trick to do the presentation work.

Then `QuickEditorBottomSheetPresenterViewControllerRepresentable` wraps it in a Representable, to be able to be inserted into the SwiftUI hierarchy.

Then, `QuickEditorBottomSheetPresenterViewControllerRepresentable` is initialised with the properties given by the public `View.gravatarQuickEditorSheet` extension, and passed to a new view modifier `QuickEditorBottomSheetViewControllerPresentationModifier`.

The new `QuickEditorBottomSheetViewControllerPresentationModifier` modifier will conditionally add or remove the presenter controller to the hierarchy according to `isPresented` property. And it will ensure that its dimensions are zero to keep it hidden. Every time the controller is added to the hierarchy, it will automatically present the QuickEditorController in a sheet presentation.

### Testing Steps

#### From SwiftUI context:

- Native transition animation on SwiftUI context when the sheet height changes.
- Native detection of dismissal attempt by the user.
- Custom image editor injection.
- System color scheme, and user specified color scheme.
- Update callbacks to parent app.
- All different presentation styles.

#### From UIKit context:

Keen eye to:
- Custom image editor injection.
- System color scheme, and user specified color scheme.

As the rest has been mostly kept as it was before, but still good to smoke test everything else.