### PR TITLE
Fix vertical padding above the vertical avatar grid

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -296,6 +296,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
                     handleAvatarAction(avatar: avatar, action: action)
                 }
             )
+            .padding(.top, .DS.Padding.double)
             .padding(.horizontal, Constants.horizontalPadding)
         } else {
             HorizontalAvatarGrid(


### PR DESCRIPTION
Closes BETS-51

No space above the avatars grid:

<img src="https://github.com/user-attachments/assets/7db981b9-1131-4c80-8bb5-2f9c8e0423e6" width=300/>

### Description

Adding space so the "after" looks like this:

<img src="https://github.com/user-attachments/assets/69175356-2257-4cbd-8c3d-de640cff5491" width=300/>

### Testing Steps

Check the spacing above the vertical avatar grid in the QE