### PR TITLE
Using device orientation to hide profile card

### DIFF
--- a/Sources/GravatarUI/SwiftUI/DeviceOrientationPropertyWrapper.swift
+++ b/Sources/GravatarUI/SwiftUI/DeviceOrientationPropertyWrapper.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import Combine
+
+enum Orientation {
+    case landscape
+    case portrait
+    case unknown
+}
+
+@propertyWrapper struct DeviceOrientation: DynamicProperty {
+    @StateObject private var manager = DeviceOrientationManager()
+
+    var wrappedValue: Orientation {
+        manager.orientation
+    }
+}
+
+private class DeviceOrientationManager: ObservableObject {
+    @Published var orientation: Orientation = .unknown
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    @MainActor
+    init() {
+        orientation = UIDevice.current.orientation.map()
+
+        NotificationCenter.default
+            .publisher(for: UIDevice.orientationDidChangeNotification)
+            .sink() { [weak self] _ in
+                self?.orientation = UIDevice.current.orientation.map()
+            }
+            .store(in: &cancellables)
+    }
+}
+
+extension UIDeviceOrientation {
+    fileprivate func map() -> Orientation {
+        switch self {
+        case .portrait, .portraitUpsideDown:
+            return .portrait
+        case .landscapeLeft, .landscapeRight:
+            return .landscape
+        default:
+            return .unknown
+        }
+    }
+}

--- a/Sources/GravatarUI/SwiftUI/DeviceOrientationPropertyWrapper.swift
+++ b/Sources/GravatarUI/SwiftUI/DeviceOrientationPropertyWrapper.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import Combine
+import SwiftUI
 
 enum Orientation {
     case landscape
@@ -7,7 +7,8 @@ enum Orientation {
     case unknown
 }
 
-@propertyWrapper struct DeviceOrientation: DynamicProperty {
+@propertyWrapper
+struct DeviceOrientation: DynamicProperty {
     @StateObject private var manager = DeviceOrientationManager()
 
     var wrappedValue: Orientation {
@@ -26,7 +27,7 @@ private class DeviceOrientationManager: ObservableObject {
 
         NotificationCenter.default
             .publisher(for: UIDevice.orientationDidChangeNotification)
-            .sink() { [weak self] _ in
+            .sink { [weak self] _ in
                 self?.orientation = UIDevice.current.orientation.map()
             }
             .store(in: &cancellables)
@@ -37,11 +38,11 @@ extension UIDeviceOrientation {
     fileprivate func map() -> Orientation {
         switch self {
         case .portrait, .portraitUpsideDown:
-            return .portrait
+            .portrait
         case .landscapeLeft, .landscapeRight:
-            return .landscape
+            .landscape
         default:
-            return .unknown
+            .unknown
         }
     }
 }

--- a/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
+++ b/Sources/GravatarUI/SwiftUI/ProfileEditor/QuickEditor.swift
@@ -28,8 +28,9 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
 
     @Environment(\.oauthSession) private var oauthSession
     @Environment(\.colorScheme) var colorScheme: ColorScheme
-    @Environment(\.verticalSizeClass) var vertcalSizeClass
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
+
+    @DeviceOrientation var deviceOrientation
 
     @AppStorage("QuickEditor.startOAuthOnAppear") private var startOAuthOnAppear: Bool = false
     @State private var fetchedToken: String?
@@ -232,7 +233,7 @@ struct QuickEditor<ImageEditor: ImageEditorView>: View {
         let iPhoneSE3rdGenScreenHeight: CGFloat = 667
 
         return model.isKeyboardPresented && (
-            vertcalSizeClass == .compact ||
+            deviceOrientation == .landscape ||
                 screenHeight <= iPhoneSE3rdGenScreenHeight ||
                 dynamicTypeSize >= .accessibility3
         )


### PR DESCRIPTION
Closes GRA-194

### Description

This PR fixes a problem on iPad mini when the device is rotated in Landscape mode.
Now the About fields are visible after removing the Profile view on landscape, when the keyboard is present.

![image](https://github.com/user-attachments/assets/00dd4583-683e-426b-b03a-cfb284cd8721)

### Testing Steps

- Run the demo app on the iPad mini
- Present the Quick Editor on About Editor scope
- Edit a field
- Turn to Landscape
  - Check that the Profile view is hidden, and the fields are visible.

 
