### PR TITLE
Replace ☢️ with :danger: in Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,7 +37,7 @@ steps:
         agents:
           queue: "default"
 
-      - label: ☢️ Danger - PR Check
+      - label: ":danger: Danger - PR Check"
         command: danger
         key: danger
         if: build.pull_request.id != null


### PR DESCRIPTION
Replace ☢️ emoji with custom Buildkite `:danger:` emoji in the Danger CI step label.

See also:
- wordpress-mobile/release-toolkit#690
- wordpress-mobile/WordPress-iOS#25250
- Automattic/Gravatar-SDK-Android#676
- Automattic/pocket-casts-android#4986

---

*This PR was created autonomously by Claude Code (Opus 4.6) on behalf of @mokagio.*