### PR TITLE
Clear warnings

### DIFF
--- a/Demo/Demo/Gravatar-Demo/SwiftUI/ContentView.swift
+++ b/Demo/Demo/Gravatar-Demo/SwiftUI/ContentView.swift
@@ -30,7 +30,7 @@ struct ContentView: View {
                 }
                 .navigationTitle("Gravatar SwiftUI Demo")
                 .navigationBarTitleDisplayMode(.inline)
-                .toolbar<DemoToolbarContentView> {
+                .toolbar {
                     DemoToolbarContentView(onDismiss: onDismiss)
                 }
             }
@@ -46,7 +46,7 @@ struct ContentView: View {
                 .listStyle(.plain)
                 .navigationTitle("Gravatar SwiftUI Demo")
                 .navigationBarTitleDisplayMode(.inline)
-                .toolbar<DemoToolbarContentView> {
+                .toolbar {
                     DemoToolbarContentView(onDismiss: onDismiss)
                 }
             }

--- a/Sources/GravatarUI/ProfileView/BaseProfileView.swift
+++ b/Sources/GravatarUI/ProfileView/BaseProfileView.swift
@@ -410,7 +410,7 @@ open class BaseProfileView: UIView, UIContentView {
         if let avatarProvider = avatarProvider as? DefaultAvatarProvider {
             avatarProvider.cornerRadiusCalculator = config.avatarConfiguration.cornerRadiusCalculator
             avatarProvider.avatarBorderWidth = config.avatarConfiguration.borderWidth
-            avatarProvider.avatarBorderColor = config.palette.palette.border
+            avatarProvider.avatarBorderColor = config.palette.palette.avatar.border
         }
         if let length = config.avatarConfiguration.avatarLength {
             avatarLength = length

--- a/Sources/GravatarUI/ProfileView/BaseProfileView.swift
+++ b/Sources/GravatarUI/ProfileView/BaseProfileView.swift
@@ -410,7 +410,7 @@ open class BaseProfileView: UIView, UIContentView {
         if let avatarProvider = avatarProvider as? DefaultAvatarProvider {
             avatarProvider.cornerRadiusCalculator = config.avatarConfiguration.cornerRadiusCalculator
             avatarProvider.avatarBorderWidth = config.avatarConfiguration.borderWidth
-            avatarProvider.avatarBorderColor = config.avatarConfiguration.borderColor
+            avatarProvider.avatarBorderColor = config.palette.palette.border
         }
         if let length = config.avatarConfiguration.avatarLength {
             avatarLength = length

--- a/Sources/GravatarUI/ProfileView/BaseProfileView.swift
+++ b/Sources/GravatarUI/ProfileView/BaseProfileView.swift
@@ -410,7 +410,7 @@ open class BaseProfileView: UIView, UIContentView {
         if let avatarProvider = avatarProvider as? DefaultAvatarProvider {
             avatarProvider.cornerRadiusCalculator = config.avatarConfiguration.cornerRadiusCalculator
             avatarProvider.avatarBorderWidth = config.avatarConfiguration.borderWidth
-            avatarProvider.avatarBorderColor = config.palette.palette.avatar.border
+            avatarProvider.avatarBorderColor = config.avatarConfiguration.borderColor
         }
         if let length = config.avatarConfiguration.avatarLength {
             avatarLength = length

--- a/Sources/GravatarUI/SwiftUI/AvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarView.swift
@@ -100,16 +100,18 @@ public struct AvatarView<LoadingView: View, Placeholder: View>: View {
         with: .email("email@google.com"),
         options: .init(preferredSize: .points(100))
     )
+
     return AvatarView(
         url: avatarURL?.url,
-        placeholder: Image(systemName: "person")
-            .renderingMode(.template)
-            .resizable(),
+        placeholderView: {
+            Image(systemName: "person")
+                .renderingMode(.template)
+                .resizable()
+        },
         loadingView: {
             ProgressView()
                 .progressViewStyle(CircularProgressViewStyle())
-        },
-        transaction: Transaction(animation: .easeInOut(duration: 1))
+        }, transaction:  Transaction(animation: .easeInOut(duration: 1))
     )
     .shape(RoundedRectangle(cornerRadius: 20), borderColor: Color.accentColor, borderWidth: 2)
     .frame(width: 100, height: 100, alignment: .center)

--- a/Sources/GravatarUI/SwiftUI/AvatarView.swift
+++ b/Sources/GravatarUI/SwiftUI/AvatarView.swift
@@ -111,7 +111,8 @@ public struct AvatarView<LoadingView: View, Placeholder: View>: View {
         loadingView: {
             ProgressView()
                 .progressViewStyle(CircularProgressViewStyle())
-        }, transaction:  Transaction(animation: .easeInOut(duration: 1))
+        },
+        transaction: Transaction(animation: .easeInOut(duration: 1))
     )
     .shape(RoundedRectangle(cornerRadius: 20), borderColor: Color.accentColor, borderWidth: 2)
     .frame(width: 100, height: 100, alignment: .center)

--- a/Tests/GravatarUITests/ProfileConfigurationTests.swift
+++ b/Tests/GravatarUITests/ProfileConfigurationTests.swift
@@ -106,11 +106,11 @@ final class TestProfileConfiguration: XCTestCase {
         var config = ProfileViewConfiguration.largeSummary(model: model)
         let view = config.makeContentView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        config.palette = .custom({
+        config.palette = .custom {
             Palette.light.withReplacing { avatarColors in
                 AvatarColors(border: .green, background: avatarColors.background)
             }
-        })
+        }
 
         config.avatarConfiguration.borderWidth = 2
         config.avatarConfiguration.cornerRadiusCalculator = { avatarLength in

--- a/Tests/GravatarUITests/ProfileConfigurationTests.swift
+++ b/Tests/GravatarUITests/ProfileConfigurationTests.swift
@@ -108,7 +108,7 @@ final class TestProfileConfiguration: XCTestCase {
         view.translatesAutoresizingMaskIntoConstraints = false
         config.palette = .custom {
             Palette.light.withReplacing { avatarColors in
-                AvatarColors(border: .green, background: avatarColors.background)
+                avatarColors.withReplacing(border: .green)
             }
         }
 

--- a/Tests/GravatarUITests/ProfileConfigurationTests.swift
+++ b/Tests/GravatarUITests/ProfileConfigurationTests.swift
@@ -106,9 +106,13 @@ final class TestProfileConfiguration: XCTestCase {
         var config = ProfileViewConfiguration.largeSummary(model: model)
         let view = config.makeContentView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        config.palette = .light
+        config.palette = .custom({
+            Palette.light.withReplacing { avatarColors in
+                AvatarColors(border: .green, background: avatarColors.background)
+            }
+        })
+
         config.avatarConfiguration.borderWidth = 2
-        config.avatarConfiguration.borderColor = .green
         config.avatarConfiguration.cornerRadiusCalculator = { avatarLength in
             avatarLength / 10
         }


### PR DESCRIPTION
Closes BETS-53

### Description

This PR clear all reminding warnings on the project.

**Note:** There is one warning left which is necessary to keep giving support for the deprecated `AvatarConfiguration.borderColor` property.

### Testing Steps

CI: 🍏 