### PR TITLE
Remove profile card on iPhone SE 1st Gen with keyboard enabled

### DIFF
--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -226,9 +226,18 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
         }
     }
 
+    var shouldHideProfileCardHeader: Bool {
+        let screenHeight = UIScreen.main.bounds.height
+        // The iPhone SE (1st Gen) only supports iOS 15.5 and lower.
+        // This can be removed after removing support for iOS 15
+        let iPhoneSE1stGenScreenHeight: CGFloat = 568
+
+        return (vertcalSizeClass == .compact || screenHeight <= iPhoneSE1stGenScreenHeight) && model.isKeyboardPresented
+    }
+
     @ViewBuilder
     func profileCardHeaderView() -> some View {
-        if !(vertcalSizeClass == .compact && model.isKeyboardPresented) {
+        if !shouldHideProfileCardHeader {
             EmailText(email: model.email)
                 .accumulateIntrinsicHeight()
             profileView()

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -228,11 +228,9 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
 
     var shouldHideProfileCardHeader: Bool {
         let screenHeight = UIScreen.main.bounds.height
-        // The iPhone SE (1st Gen) only supports iOS 15.5 and lower.
-        // This can be removed after removing support for iOS 15
-        let iPhoneSE1stGenScreenHeight: CGFloat = 568
+        let iPhoneSE3rdGenScreenHeight: CGFloat = 667
 
-        return (vertcalSizeClass == .compact || screenHeight <= iPhoneSE1stGenScreenHeight) && model.isKeyboardPresented
+        return (vertcalSizeClass == .compact || screenHeight <= iPhoneSE3rdGenScreenHeight) && model.isKeyboardPresented
     }
 
     @ViewBuilder


### PR DESCRIPTION
Closes GRA-179

### Description

This PR address a problem where the About fields wouldn't be visible on an iPhone SE 1st gen with the keyboard enabled.
Now the Profile card is removed on this case.

**Note:** We have decided to also include other iPhone SE and iPhone 8 to this logic.

![CleanShot 2025-06-12 at 13 03 17@2x](https://github.com/user-attachments/assets/e6c47c59-4f67-47d7-8b4e-bad1903850e6)



### Testing Steps

- Run the demo app on an iPhone SE 1st gen 
- Open the Quick Editor on About Editor scope
- Edit a field with the keyboard present
  - Check that the field is visible 
