### PR TITLE
Enable SwiftLint rule: contains_over_filter_is_empty

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,6 @@
 swiftlint_version: 0.57.1
 only_rules: # Rules to run
+  - contains_over_filter_is_empty
   - custom_rules
   - empty_count
   - empty_string


### PR DESCRIPTION
## Summary

- Enable the `contains_over_filter_is_empty` SwiftLint rule
- Zero existing violations — config-only change to `.swiftlint.yml`
- Part of the Orchard SwiftLint rules rollout campaign

## What does this rule do?

Prefer `contains` over comparing `filter(where:)` to an empty collection.
For example, `myList.filter { $0 > 1 }.isEmpty` should be `!myList.contains { $0 > 1 }`.

## Test plan

- [x] SwiftLint passes with the new rule enabled (0 violations in 259 files)
- [ ] CI passes

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*