### PR TITLE
Fix typos in comments and docs

### DIFF
--- a/CODINGSTYLE.md
+++ b/CODINGSTYLE.md
@@ -14,7 +14,7 @@ You can run `SwiftFormat` locally with `make lint` to get warnings, or `make swi
 
 - Always UPPERCASED when it's part of a Type name.
 - Use lowercase everytime it's a prefix, and is not a type name.
-- Use lowercase if it's writen alone, and it's not a type name.
+- Use lowercase if it's written alone, and it's not a type name.
 
 For example:
 

--- a/Sources/Gravatar/Cache/ImageCaching.swift
+++ b/Sources/Gravatar/Cache/ImageCaching.swift
@@ -45,10 +45,10 @@ public struct ImageCache: ImageCaching {
 
 private class NSCacheForImage: NSCache<NSString, CacheEntryObject>, @unchecked Sendable {}
 
-/// ImageCache can save an in-progress task of retreiving an image from remote.
+/// ImageCache can save an in-progress task of retrieving an image from remote.
 /// This enum represent both possible states for an image in the cache system.
 public enum CacheEntry: Sendable {
-    /// A task of retreiving an image is in progress.
+    /// A task of retrieving an image is in progress.
     case inProgress(Task<UIImage, Error>)
     /// An image instance is readily available.
     case ready(UIImage)

--- a/Sources/Gravatar/Extensions/UIImage+Square.swift
+++ b/Sources/Gravatar/Extensions/UIImage+Square.swift
@@ -55,7 +55,7 @@ extension UIImage {
         return (shortEdge * scale) / (longEdge * scale)
     }
 
-    /// Returns the lenght of the shorter edge of an image
+    /// Returns the length of the shorter edge of an image
     var shortEdge: CGFloat {
         min(self.size.width, self.size.height)
     }

--- a/Sources/GravatarUI/GravatarUI.docc/Tutorials/ContactsList/Tut_05.swift
+++ b/Sources/GravatarUI/GravatarUI.docc/Tutorials/ContactsList/Tut_05.swift
@@ -8,7 +8,7 @@ class TableViewController: UITableViewController {
         let profile = try await service.fetch(with: .email(email))
 
         // Create a Summary ProfileViewConfiguration to display the profile obtained,
-        // and store it to be retreived later on.
+        // and store it to be retrieved later on.
         models[email] = .summary(model: profile)
 
         // Reload the cell for the given email.

--- a/Sources/GravatarUI/ProfileView/LargeProfileSummaryView.swift
+++ b/Sources/GravatarUI/ProfileView/LargeProfileSummaryView.swift
@@ -2,7 +2,7 @@ import Gravatar
 import UIKit
 
 /// ![](largeProfileSummaryView.view)
-/// A  profile view with large avatar image and summarized information..
+/// A profile view with large avatar image and summarized information.
 public class LargeProfileSummaryView: BaseProfileView {
     private enum Constants {
         static let avatarLength: CGFloat = 132.0

--- a/Sources/GravatarUI/ProfileView/LargeProfileSummaryView.swift
+++ b/Sources/GravatarUI/ProfileView/LargeProfileSummaryView.swift
@@ -2,7 +2,7 @@ import Gravatar
 import UIKit
 
 /// ![](largeProfileSummaryView.view)
-/// A  profile view with large avatar image and sumarized information..
+/// A  profile view with large avatar image and summarized information..
 public class LargeProfileSummaryView: BaseProfileView {
     private enum Constants {
         static let avatarLength: CGFloat = 132.0

--- a/Sources/GravatarUI/ProfileView/ProfileSummaryView.swift
+++ b/Sources/GravatarUI/ProfileView/ProfileSummaryView.swift
@@ -2,7 +2,7 @@ import Gravatar
 import UIKit
 
 /// ![](profileSummaryView.view)
-/// A smaller profile view with sumarized information
+/// A smaller profile view with summarized information
 public class ProfileSummaryView: BaseProfileView {
     private lazy var basicInfoStackView: UIStackView = {
         let stack = UIStackView(arrangedSubviews: [displayNameLabel, personalInfoLabel, profileButton])

--- a/Sources/GravatarUI/ProfileView/ProfileViewConfiguration.swift
+++ b/Sources/GravatarUI/ProfileView/ProfileViewConfiguration.swift
@@ -30,7 +30,7 @@ public struct ProfileViewConfiguration: UIContentConfiguration {
     /// A customization block on the PaletteType. Set this if you need to partially alter the current palette.
     public var paletteCustomizer: PaletteCustomizer?
     /// Creates a padding space around the content of the profile view.
-    /// To remove all pading, set this to zero.
+    /// To remove all padding, set this to zero.
     public var padding: UIEdgeInsets = BaseProfileView.defaultPadding
     /// Whether the state of the view is `loading`.
     /// Set this property to `true` when the profile information is being retrieved and not yet set to the profile view.

--- a/Sources/GravatarUI/ProfileView/ProfileViewConfiguration.swift
+++ b/Sources/GravatarUI/ProfileView/ProfileViewConfiguration.swift
@@ -32,8 +32,8 @@ public struct ProfileViewConfiguration: UIContentConfiguration {
     /// Creates a padding space around the content of the profile view.
     /// To remove all pading, set this to zero.
     public var padding: UIEdgeInsets = BaseProfileView.defaultPadding
-    /// Wether the state of the view is `loading`.
-    /// Set this property to `true` when the profile information is being retreived and not yet set to the profile view.
+    /// Whether the state of the view is `loading`.
+    /// Set this property to `true` when the profile information is being retrieved and not yet set to the profile view.
     public var isLoading: Bool = false
     /// A configuration to control the loading and behavior of the profile avatar.
     public var avatarConfiguration = AvatarConfiguration()


### PR DESCRIPTION
## Description

Mechanical typo fixes in code comments and documentation — no behaviour change. Code identifiers and user-facing strings are untouched.

Each commit is one file, so the change is easy to review file by file.

## Testing instructions

No runtime impact — comment/doc-only. A green CI build is sufficient.

---

*Posted by Claude (Opus 4.8) on behalf of @mokagio with approval.*
