### PR TITLE
Disable fields on save

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
@@ -226,6 +226,7 @@ struct AboutEditorView: View {
                     .padding(.vertical, 0)
                     .inputBorders(colorScheme: colorScheme)
                     .frame(height: dynamicTypeSize >= .accessibility1 ? 150 : 120)
+                    .disabled(isSaving)
             } else {
                 TextField(
                     "",
@@ -234,6 +235,7 @@ struct AboutEditorView: View {
                 .font(Constants.primaryFont)
                 .padding(.DS.Padding.split)
                 .inputBorders(colorScheme: colorScheme)
+                .disabled(isSaving)
             }
 
             if let footerText {


### PR DESCRIPTION
Closes GRA-124

### Description

This PR is meant to disable the About editor fields while the save request is ongoing.

I tried changing the style of the fields for a visual feedback but there's an issue with the text `TextEditor` on pre-iOS16

<img src="https://github.com/user-attachments/assets/c7b0e939-30c4-4731-a925-abecbdca00ec" width="40%"><img src="https://github.com/user-attachments/assets/946854e5-f343-4790-9aa2-7ab7188f2e65" width="40%">

To be able to remove this white background from the text on pre-iOS16, we need to call:
`UITextView.appearance().backgroundColor = .clear`

Which doesn't seem good to do from an external library.

### Testing Steps

- Open the Quick Editor with About editor scope
- Save some changes
  - Check that the fields are disabled while the request is ongoing. 