### PR TITLE
The edit button's fade away animation looks a bit glitchy

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileView.swift
@@ -47,6 +47,7 @@ struct AvatarPickerProfileView<AccessoryView>: View where AccessoryView: View {
             ZStack(alignment: .bottomTrailing) {
                 avatarView()
                 avatarAccessoryView()
+                    .zIndex(1)
             }
 
             if model == nil && isLoading {


### PR DESCRIPTION
Closes GRA-122

The edit button's fade away animation looks a bit glitchy, it hides behind the avatar before fully fading away.

https://github.com/user-attachments/assets/f47be73d-ded8-4078-9c3a-7e6477159d72


### Description

When the button is fading away there's a point where SwiftUI decides to degrade it in the ZStack hierarcy so it gets hidden behind the avarar before completely fading.

Setting its zIndex prevents it to be hidden behind the avatar before it completely fades. 

### Testing Steps

The animation issue displayed in the video should be fixed.