### PR TITLE
Using `LazyHGrid` on `HorizontalAvatarGrid`

### DIFF
--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/HorizontalAvatarGrid.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/Views/HorizontalAvatarGrid.swift
@@ -5,6 +5,14 @@ struct HorizontalAvatarGrid: View {
         static let avatarSpacing: CGFloat = .DS.Padding.single
     }
 
+    private let gridItems: [GridItem] = [GridItem(
+        .adaptive(
+            minimum: AvatarGridConstants.minAvatarWidth,
+            maximum: AvatarGridConstants.maxAvatarWidth
+        ),
+        spacing: AvatarGridConstants.avatarSpacing
+    )]
+
     @ObservedObject var grid: AvatarGridModel
 
     let onAvatarTap: (AvatarImageModel) -> Void
@@ -13,7 +21,7 @@ struct HorizontalAvatarGrid: View {
 
     var body: some View {
         ScrollView(.horizontal) {
-            HStack(spacing: Constants.avatarSpacing) {
+            LazyHGrid(rows: gridItems, spacing: Constants.avatarSpacing) {
                 ForEach(grid.avatars, id: \.self) { avatar in
                     AvatarPickerAvatarView(
                         avatar: avatar,


### PR DESCRIPTION
Closes GRA-141

### Description

This PR is aimed to solve the issue described on https://github.com/Automattic/Gravatar-SDK-iOS/pull/776#issuecomment-2939335099.

The issue was point down to the number of avatars being loaded at once. Solved by using `LazyHGrid`.

### Testing Steps

Steps shown on https://github.com/Automattic/Gravatar-SDK-iOS/pull/776#issuecomment-2939335099

- On device - dragging down the sheet having many avatars (over 30) should be smooth