### PR TITLE
Enable SwiftLint rule: empty_string

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,6 +2,7 @@ swiftlint_version: 0.57.1
 only_rules: # Rules to run
   - custom_rules
   - empty_count
+  - empty_string
 
 # If true, SwiftLint will treat all warnings as errors.
 strict: true


### PR DESCRIPTION
## Summary

- Enable the `empty_string` SwiftLint rule, which flags comparisons like `string == ""` in favor of `.isEmpty`.
- 0 auto-fixed violations — the codebase already complies.
- 0 manual fixes needed.

This is part of the [Orchard SwiftLint rollout campaign](https://github.com/nicktmro/orchard).

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*