### PR TITLE
Update addressable to 2.9.0 (CVE-2026-35611)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,8 +17,8 @@ GEM
       minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
@@ -412,4 +412,4 @@ DEPENDENCIES
   rubocop (~> 1.65)
 
 BUNDLED WITH
-   2.5.20
+   2.6.8


### PR DESCRIPTION
Fixes AINFRA-2264

## Summary
- Bumps `addressable` gem from vulnerable version to 2.9.0
- Fixes CVE-2026-35611 (GHSA-h27x-rffw-24p4) — high severity ReDoS in Addressable templates
- Vulnerable range: `>= 2.3.0, < 2.9.0`

## Test plan
- [ ] CI passes
- [ ] No changes to app behavior (transitive dependency only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)