### PR TITLE
Disable unwanted scroll bouncing

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerView.swift
@@ -84,6 +84,7 @@ struct AvatarPickerView<ImageEditor: ImageEditorView>: View {
                     }
                     .accumulateIntrinsicHeight()
                 }
+                .scrollingEnabled(contentLayoutProvider.contentLayout == .vertical || verticalSizeClass == .compact)
                 .confirmationDialog(
                     Localized.uploadErrorTitle,
                     isPresented: $isUploadErrorDialogPresented,
@@ -532,4 +533,14 @@ enum AvatarPicker {
 #Preview("Load from network") {
     /// Enter valid email and auth token.
     AvatarPickerView<NoCustomEditor>(model: AvatarPickerViewModel(email: .init(""), authToken: ""), isPresented: .constant(true))
+}
+
+extension View {
+    func scrollingEnabled(_ enabled: Bool) -> some View {
+        if #available(iOS 16.0, *) {
+            return self.scrollDisabled(!enabled)
+        } else {
+            return self
+        }
+    }
 }


### PR DESCRIPTION
Closes BETS-52

### Description

This PR is aimed to remove the unwanted bouncing of the Avatar Picker when it's on horizontal layout.

![CleanShot 2025-06-03 at 20 16 10](https://github.com/user-attachments/assets/46f09425-0cd9-4d62-823b-d923d358bddf)

### Testing Steps

- Run the demo app
- Go to Quick Editor demo screen
- Present the quick editor with Avatar Picker scope in horizontal layout.
  - Check that there is no bouncing on the avatars section. 
  - Check that scroll is enabled on landscape.
- Smoke-test other layouts and configurations. 