### PR TITLE
Accessibility mark iii

### DIFF
--- a/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
+++ b/Demo/Demo/Gravatar-Demo/DemoQuickEditorViewController.swift
@@ -48,7 +48,7 @@ final class DemoQuickEditorViewController: BaseFormViewController {
     )
 
     lazy var initialPageButton = ButtonLabelField(
-        title: "Initital Page",
+        title: "Initial Page",
         subtitle: selectedInitialPage.rawValue,
         buttonTitle: "Select",
         menuActions: InitialPage.allCases.compactMap { [weak self] page in

--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -266,7 +266,7 @@
 "Profile.Update.Success" = "Profile updated successfully";
 
 /* Accessible label for button to switch to the About editor. */
-"AvatarPickerProfile.PageSwitchButton.AboutEditor" = "Switch to About editor";
+"AvatarPickerProfile.PageSwitchButton.AboutEditor" = "Switch to about editor";
 
 /* Accessible label for button to switch to the Avatar picker. */
-"AvatarPickerProfile.PageSwitchButton.AvatarPicker" = "Switch to Avatar picker";
+"AvatarPickerProfile.PageSwitchButton.AvatarPicker" = "Switch to avatar picker";

--- a/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/GravatarUI/Resources/en.lproj/Localizable.strings
@@ -264,3 +264,9 @@
 
 /* This confirmation message shows when the user updates fields of their profile. */
 "Profile.Update.Success" = "Profile updated successfully";
+
+/* Accessible label for button to switch to the About editor. */
+"AvatarPickerProfile.PageSwitchButton.AboutEditor" = "Switch to About editor";
+
+/* Accessible label for button to switch to the Avatar picker. */
+"AvatarPickerProfile.PageSwitchButton.AvatarPicker" = "Switch to Avatar picker";

--- a/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
+++ b/Sources/GravatarUI/SwiftUI/AboutEditor/AboutEditorView.swift
@@ -218,6 +218,7 @@ struct AboutEditorView: View {
             Text(title)
                 .font(Constants.primaryFont)
                 .multilineTextAlignment(.leading)
+                .accessibilityHidden(true)
             if isLarge {
                 TextEditor(text: value)
                     .font(Constants.primaryFont)
@@ -227,6 +228,7 @@ struct AboutEditorView: View {
                     .inputBorders(colorScheme: colorScheme)
                     .frame(height: dynamicTypeSize >= .accessibility1 ? 150 : 120)
                     .disabled(isSaving)
+                    .accessibilityLabel(title)
             } else {
                 TextField(
                     "",
@@ -236,6 +238,7 @@ struct AboutEditorView: View {
                 .padding(.DS.Padding.split)
                 .inputBorders(colorScheme: colorScheme)
                 .disabled(isSaving)
+                .accessibilityLabel(title)
             }
 
             if let footerText {

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileViewWrapper.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileViewWrapper.swift
@@ -90,10 +90,19 @@ struct AvatarPickerProfileViewWrapper: View {
 
 extension String {
     fileprivate static var localizedEditAboutEditorButtonLabel: String {
-        SDKLocalizedString("AvatarPickerProfile.PageSwitchButton.AboutEditor", value: "Switch to about editor", comment: "Accessible label for button to switch to the About editor")
+        SDKLocalizedString(
+            "AvatarPickerProfile.PageSwitchButton.AboutEditor",
+            value: "Switch to about editor",
+            comment: "Accessible label for button to switch to the About editor"
+        )
     }
+
     fileprivate static var localizedEditAvatarsButtonLabel: String {
-        SDKLocalizedString("AvatarPickerProfile.PageSwitchButton.AvatarPicker", value: "Switch to avatar picker", comment: "Accessible label for button to switch to the Avatar picker")
+        SDKLocalizedString(
+            "AvatarPickerProfile.PageSwitchButton.AvatarPicker",
+            value: "Switch to avatar picker",
+            comment: "Accessible label for button to switch to the Avatar picker"
+        )
     }
 }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileViewWrapper.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileViewWrapper.swift
@@ -27,7 +27,7 @@ struct AvatarPickerProfileViewWrapper: View {
                     isLoading: $isLoading,
                     avatarAccessoryView: {
                         if case .avatar = buttonsMode {
-                            editButton {
+                            editButton(accessibilityLabel: .localizedEditAvatarsButtonLabel) {
                                 buttonTapHandler?(.avatar)
                             }
                         } else {
@@ -47,7 +47,7 @@ struct AvatarPickerProfileViewWrapper: View {
                 .background(profileBackground)
                 .cornerRadius(8)
                 if case .aboutInfo = buttonsMode {
-                    editButton {
+                    editButton(accessibilityLabel: .localizedEditAboutEditorButtonLabel) {
                         buttonTapHandler?(.aboutInfo)
                     }.padding()
                 }
@@ -74,7 +74,7 @@ struct AvatarPickerProfileViewWrapper: View {
     }
 
     @ViewBuilder
-    private func editButton(action: @escaping () -> Void) -> some View {
+    private func editButton(accessibilityLabel: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image("pencil", bundle: Bundle.module)
                 .resizable()
@@ -83,7 +83,17 @@ struct AvatarPickerProfileViewWrapper: View {
                 .padding(6)
                 .background(Color.white)
                 .clipShape(Circle())
+                .accessibilityLabel(accessibilityLabel)
         }
+    }
+}
+
+extension String {
+    fileprivate static var localizedEditAboutEditorButtonLabel: String {
+        SDKLocalizedString("AvatarPickerProfile.PageSwitchButton.AboutEditor", value: "Switch to About editor", comment: "Accessible label for button to switch to the About editor")
+    }
+    fileprivate static var localizedEditAvatarsButtonLabel: String {
+        SDKLocalizedString("AvatarPickerProfile.PageSwitchButton.AvatarPicker", value: "Switch to Avatar picker", comment: "Accessible label for button to switch to the Avatar picker")
     }
 }
 

--- a/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileViewWrapper.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarPicker/AvatarPickerProfileViewWrapper.swift
@@ -90,10 +90,10 @@ struct AvatarPickerProfileViewWrapper: View {
 
 extension String {
     fileprivate static var localizedEditAboutEditorButtonLabel: String {
-        SDKLocalizedString("AvatarPickerProfile.PageSwitchButton.AboutEditor", value: "Switch to About editor", comment: "Accessible label for button to switch to the About editor")
+        SDKLocalizedString("AvatarPickerProfile.PageSwitchButton.AboutEditor", value: "Switch to about editor", comment: "Accessible label for button to switch to the About editor")
     }
     fileprivate static var localizedEditAvatarsButtonLabel: String {
-        SDKLocalizedString("AvatarPickerProfile.PageSwitchButton.AvatarPicker", value: "Switch to Avatar picker", comment: "Accessible label for button to switch to the Avatar picker")
+        SDKLocalizedString("AvatarPickerProfile.PageSwitchButton.AvatarPicker", value: "Switch to avatar picker", comment: "Accessible label for button to switch to the Avatar picker")
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/Automattic/Gravatar-SDK-iOS/issues/675

### Description

This PR makes the page switch buttons on the profile card accessible with a label for Voice Over.
- Note that the design itself is not good for accessibility, and grouping all the card together will make it difficult for the system to read out the image description. So I decided to go with the simpler route and name the buttons appropriately, even with the confusion of the position change for voice over users.

We also mix the textfield title and value together as one accessibility element in the About Editor page, which is the recommendation for these cases.

### Testing Steps

- Run the demo app
- Go to Quick Editor demo
- Present the quick editor with the Avatar & About scope
- Turn ON Voice Over
  - Check that Voice Over reads the label on the page switch buttons.
  - Check that on the About Editor page, Voice Over reads the title and the fields content together, and does not interact with the title label. 

