### PR TITLE
Remove strong references of self in closures

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
@@ -284,9 +284,9 @@ final class DemoQuickEditorViewController: UIViewController {
 
     lazy var schemeToggle: UISegmentedControl = {
         let control = UISegmentedControl(items: [
-            UIAction.init(title: "System") { _ in self.customColorScheme = .unspecified },
-            UIAction.init(title: "Light") { _ in self.customColorScheme = .light },
-            UIAction.init(title: "Dark") { _ in self.customColorScheme = .dark },
+            UIAction.init(title: "System") { [weak self] _ in self?.customColorScheme = .unspecified },
+            UIAction.init(title: "Light") { [weak self] _ in self?.customColorScheme = .light },
+            UIAction.init(title: "Dark") { [weak self] _ in self?.customColorScheme = .dark },
         ])
         control.selectedSegmentIndex = 0
         return control
@@ -294,8 +294,8 @@ final class DemoQuickEditorViewController: UIViewController {
 
     lazy var imageEditorToggle: UISegmentedControl = {
         let control = UISegmentedControl(items: [
-            UIAction.init(title: "Default Image Editor") { _ in self.useCustomImageEditor = false },
-            UIAction.init(title: "Custom Image Editor") { _ in self.useCustomImageEditor = true },
+            UIAction.init(title: "Default Image Editor") { [weak self] _ in self?.useCustomImageEditor = false },
+            UIAction.init(title: "Custom Image Editor") { [weak self] _ in self?.useCustomImageEditor = true },
         ])
         control.selectedSegmentIndex = 0
         return control

--- a/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorConfiguration.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public class QuickEditorConfiguration {
+public struct QuickEditorConfiguration {
     let interfaceStyle: UIUserInterfaceStyle
     let customImageEditorProvider: CustomImageEditorControllerProvider?
 

--- a/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
@@ -19,11 +19,11 @@ final class QuickEditorViewController<ImageEditor: ImageEditorView>: UIViewContr
 
     private lazy var isPresented: Binding<Bool> = Binding {
         true
-    } set: { isPresented in
-        Task { @MainActor in
+    } set: { [weak self] isPresented in
+        Task { @MainActor  in
             guard !isPresented else { return }
-            self.dismiss(animated: true)
-            self.onDismiss?()
+            self?.dismiss(animated: true)
+            self?.onDismiss?()
         }
     }
 
@@ -87,7 +87,6 @@ final class QuickEditorViewController<ImageEditor: ImageEditorView>: UIViewContr
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         quickEditor.willMove(toParent: self)
         addChild(quickEditor)
         view.addSubview(quickEditor.view)
@@ -111,7 +110,8 @@ final class QuickEditorViewController<ImageEditor: ImageEditorView>: UIViewContr
 
     func updateDetents() {
         if let sheet = sheetPresentationController {
-            sheet.animateChanges {
+            sheet.animateChanges { [weak self] in
+                guard let self = self else { return }
                 sheet.detents = QEDetent.detents(
                     for: scopeOption,
                     intrinsicHeight: sheetHeight,

--- a/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
+++ b/Sources/GravatarUI/QuickEditor/QuickEditorViewController.swift
@@ -20,7 +20,7 @@ final class QuickEditorViewController<ImageEditor: ImageEditorView>: UIViewContr
     private lazy var isPresented: Binding<Bool> = Binding {
         true
     } set: { [weak self] isPresented in
-        Task { @MainActor  in
+        Task { @MainActor in
             guard !isPresented else { return }
             self?.dismiss(animated: true)
             self?.onDismiss?()
@@ -111,7 +111,7 @@ final class QuickEditorViewController<ImageEditor: ImageEditorView>: UIViewContr
     func updateDetents() {
         if let sheet = sheetPresentationController {
             sheet.animateChanges { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 sheet.detents = QEDetent.detents(
                     for: scopeOption,
                     intrinsicHeight: sheetHeight,

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -121,11 +121,13 @@ class AvatarPickerViewModel: ObservableObject {
                 }.count
             }
             .combineLatest($selectedAvatarURL)
-            .map { loadedAvatarCount, selectedAvatarURL in
+            .map { [weak self] loadedAvatarCount, _ in
                 // Determine if the warning should be displayed
-                selectedAvatarURL == nil && loadedAvatarCount > 0
+                self?.selectedAvatarURL == nil && loadedAvatarCount > 0
             }
-            .assign(to: \.shouldDisplayNoSelectedAvatarWarning, on: self)
+            .sink { [weak self] shouldShowWarning in
+                self?.shouldDisplayNoSelectedAvatarWarning = shouldShowWarning
+            }
             .store(in: &cancellables)
 
         $profileResult.sink { [weak self] profileResult in

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerViewModel.swift
@@ -121,9 +121,9 @@ class AvatarPickerViewModel: ObservableObject {
                 }.count
             }
             .combineLatest($selectedAvatarURL)
-            .map { [weak self] loadedAvatarCount, _ in
+            .map { loadedAvatarCount, selectedAvatarURL in
                 // Determine if the warning should be displayed
-                self?.selectedAvatarURL == nil && loadedAvatarCount > 0
+                selectedAvatarURL == nil && loadedAvatarCount > 0
             }
             .sink { [weak self] shouldShowWarning in
                 self?.shouldDisplayNoSelectedAvatarWarning = shouldShowWarning


### PR DESCRIPTION
Closes #

### Description
This PR fixes a retain cycle on `QuickEditorViewController`, and in `DemoQuickEditorViewController` 

### Testing Steps

- Run the demo app
- Go to Quick Editor demo screen
- Display the Quick Editor
- Close and display it again a few times.
- Go back to the root screen of the demo app
- Check the Debug Memory Graph on xcode
  - Check that there are no references to `QuickEditorViewController`, `InnerHeightUIHostingController`, or `DemoQuickEditorViewController` in the graph. 